### PR TITLE
Changes to consolidate multiple fields under a "document" parent.

### DIFF
--- a/sandbox/csaf_2.0/json_schema/CVE-2018-0171-modified.json
+++ b/sandbox/csaf_2.0/json_schema/CVE-2018-0171-modified.json
@@ -1,143 +1,145 @@
 {
-  "document_title": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability",
-  "document_type": "Cisco Security Advisory",
-  "document_publisher": {
-    "contact_details": "Emergency Support:\n+1 877 228 7302 (toll-free within North America)\n+1 408 525 6532 (International direct-dial)\nNon-emergency Support:\nEmail: psirt@cisco.com\nSupport requests that are received via e-mail are typically acknowledged within 48 hours.",
-    "issuing_authority": "Cisco product security incident response is the responsibility of the Cisco Product Security Incident Response Team (PSIRT). The Cisco PSIRT is a dedicated, global team that manages the receipt, investigation, and public reporting of security vulnerability information that is related to Cisco products and networks. The on-call Cisco PSIRT works 24x7 with Cisco customers, independent security researchers, consultants, industry organizations, and other vendors to identify possible security issues with Cisco products and networks.\nMore information can be found in Cisco Security Vulnerability Policy available at http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html"
-  },
-  "document_tracking": {
-    "identification": {
-      "id": "cisco-sa-20180328-smi2"
+  "document": {
+    "title": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability",
+    "type": "Cisco Security Advisory",
+    "publisher": {
+      "contact_details": "Emergency Support:\n+1 877 228 7302 (toll-free within North America)\n+1 408 525 6532 (International direct-dial)\nNon-emergency Support:\nEmail: psirt@cisco.com\nSupport requests that are received via e-mail are typically acknowledged within 48 hours.",
+      "issuing_authority": "Cisco product security incident response is the responsibility of the Cisco Product Security Incident Response Team (PSIRT). The Cisco PSIRT is a dedicated, global team that manages the receipt, investigation, and public reporting of security vulnerability information that is related to Cisco products and networks. The on-call Cisco PSIRT works 24x7 with Cisco customers, independent security researchers, consultants, industry organizations, and other vendors to identify possible security issues with Cisco products and networks.\nMore information can be found in Cisco Security Vulnerability Policy available at http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html"
     },
-    "status": "final",
-    "version": "1.6",
-    "revision_history": [
+    "tracking": {
+      "identification": {
+        "id": "cisco-sa-20180328-smi2"
+      },
+      "status": "final",
+      "version": "1.6",
+      "revision_history": [
+        {
+          "number": "1.0",
+          "date": "2018-03-28T15:17:05Z",
+          "description": "Initial public release."
+        },
+        {
+          "number": "1.1",
+          "date": "2018-03-29T17:13:23Z",
+          "description": "Added the researcher's company name."
+        },
+        {
+          "number": "1.2",
+          "date": "2018-04-02T13:18:01Z",
+          "description": "Metadata update."
+        },
+        {
+          "number": "1.3",
+          "date": "2018-04-06T19:35:44Z",
+          "description": "Added more details to the Workarounds section."
+        },
+        {
+          "number": "1.4",
+          "date": "2018-04-09T14:20:12Z",
+          "description": "Emphasized that Smart Install is enabled by default. Added a link to the list of devices that support Smart Install."
+        },
+        {
+          "number": "1.5",
+          "date": "2018-04-16T18:21:34Z",
+          "description": "Updated IOS Software Checker with products found to be non-vulnerable."
+        },
+        {
+          "number": "1.6",
+          "date": "2018-04-17T15:08:41Z",
+          "description": "Updated IOS Software Checker with products found to be vulnerable."
+        }
+      ],
+      "initial_release_date": "2018-03-28T16:00:00Z",
+      "current_release_date": "2018-04-17T15:08:41Z",
+      "generator": {
+        "engine": "TVCE"
+      }
+    },
+    "notes": [
       {
-        "number": "1.0",
-        "date": "2018-03-28T15:17:05Z",
-        "description": "Initial public release."
+        "title": "Summary",
+        "type": "summary",
+        "ordinal": "1",
+        "text": "A vulnerability in the Smart Install feature of Cisco IOS Software and Cisco IOS XE Software could allow an unauthenticated, remote attacker to trigger a reload of an affected device, resulting in a denial of service (DoS) condition, or to execute arbitrary code on an affected device.\n\nThe vulnerability is due to improper validation of packet data. An attacker could exploit this vulnerability by sending a crafted Smart Install message to an affected device on TCP port 4786. A successful exploit could allow the attacker to cause a buffer overflow on the affected device, which could have the following impacts:\n\nTriggering a reload of the device\nAllowing the attacker to execute arbitrary code on the device\nCausing an indefinite loop on the affected device that triggers a watchdog crash\n\nCisco has released software updates that address this vulnerability. There are no workarounds that address this vulnerability.\n\nSmart Install client functionality is enabled by default on switches that are running Cisco IOS Software releases that have not been updated to address Cisco bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"].\n\nThis advisory is available at the following link:\nhttps://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2 [\"https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2\"]\n\nThis advisory is part of the March 28, 2018, release of the Cisco IOS and IOS XE Software Security Advisory Bundled Publication, which includes 20 Cisco Security Advisories that describe 22 vulnerabilities. For a complete list of the advisories and links to them, see Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication [\"https://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682\"]."
       },
       {
-        "number": "1.1",
-        "date": "2018-03-29T17:13:23Z",
-        "description": "Added the researcher's company name."
+        "title": "Vulnerable Products",
+        "type": "general",
+        "ordinal": "2",
+        "text": "This vulnerability affects Cisco devices that are running a vulnerable release of Cisco IOS or IOS XE Software and have the Smart Install client feature enabled.\n\nOnly Smart Install client switches are affected by the vulnerability that is described in this advisory. Cisco devices that are configured as a Smart Install director are not affected by this vulnerability.\n\nFor a list of devices that support Smart Install, see Smart Install Configuration Guide - Supported Devices [\"https://www.cisco.com/c/en/us/td/docs/switches/lan/smart_install/configuration/guide/smart_install/supported_devices.html\"].\n\nFor information about which Cisco IOS and IOS XE Software releases are vulnerable, see the Fixed Software [\"#fixed\"] section of this advisory.\n  Notes Regarding Specific Releases\nSmart Install client functionality is enabled by default on switches that are running Cisco IOS Software releases that have not been updated to address Cisco bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"].\n\nSwitches that are running releases earlier than Cisco IOS Software Release 12.2(52)SE are not capable of running Smart Install, but they can be Smart Install clients if they support the archive download-sw privileged EXEC command.\n  Determining Whether the Smart Install Client Feature Is Enabled\nTo determine whether a device is configured with the Smart Install client feature enabled, use the show vstack config privileged EXEC command on the Smart Install client. An output of Role: Client and Oper Mode: Enabled or Role: Client (SmartInstall enabled) from the show vstack config command confirms that the feature is enabled on the device.\n\nThe following examples show the output of the show vstack config command on Cisco Catalyst Switches that are configured as Smart Install clients:\n\n\nswitch1# show vstack config\nRole: Client (SmartInstall enabled)\n.\n.\n.\n\nswitch2# show vstack config\nCapability: Client\nOper Mode: Enabled\nRole: Client\n.\n.\n.\nDetermining the Cisco IOS Software Release\nTo determine which Cisco IOS Software release is running on a device, administrators can log in to the device, use the show version command in the CLI, and then refer to the system banner that appears. If the device is running Cisco IOS Software, the system banner displays text similar to Cisco Internetwork Operating System Software or Cisco IOS Software. The banner also displays the installed image name in parentheses, followed by the Cisco IOS Software release number and release name. Some Cisco devices do not support the show version command or may provide different output.\n\nThe following example shows the output of the command for a device that is running Cisco IOS Software Release 15.5(2)T1 and has an installed image name of C2951-UNIVERSALK9-M:\n\n\nRouter> show version\n  Cisco IOS Software, C2951 Software (C2951-UNIVERSALK9-M), Version 15.5(2)T1, RELEASE SOFTWARE (fc1)  Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2015 by Cisco Systems, Inc.  Compiled Mon 22-Jun-15 09:32 by prod_rel_team  .  .  .\n\nFor information about the naming and numbering conventions for Cisco IOS Software releases, see the Cisco IOS and NX-OS Software Reference Guide [\"https://www.cisco.com/c/en/us/about/security-center/ios-nx-os-reference-guide.html\"].\nDetermining the Cisco IOS XE Software Release\nTo determine which Cisco IOS XE Software release is running on a device, administrators can log in to the device, use the show version command in the CLI, and then refer to the system banner that appears. If the device is running Cisco IOS XE Software, the system banner displays Cisco IOS Software, Cisco IOS XE Software, or similar text.\n\nThe following example shows the output of the command for a device that is running Cisco IOS XE Software Release 16.2.1 and has an installed image name of CAT3K_CAA-UNIVERSALK9-M:\n\n\nios-xe-device# show version\n  Cisco IOS Software, Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version Denali 16.2.1, RELEASE SOFTWARE (fc1)  Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2016 by Cisco Systems, Inc.  Compiled Sun 27-Mar-16 21:47 by mcpre  .  .  .\n\nFor information about the naming and numbering conventions for Cisco IOS XE Software releases, see the Cisco IOS and NX-OS Software Reference Guide [\"https://www.cisco.com/c/en/us/about/security-center/ios-nx-os-reference-guide.html\"]."
       },
       {
-        "number": "1.2",
-        "date": "2018-04-02T13:18:01Z",
-        "description": "Metadata update."
+        "title": "Products Confirmed Not Vulnerable",
+        "type": "general",
+        "ordinal": "3",
+        "text": "No other Cisco products are currently known to be affected by this vulnerability.\n\nCisco has confirmed that this vulnerability does not affect Cisco IOS XR Software or Cisco NX-OS Software."
       },
       {
-        "number": "1.3",
-        "date": "2018-04-06T19:35:44Z",
-        "description": "Added more details to the Workarounds section."
+        "title": "Details",
+        "type": "general",
+        "ordinal": "4",
+        "text": "Cisco Smart Install is a ?plug-and-play? configuration and image-management feature that provides zero-touch deployment for new (typically access layer) switches. The feature allows a customer to ship a Cisco switch to any location, install it in the network, and power it on without additional configuration requirements. The Smart Install feature incorporates no authentication by design.\n\nA Smart Install network consists of exactly one Smart Install director switch or router, also known as an integrated branch director (IBD), and one or more Smart Install client switches, also known as integrated branch clients (IBCs). A client switch does not need to be directly connected to the director; the client switch can be up to seven hops away.\n\nThe director provides a single management point for images and configuration of client switches. When a client switch is first installed in the network, the director automatically detects the new switch and identifies the correct Cisco IOS Software image and the configuration file for downloading. The director can also allocate an IP address and hostname to a client."
       },
       {
-        "number": "1.4",
-        "date": "2018-04-09T14:20:12Z",
-        "description": "Emphasized that Smart Install is enabled by default. Added a link to the list of devices that support Smart Install."
+        "title": "Workarounds",
+        "type": "general",
+        "ordinal": "5",
+        "text": "There are no workarounds that address this vulnerability for customers who require the use of Cisco Smart Install. For customers not requiring Cisco Smart Install, the feature can be disabled with the no vstack command. In software releases that are associated with Cisco Bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"], Cisco Smart Install will auto-disable if not in use.\n\nAdministrators are encouraged to consult the informational security advisory on Cisco Smart Install Protocol Misuse [\"https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20170214-smi\"] and the Smart Install Configuration Guide [\"http://www.cisco.com/c/en/us/td/docs/switches/lan/smart_install/configuration/guide/smart_install/concepts.html#23355\"]."
       },
       {
-        "number": "1.5",
-        "date": "2018-04-16T18:21:34Z",
-        "description": "Updated IOS Software Checker with products found to be non-vulnerable."
+        "title": "Fixed Software",
+        "type": "general",
+        "ordinal": "6",
+        "text": "Cisco has released free software updates that address the vulnerability described in this advisory. Customers may only install and expect support for software versions and feature sets for which they have purchased a license. By installing, downloading, accessing, or otherwise using such software upgrades, customers agree to follow the terms of the Cisco software license:\nhttps://www.cisco.com/c/en/us/products/end-user-license-agreement.html [\"https://www.cisco.com/c/en/us/products/end-user-license-agreement.html\"]\n\nAdditionally, customers may only download software for which they have a valid license, procured from Cisco directly, or through a Cisco authorized reseller or partner. In most cases this will be a maintenance upgrade to software that was previously purchased. Free security software updates do not entitle customers to a new software license, additional software feature sets, or major revision upgrades.\n\nWhen considering software upgrades, customers are advised to regularly consult the advisories for Cisco products, which are available from the Cisco Security Advisories and Alerts page [\"https://www.cisco.com/go/psirt\"], to determine exposure and a complete upgrade solution.\n\nIn all cases, customers should ensure that the devices to be upgraded contain sufficient memory and confirm that current hardware and software configurations will continue to be supported properly by the new release. If the information is not clear, customers are advised to contact the Cisco Technical Assistance Center (TAC) or their contracted maintenance providers.\n\nCustomers Without Service Contracts\n\nCustomers who purchase directly from Cisco but do not hold a Cisco service contract and customers who make purchases through third-party vendors but are unsuccessful in obtaining fixed software through their point of sale should obtain upgrades by contacting the Cisco TAC:\nhttps://www.cisco.com/c/en/us/support/web/tsd-cisco-worldwide-contacts.html [\"https://www.cisco.com/c/en/us/support/web/tsd-cisco-worldwide-contacts.html\"]\n\nCustomers should have the product serial number available and be prepared to provide the URL of this advisory as evidence of entitlement to a free upgrade.\n                      Cisco IOS and IOS XE Software\nTo help customers determine their exposure to vulnerabilities in Cisco IOS and IOS XE Software, Cisco provides a tool, the Cisco IOS Software Checker [\"https://tools.cisco.com/security/center/softwarechecker.x\"], that identifies any Cisco Security Advisories that impact a specific software release and the earliest release that fixes the vulnerabilities described in each advisory (?First Fixed?). If applicable, the tool also returns the earliest release that fixes all the vulnerabilities described in all the advisories identified (?Combined First Fixed?).\n\nCustomers can use this tool to perform the following tasks:\n\nInitiate a search by choosing one or more releases from a drop-down list or uploading a file from a local system for the tool to parse\nEnter the output of the show version command for the tool to parse\nCreate a custom search by including all previously published Cisco Security Advisories, a specific advisory, or all advisories in the most recent bundled publication\n\nTo determine whether a release is affected by any published Cisco Security Advisory, use the Cisco IOS Software Checker [\"https://tools.cisco.com/security/center/softwarechecker.x\"] on Cisco.com or enter a Cisco IOS Software or Cisco IOS XE Software release?for example, 15.1(4)M2 or 3.13.8S?in the following field:\n\n\n\n\n\nFor a mapping of Cisco IOS XE Software releases to Cisco IOS Software releases, refer to the Cisco IOS XE 2 Release Notes [\"https://www.cisco.com/c/en/us/td/docs/ios/ios_xe/2/release/notes/rnasr21/rnasr21_gen.html#wp3000032\"], Cisco IOS XE 3S Release Notes [\"https://www.cisco.com/c/en/us/td/docs/ios/ios_xe/3/release/notes/asr1k_rn_3s_rel_notes/asr1k_rn_3s_sys_req.html#wp3069754\"], or Cisco IOS XE 3SG Release Notes [\"https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst4500/release/note/OL_24726.html#pgfId-2570252\"], depending on the Cisco IOS XE Software release."
       },
       {
-        "number": "1.6",
-        "date": "2018-04-17T15:08:41Z",
-        "description": "Updated IOS Software Checker with products found to be vulnerable."
+        "title": "Vulnerability Policy",
+        "type": "general",
+        "ordinal": "7",
+        "text": "To learn about Cisco security vulnerability disclosure policies and publications, see the Security Vulnerability Policy [\"http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html\"]. This document also contains instructions for obtaining fixed software and receiving security vulnerability information from Cisco."
+      },
+      {
+        "title": "Exploitation and Public Announcements",
+        "type": "general",
+        "ordinal": "8",
+        "text": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory."
+      },
+      {
+        "title": "Source",
+        "type": "general",
+        "ordinal": "9",
+        "text": "Cisco would like to thank George Nosenko from Embedi for reporting this vulnerability via GeekPwn."
+      },
+      {
+        "title": "Legal Disclaimer",
+        "type": "legal disclaimer",
+        "ordinal": "10",
+        "text": "THIS DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS AND DOES NOT IMPLY ANY KIND OF GUARANTEE OR WARRANTY, INCLUDING THE WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE. YOUR USE OF THE INFORMATION ON THE DOCUMENT OR MATERIALS LINKED FROM THE DOCUMENT IS AT YOUR OWN RISK. CISCO RESERVES THE RIGHT TO CHANGE OR UPDATE THIS DOCUMENT AT ANY TIME.\n\nA standalone copy or paraphrase of the text of this document that omits the distribution URL is an uncontrolled copy and may lack important information or contain factual errors. The information in this document is intended for end users of Cisco products."
       }
     ],
-    "initial_release_date": "2018-03-28T16:00:00Z",
-    "current_release_date": "2018-04-17T15:08:41Z",
-    "generator": {
-      "engine": "TVCE"
-    }
+    "references": [
+      {
+        "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2",
+        "description": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability"
+      },
+      {
+        "url": "https://tools.cisco.com/security/center/content/CiscoSecurityBundle/cisco-sa-20180328-bundle",
+        "description": "Summary of the Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication, March 28, 2018"
+      },
+      {
+        "url": "http://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682",
+        "description": "Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication"
+      },
+      {
+        "url": "https://tools.cisco.com/security/center/content/CiscoSecurityBundle/cisco-sa-20180328-bundle",
+        "description": "Summary of the Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication, March 28, 2018"
+      },
+      {
+        "url": "http://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682",
+        "description": "Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication"
+      }
+    ]
   },
-  "document_notes": [
-    {
-      "title": "Summary",
-      "type": "summary",
-      "ordinal": "1",
-      "text": "A vulnerability in the Smart Install feature of Cisco IOS Software and Cisco IOS XE Software could allow an unauthenticated, remote attacker to trigger a reload of an affected device, resulting in a denial of service (DoS) condition, or to execute arbitrary code on an affected device.\n\nThe vulnerability is due to improper validation of packet data. An attacker could exploit this vulnerability by sending a crafted Smart Install message to an affected device on TCP port 4786. A successful exploit could allow the attacker to cause a buffer overflow on the affected device, which could have the following impacts:\n\nTriggering a reload of the device\nAllowing the attacker to execute arbitrary code on the device\nCausing an indefinite loop on the affected device that triggers a watchdog crash\n\nCisco has released software updates that address this vulnerability. There are no workarounds that address this vulnerability.\n\nSmart Install client functionality is enabled by default on switches that are running Cisco IOS Software releases that have not been updated to address Cisco bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"].\n\nThis advisory is available at the following link:\nhttps://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2 [\"https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2\"]\n\nThis advisory is part of the March 28, 2018, release of the Cisco IOS and IOS XE Software Security Advisory Bundled Publication, which includes 20 Cisco Security Advisories that describe 22 vulnerabilities. For a complete list of the advisories and links to them, see Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication [\"https://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682\"]."
-    },
-    {
-      "title": "Vulnerable Products",
-      "type": "general",
-      "ordinal": "2",
-      "text": "This vulnerability affects Cisco devices that are running a vulnerable release of Cisco IOS or IOS XE Software and have the Smart Install client feature enabled.\n\nOnly Smart Install client switches are affected by the vulnerability that is described in this advisory. Cisco devices that are configured as a Smart Install director are not affected by this vulnerability.\n\nFor a list of devices that support Smart Install, see Smart Install Configuration Guide - Supported Devices [\"https://www.cisco.com/c/en/us/td/docs/switches/lan/smart_install/configuration/guide/smart_install/supported_devices.html\"].\n\nFor information about which Cisco IOS and IOS XE Software releases are vulnerable, see the Fixed Software [\"#fixed\"] section of this advisory.\n  Notes Regarding Specific Releases\nSmart Install client functionality is enabled by default on switches that are running Cisco IOS Software releases that have not been updated to address Cisco bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"].\n\nSwitches that are running releases earlier than Cisco IOS Software Release 12.2(52)SE are not capable of running Smart Install, but they can be Smart Install clients if they support the archive download-sw privileged EXEC command.\n  Determining Whether the Smart Install Client Feature Is Enabled\nTo determine whether a device is configured with the Smart Install client feature enabled, use the show vstack config privileged EXEC command on the Smart Install client. An output of Role: Client and Oper Mode: Enabled or Role: Client (SmartInstall enabled) from the show vstack config command confirms that the feature is enabled on the device.\n\nThe following examples show the output of the show vstack config command on Cisco Catalyst Switches that are configured as Smart Install clients:\n\n\nswitch1# show vstack config\nRole: Client (SmartInstall enabled)\n.\n.\n.\n\nswitch2# show vstack config\nCapability: Client\nOper Mode: Enabled\nRole: Client\n.\n.\n.\nDetermining the Cisco IOS Software Release\nTo determine which Cisco IOS Software release is running on a device, administrators can log in to the device, use the show version command in the CLI, and then refer to the system banner that appears. If the device is running Cisco IOS Software, the system banner displays text similar to Cisco Internetwork Operating System Software or Cisco IOS Software. The banner also displays the installed image name in parentheses, followed by the Cisco IOS Software release number and release name. Some Cisco devices do not support the show version command or may provide different output.\n\nThe following example shows the output of the command for a device that is running Cisco IOS Software Release 15.5(2)T1 and has an installed image name of C2951-UNIVERSALK9-M:\n\n\nRouter> show version\n  Cisco IOS Software, C2951 Software (C2951-UNIVERSALK9-M), Version 15.5(2)T1, RELEASE SOFTWARE (fc1)  Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2015 by Cisco Systems, Inc.  Compiled Mon 22-Jun-15 09:32 by prod_rel_team  .  .  .\n\nFor information about the naming and numbering conventions for Cisco IOS Software releases, see the Cisco IOS and NX-OS Software Reference Guide [\"https://www.cisco.com/c/en/us/about/security-center/ios-nx-os-reference-guide.html\"].\nDetermining the Cisco IOS XE Software Release\nTo determine which Cisco IOS XE Software release is running on a device, administrators can log in to the device, use the show version command in the CLI, and then refer to the system banner that appears. If the device is running Cisco IOS XE Software, the system banner displays Cisco IOS Software, Cisco IOS XE Software, or similar text.\n\nThe following example shows the output of the command for a device that is running Cisco IOS XE Software Release 16.2.1 and has an installed image name of CAT3K_CAA-UNIVERSALK9-M:\n\n\nios-xe-device# show version\n  Cisco IOS Software, Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version Denali 16.2.1, RELEASE SOFTWARE (fc1)  Technical Support: http://www.cisco.com/techsupport  Copyright (c) 1986-2016 by Cisco Systems, Inc.  Compiled Sun 27-Mar-16 21:47 by mcpre  .  .  .\n\nFor information about the naming and numbering conventions for Cisco IOS XE Software releases, see the Cisco IOS and NX-OS Software Reference Guide [\"https://www.cisco.com/c/en/us/about/security-center/ios-nx-os-reference-guide.html\"]."
-    },
-    {
-      "title": "Products Confirmed Not Vulnerable",
-      "type": "general",
-      "ordinal": "3",
-      "text": "No other Cisco products are currently known to be affected by this vulnerability.\n\nCisco has confirmed that this vulnerability does not affect Cisco IOS XR Software or Cisco NX-OS Software."
-    },
-    {
-      "title": "Details",
-      "type": "general",
-      "ordinal": "4",
-      "text": "Cisco Smart Install is a ?plug-and-play? configuration and image-management feature that provides zero-touch deployment for new (typically access layer) switches. The feature allows a customer to ship a Cisco switch to any location, install it in the network, and power it on without additional configuration requirements. The Smart Install feature incorporates no authentication by design.\n\nA Smart Install network consists of exactly one Smart Install director switch or router, also known as an integrated branch director (IBD), and one or more Smart Install client switches, also known as integrated branch clients (IBCs). A client switch does not need to be directly connected to the director; the client switch can be up to seven hops away.\n\nThe director provides a single management point for images and configuration of client switches. When a client switch is first installed in the network, the director automatically detects the new switch and identifies the correct Cisco IOS Software image and the configuration file for downloading. The director can also allocate an IP address and hostname to a client."
-    },
-    {
-      "title": "Workarounds",
-      "type": "general",
-      "ordinal": "5",
-      "text": "There are no workarounds that address this vulnerability for customers who require the use of Cisco Smart Install. For customers not requiring Cisco Smart Install, the feature can be disabled with the no vstack command. In software releases that are associated with Cisco Bug ID CSCvd36820 [\"https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvd36820\"], Cisco Smart Install will auto-disable if not in use.\n\nAdministrators are encouraged to consult the informational security advisory on Cisco Smart Install Protocol Misuse [\"https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20170214-smi\"] and the Smart Install Configuration Guide [\"http://www.cisco.com/c/en/us/td/docs/switches/lan/smart_install/configuration/guide/smart_install/concepts.html#23355\"]."
-    },
-    {
-      "title": "Fixed Software",
-      "type": "general",
-      "ordinal": "6",
-      "text": "Cisco has released free software updates that address the vulnerability described in this advisory. Customers may only install and expect support for software versions and feature sets for which they have purchased a license. By installing, downloading, accessing, or otherwise using such software upgrades, customers agree to follow the terms of the Cisco software license:\nhttps://www.cisco.com/c/en/us/products/end-user-license-agreement.html [\"https://www.cisco.com/c/en/us/products/end-user-license-agreement.html\"]\n\nAdditionally, customers may only download software for which they have a valid license, procured from Cisco directly, or through a Cisco authorized reseller or partner. In most cases this will be a maintenance upgrade to software that was previously purchased. Free security software updates do not entitle customers to a new software license, additional software feature sets, or major revision upgrades.\n\nWhen considering software upgrades, customers are advised to regularly consult the advisories for Cisco products, which are available from the Cisco Security Advisories and Alerts page [\"https://www.cisco.com/go/psirt\"], to determine exposure and a complete upgrade solution.\n\nIn all cases, customers should ensure that the devices to be upgraded contain sufficient memory and confirm that current hardware and software configurations will continue to be supported properly by the new release. If the information is not clear, customers are advised to contact the Cisco Technical Assistance Center (TAC) or their contracted maintenance providers.\n\nCustomers Without Service Contracts\n\nCustomers who purchase directly from Cisco but do not hold a Cisco service contract and customers who make purchases through third-party vendors but are unsuccessful in obtaining fixed software through their point of sale should obtain upgrades by contacting the Cisco TAC:\nhttps://www.cisco.com/c/en/us/support/web/tsd-cisco-worldwide-contacts.html [\"https://www.cisco.com/c/en/us/support/web/tsd-cisco-worldwide-contacts.html\"]\n\nCustomers should have the product serial number available and be prepared to provide the URL of this advisory as evidence of entitlement to a free upgrade.\n                      Cisco IOS and IOS XE Software\nTo help customers determine their exposure to vulnerabilities in Cisco IOS and IOS XE Software, Cisco provides a tool, the Cisco IOS Software Checker [\"https://tools.cisco.com/security/center/softwarechecker.x\"], that identifies any Cisco Security Advisories that impact a specific software release and the earliest release that fixes the vulnerabilities described in each advisory (?First Fixed?). If applicable, the tool also returns the earliest release that fixes all the vulnerabilities described in all the advisories identified (?Combined First Fixed?).\n\nCustomers can use this tool to perform the following tasks:\n\nInitiate a search by choosing one or more releases from a drop-down list or uploading a file from a local system for the tool to parse\nEnter the output of the show version command for the tool to parse\nCreate a custom search by including all previously published Cisco Security Advisories, a specific advisory, or all advisories in the most recent bundled publication\n\nTo determine whether a release is affected by any published Cisco Security Advisory, use the Cisco IOS Software Checker [\"https://tools.cisco.com/security/center/softwarechecker.x\"] on Cisco.com or enter a Cisco IOS Software or Cisco IOS XE Software release?for example, 15.1(4)M2 or 3.13.8S?in the following field:\n\n\n\n\n\nFor a mapping of Cisco IOS XE Software releases to Cisco IOS Software releases, refer to the Cisco IOS XE 2 Release Notes [\"https://www.cisco.com/c/en/us/td/docs/ios/ios_xe/2/release/notes/rnasr21/rnasr21_gen.html#wp3000032\"], Cisco IOS XE 3S Release Notes [\"https://www.cisco.com/c/en/us/td/docs/ios/ios_xe/3/release/notes/asr1k_rn_3s_rel_notes/asr1k_rn_3s_sys_req.html#wp3069754\"], or Cisco IOS XE 3SG Release Notes [\"https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst4500/release/note/OL_24726.html#pgfId-2570252\"], depending on the Cisco IOS XE Software release."
-    },
-    {
-      "title": "Vulnerability Policy",
-      "type": "general",
-      "ordinal": "7",
-      "text": "To learn about Cisco security vulnerability disclosure policies and publications, see the Security Vulnerability Policy [\"http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html\"]. This document also contains instructions for obtaining fixed software and receiving security vulnerability information from Cisco."
-    },
-    {
-      "title": "Exploitation and Public Announcements",
-      "type": "general",
-      "ordinal": "8",
-      "text": "The Cisco Product Security Incident Response Team (PSIRT) is not aware of any public announcements or malicious use of the vulnerability that is described in this advisory."
-    },
-    {
-      "title": "Source",
-      "type": "general",
-      "ordinal": "9",
-      "text": "Cisco would like to thank George Nosenko from Embedi for reporting this vulnerability via GeekPwn."
-    },
-    {
-      "title": "Legal Disclaimer",
-      "type": "legal disclaimer",
-      "ordinal": "10",
-      "text": "THIS DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS AND DOES NOT IMPLY ANY KIND OF GUARANTEE OR WARRANTY, INCLUDING THE WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR USE. YOUR USE OF THE INFORMATION ON THE DOCUMENT OR MATERIALS LINKED FROM THE DOCUMENT IS AT YOUR OWN RISK. CISCO RESERVES THE RIGHT TO CHANGE OR UPDATE THIS DOCUMENT AT ANY TIME.\n\nA standalone copy or paraphrase of the text of this document that omits the distribution URL is an uncontrolled copy and may lack important information or contain factual errors. The information in this document is intended for end users of Cisco products."
-    }
-  ],
-  "document_references": [
-    {
-      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20180328-smi2",
-      "description": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability"
-    },
-    {
-      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityBundle/cisco-sa-20180328-bundle",
-      "description": "Summary of the Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication, March 28, 2018"
-    },
-    {
-      "url": "http://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682",
-      "description": "Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication"
-    },
-    {
-      "url": "https://tools.cisco.com/security/center/content/CiscoSecurityBundle/cisco-sa-20180328-bundle",
-      "description": "Summary of the Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication, March 28, 2018"
-    },
-    {
-      "url": "http://tools.cisco.com/security/center/viewErp.x?alertId=ERP-66682",
-      "description": "Cisco Event Response: March 2018 Semiannual Cisco IOS and IOS XE Software Security Advisory Bundled Publication"
-    }
-  ],
   "product_tree": {
     "branch": [
       {

--- a/sandbox/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/sandbox/csaf_2.0/json_schema/csaf_json_schema.json
@@ -445,78 +445,95 @@
     }
   },
   "required": [
-    "document_title",
-    "document_publisher",
-    "document_type",
-    "document_tracking"
+    "document"
   ],
   "properties": {
-    "document_title": {
-      "$ref": "#/definitions/str_option_t"
-    },
-    "document_type": {
-      "$ref": "#/definitions/non_empty_string_t"
-    },
-    "document_publisher": {
+    "document": {
       "type": "object",
+      "required": [
+        "title",
+        "publisher",
+        "type",
+        "tracking"
+      ],
       "properties": {
-        "contact_details": {
-          "type": "string"
+        "distribution": {
+          "$ref": "#/definitions/str_option_t"
         },
-        "issuing_authority": {
-          "type": "string"
+        "notes": {
+          "$ref": "#/definitions/notes_t"
         },
-        "vendor_id": {
-          "type": "string"
-        }
-      }
-    },
-    "document_tracking": {
-      "type": "object",
-      "properties": {
-        "current_release_date": {
-          "$ref": "#/definitions/date_t"
-        },
-        "generator": {
+        "publisher": {
           "type": "object",
           "properties": {
-            "engine": {
+            "contact_details": {
               "type": "string"
             },
-            "date": {
-              "type": "string",
-              "format": "date-time"
+            "issuing_authority": {
+              "type": "string"
+            },
+            "vendor_id": {
+              "type": "string"
             }
           }
         },
-        "identification": {
+        "references": {
+          "$ref": "#/definitions/references_t"
+        },
+        "title": {
+          "$ref": "#/definitions/str_option_t"
+        },
+        "tracking": {
           "type": "object",
           "properties": {
-            "id": {
-              "type": "string"
+            "current_release_date": {
+              "$ref": "#/definitions/date_t"
             },
-            "aliases": {
+            "generator": {
+              "type": "object",
+              "properties": {
+                "engine": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "identification": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "aliases": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/non_empty_string_t"
+                  }
+                }
+              }
+            },
+            "initial_release_date": {
+              "$ref": "#/definitions/date_t"
+            },
+            "revision_history": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/non_empty_string_t"
+                "$ref": "#/definitions/revision_t"
               }
+            },
+            "status": {
+              "$ref": "#/definitions/status_t"
+            },
+            "version": {
+              "$ref": "#/definitions/version_type_t"
             }
           }
         },
-        "initial_release_date": {
-          "$ref": "#/definitions/date_t"
-        },
-        "revision_history": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/revision_t"
-          }
-        },
-        "status": {
-          "$ref": "#/definitions/status_t"
-        },
-        "version": {
-          "$ref": "#/definitions/version_type_t"
+        "type": {
+          "$ref": "#/definitions/non_empty_string_t"
         }
       }
     },
@@ -536,15 +553,6 @@
           }
         }
       }
-    },
-    "document_notes": {
-      "$ref": "#/definitions/notes_t"
-    },
-    "document_references": {
-      "$ref": "#/definitions/references_t"
-    },
-    "document_distribution": {
-      "$ref": "#/definitions/str_option_t"
     },
     "vulnerabilities": {
       "type": "array",

--- a/sandbox/csaf_2.0/json_schema/cvrf-rhba-2018-0489-modified.json
+++ b/sandbox/csaf_2.0/json_schema/cvrf-rhba-2018-0489-modified.json
@@ -1,1322 +1,1324 @@
 {
-  "document_title": {
-    "lang": "en",
-    "text": "Red Hat Bug Fix Advisory: Red Hat OpenShift Container Platform 3.9 RPM Release Advisory"
-  },
-  "document_type": "Security Advisory",
-  "document_publisher": {
-    "contact_details": "secalert@redhat.com",
-    "issuing_authority": "Red Hat Product Security"
-  },
-  "document_tracking": {
-    "identification": {
-      "id": "RHBA-2018:0489"
+  "document": {
+    "title": {
+      "lang": "en",
+      "text": "Red Hat Bug Fix Advisory: Red Hat OpenShift Container Platform 3.9 RPM Release Advisory"
     },
-    "status": "final",
-    "version": "1",
-    "revision_history": [
+    "type": "Security Advisory",
+    "publisher": {
+      "contact_details": "secalert@redhat.com",
+      "issuing_authority": "Red Hat Product Security"
+    },
+    "tracking": {
+      "identification": {
+        "id": "RHBA-2018:0489"
+      },
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "number": "1",
+          "date": "2018-03-28T13:49:00Z",
+          "description": "Current version"
+        }
+      ],
+      "initial_release_date": "2018-03-28T13:49:00Z",
+      "current_release_date": "2018-03-28T13:49:00Z",
+      "generator": {
+        "engine": "Red Hat rhsa-to-cvrf 2.1",
+        "date": "2018-04-11T19:24:01Z"
+      }
+    },
+    "notes": [
       {
-        "number": "1",
-        "date": "2018-03-28T13:49:00Z",
-        "description": "Current version"
+        "title": "Topic",
+        "ordinal": "1",
+        "lang": "en",
+        "type": "summary",
+        "text": "Red Hat OpenShift Container Platform 3.9, which fixes several bugs and includes various enhancements, is now available."
+      },
+      {
+        "title": "Details",
+        "ordinal": "2",
+        "lang": "en",
+        "type": "general",
+        "text": "Red Hat OpenShift Container Platform is the company's cloud computing\nPlatform-as-a-Service (PaaS) solution designed for on-premise or private cloud deployments.\n\nThe OpenShift Container Platform 3.9 Release Notes provide information about new features, bug fixes, and known issues:\n\nhttps://docs.openshift.com/container-platform/3.9/release_notes/ocp_3_9_release_notes.html\n\nThis advisory contains the RPM packages for this release. See the following\nadvisory for the container images for this release:\n\nhttps://access.redhat.com/errata/RHBA-2018:0490"
+      },
+      {
+        "title": "Terms of Use",
+        "ordinal": "3",
+        "lang": "en",
+        "type": "legal disclaimer",
+        "text": "Please see https://www.redhat.com/footer/terms-of-use.html"
       }
     ],
-    "initial_release_date": "2018-03-28T13:49:00Z",
-    "current_release_date": "2018-03-28T13:49:00Z",
-    "generator": {
-      "engine": "Red Hat rhsa-to-cvrf 2.1",
-      "date": "2018-04-11T19:24:01Z"
-    }
-  },
-  "document_notes": [
-    {
-      "title": "Topic",
-      "ordinal": "1",
+    "distribution": {
       "lang": "en",
-      "type": "summary",
-      "text": "Red Hat OpenShift Container Platform 3.9, which fixes several bugs and includes various enhancements, is now available."
+      "text": "Copyright © 2018 Red Hat, Inc. All rights reserved."
     },
-    {
-      "title": "Details",
-      "ordinal": "2",
-      "lang": "en",
-      "type": "general",
-      "text": "Red Hat OpenShift Container Platform is the company's cloud computing\nPlatform-as-a-Service (PaaS) solution designed for on-premise or private cloud deployments.\n\nThe OpenShift Container Platform 3.9 Release Notes provide information about new features, bug fixes, and known issues:\n\nhttps://docs.openshift.com/container-platform/3.9/release_notes/ocp_3_9_release_notes.html\n\nThis advisory contains the RPM packages for this release. See the following\nadvisory for the container images for this release:\n\nhttps://access.redhat.com/errata/RHBA-2018:0490"
-    },
-    {
-      "title": "Terms of Use",
-      "ordinal": "3",
-      "lang": "en",
-      "type": "legal disclaimer",
-      "text": "Please see https://www.redhat.com/footer/terms-of-use.html"
-    }
-  ],
-  "document_distribution": {
-    "lang": "en",
-    "text": "Copyright © 2018 Red Hat, Inc. All rights reserved."
+    "references": [
+      {
+        "url": "https://access.redhat.com/errata/RHBA-2018:0489",
+        "description": "https://access.redhat.com/errata/RHBA-2018:0489"
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2017-15137",
+        "description": "https://access.redhat.com/security/cve/CVE-2017-15137"
+      },
+      {
+        "url": "https://access.redhat.com/security/cve/CVE-2017-15138",
+        "description": "https://access.redhat.com/security/cve/CVE-2017-15138"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1333030",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1333030"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1378883",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1378883"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1383707",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1383707"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1396404",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1396404"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1419801",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1419801"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1430322",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1430322"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1440892",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1440892"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1463617",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1463617"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1463844",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1463844"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464657",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1464657"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1466216",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1466216"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1467557",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1467557"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1469411",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1469411"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1480835",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1480835"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1483579",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1483579"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1488380",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1488380"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1489603",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1489603"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1491100",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1491100"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1491717",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1491717"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1493955",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1493955"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496256",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496256"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496261",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496261"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496758",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496758"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1497038",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1497038"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1497408",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1497408"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500207",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500207"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500225",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500225"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500897",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500897"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1501254",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1501254"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502838",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502838"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502850",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502850"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502945",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502945"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1503260",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1503260"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1503601",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1503601"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1504075",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1504075"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1504464",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1504464"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505558",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505558"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505681",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505681"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505796",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505796"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506177",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506177"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506651",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506651"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506750",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506750"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506866",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506866"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507424",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507424"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507469",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507469"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507816",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507816"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508310",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508310"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508346",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508346"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508352",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508352"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508391",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508391"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508496",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508496"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508561",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508561"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508563",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508563"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508761",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508761"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508781",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508781"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509028",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509028"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509082",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509082"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509129",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509129"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509661",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509661"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509799",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509799"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509853",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509853"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510174",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510174"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510178",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510178"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510294",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510294"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510486",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510486"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510573",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510573"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510786",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510786"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510804",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510804"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511097",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511097"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511400",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511400"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511576",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511576"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511852",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511852"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1512473",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1512473"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1512825",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1512825"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1513706",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1513706"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1513859",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1513859"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515058",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515058"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515060",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515060"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515527",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515527"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515972",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515972"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1516569",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1516569"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1517605",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1517605"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1517875",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1517875"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518386",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518386"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518502",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518502"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518684",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518684"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518912",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518912"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519060",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519060"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519193",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519193"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519619",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519619"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519991",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519991"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1521151",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1521151"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523142",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523142"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523354",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523354"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523534",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523534"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523638",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523638"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523681",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523681"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524379",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524379"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524707",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524707"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524805",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524805"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524883",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524883"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525426",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525426"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525817",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525817"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525819",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525819"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1526887",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1526887"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1526949",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1526949"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527210",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527210"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527346",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527346"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527602",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527602"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527685",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527685"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527689",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527689"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528135",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528135"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528548",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528548"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528570",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528570"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528613",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528613"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529070",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529070"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529083",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529083"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529467",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529467"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529473",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529473"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529478",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529478"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530162",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530162"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530203",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530203"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530366",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530366"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530403",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530403"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530924",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530924"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531157",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531157"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531511",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531511"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531513",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531513"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531558",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531558"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532060",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532060"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532149",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532149"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532512",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532512"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532936",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532936"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532942",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532942"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532955",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532955"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532960",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532960"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532966",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532966"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532967",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532967"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532972",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532972"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532975",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532975"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532981",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532981"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532986",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532986"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533099",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533099"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533153",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533153"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533208",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533208"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533318",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533318"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533348",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533348"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533363",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533363"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533658",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533658"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533753",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533753"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533818",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533818"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534316",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534316"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534320",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534320"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534467",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534467"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534514",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534514"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534715",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534715"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534720",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534720"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534858",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534858"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534879",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534879"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534883",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534883"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534895",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534895"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534922",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534922"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534933",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534933"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534955",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534955"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534957",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534957"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535182",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535182"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535270",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535270"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535277",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535277"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535314",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535314"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535323",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535323"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535402",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535402"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535639",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535639"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535902",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535902"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535917",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535917"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535929",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535929"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535931",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535931"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535940",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535940"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535976",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535976"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536088",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536088"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536217",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536217"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536253",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536253"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536289",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536289"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536362",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536362"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536629",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536629"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536659",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536659"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536839",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536839"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537105",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537105"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537237",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537237"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537367",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537367"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537426",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537426"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537726",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537726"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537857",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537857"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537873",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537873"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537946",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537946"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537955",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537955"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538044",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538044"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538048",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538048"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538216",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538216"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538321",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538321"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538389",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538389"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538445",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538445"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538452",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538452"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538581",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538581"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538722",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538722"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538732",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538732"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538806",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538806"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538922",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538922"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538943",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538943"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538960",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538960"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538969",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538969"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538974",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538974"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538986",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538986"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538988",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538988"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538995",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538995"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539102",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539102"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539187",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539187"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539308",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539308"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539382",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539382"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539542",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539542"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539566",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539566"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539840",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539840"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539859",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539859"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539892",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539892"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539987",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539987"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540039",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540039"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540080",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540080"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540462",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540462"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540487",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540487"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540490",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540490"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540521",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540521"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540526",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540526"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540729",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540729"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540785",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540785"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540812",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540812"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540822",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540822"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540840",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540840"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540842",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540842"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540846",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540846"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540848",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540848"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540866",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540866"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540912",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540912"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540916",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540916"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540976",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540976"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541247",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541247"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541263",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541263"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541265",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541265"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541339",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541339"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541461",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541461"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541589",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541589"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541946",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541946"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542099",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542099"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542238",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542238"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542324",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542324"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542397",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542397"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542406",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542406"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542612",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542612"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542669",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542669"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542781",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542781"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542855",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542855"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542861",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542861"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542868",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542868"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543122",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543122"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543229",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543229"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543256",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543256"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543324",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543324"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543446",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543446"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543478",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543478"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543511",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543511"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543521",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543521"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543532",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543532"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543625",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543625"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543714",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543714"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543771",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543771"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543830",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543830"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543869",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543869"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544027",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544027"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544083",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544083"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544207",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544207"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544360",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544360"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544387",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544387"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544645",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544645"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544657",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544657"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544815",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544815"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544903",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544903"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545011",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545011"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545280",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545280"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545828",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545828"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546188",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546188"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546293",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546293"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546311",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546311"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546365",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546365"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546374",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546374"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546854",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546854"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547229",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547229"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547284",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547284"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547727",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547727"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547898",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547898"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547923",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547923"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547944",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547944"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548104",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548104"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548485",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548485"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548633",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548633"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548641",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548641"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548720",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548720"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1549491",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1549491"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1549971",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1549971"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1550140",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1550140"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1550148",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1550148"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1551775",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1551775"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1552165",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1552165"
+      },
+      {
+        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1552430",
+        "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1552430"
+      }
+    ]
   },
   "aggregate_severity": {
     "namespace": "https://access.redhat.com/security/updates/classification/",
     "text": "Moderate"
   },
-  "document_references": [
-    {
-      "url": "https://access.redhat.com/errata/RHBA-2018:0489",
-      "description": "https://access.redhat.com/errata/RHBA-2018:0489"
-    },
-    {
-      "url": "https://access.redhat.com/security/cve/CVE-2017-15137",
-      "description": "https://access.redhat.com/security/cve/CVE-2017-15137"
-    },
-    {
-      "url": "https://access.redhat.com/security/cve/CVE-2017-15138",
-      "description": "https://access.redhat.com/security/cve/CVE-2017-15138"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1333030",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1333030"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1378883",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1378883"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1383707",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1383707"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1396404",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1396404"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1419801",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1419801"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1430322",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1430322"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1440892",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1440892"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1463617",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1463617"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1463844",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1463844"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464657",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1464657"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1466216",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1466216"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1467557",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1467557"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1469411",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1469411"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1480835",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1480835"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1483579",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1483579"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1488380",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1488380"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1489603",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1489603"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1491100",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1491100"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1491717",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1491717"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1493955",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1493955"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496256",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496256"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496261",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496261"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1496758",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1496758"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1497038",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1497038"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1497408",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1497408"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500207",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500207"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500225",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500225"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1500897",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1500897"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1501254",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1501254"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502838",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502838"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502850",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502850"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1502945",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1502945"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1503260",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1503260"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1503601",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1503601"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1504075",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1504075"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1504464",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1504464"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505558",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505558"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505681",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505681"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1505796",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1505796"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506177",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506177"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506651",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506651"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506750",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506750"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1506866",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1506866"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507424",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507424"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507469",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507469"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1507816",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1507816"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508310",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508310"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508346",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508346"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508352",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508352"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508391",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508391"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508496",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508496"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508561",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508561"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508563",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508563"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508761",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508761"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1508781",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1508781"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509028",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509028"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509082",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509082"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509129",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509129"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509661",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509661"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509799",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509799"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1509853",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1509853"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510174",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510174"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510178",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510178"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510294",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510294"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510486",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510486"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510573",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510573"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510786",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510786"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1510804",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1510804"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511097",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511097"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511400",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511400"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511576",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511576"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1511852",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1511852"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1512473",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1512473"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1512825",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1512825"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1513706",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1513706"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1513859",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1513859"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515058",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515058"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515060",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515060"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515527",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515527"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1515972",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1515972"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1516569",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1516569"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1517605",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1517605"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1517875",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1517875"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518386",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518386"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518502",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518502"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518684",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518684"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1518912",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1518912"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519060",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519060"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519193",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519193"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519619",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519619"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1519991",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1519991"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1521151",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1521151"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523142",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523142"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523354",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523354"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523534",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523534"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523638",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523638"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1523681",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1523681"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524379",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524379"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524707",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524707"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524805",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524805"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1524883",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1524883"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525426",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525426"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525817",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525817"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1525819",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1525819"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1526887",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1526887"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1526949",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1526949"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527210",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527210"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527346",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527346"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527602",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527602"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527685",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527685"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1527689",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1527689"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528135",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528135"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528548",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528548"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528570",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528570"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1528613",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1528613"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529070",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529070"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529083",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529083"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529467",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529467"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529473",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529473"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1529478",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1529478"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530162",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530162"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530203",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530203"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530366",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530366"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530403",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530403"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1530924",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1530924"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531157",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531157"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531511",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531511"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531513",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531513"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1531558",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1531558"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532060",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532060"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532149",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532149"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532512",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532512"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532936",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532936"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532942",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532942"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532955",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532955"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532960",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532960"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532966",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532966"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532967",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532967"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532972",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532972"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532975",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532975"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532981",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532981"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1532986",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1532986"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533099",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533099"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533153",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533153"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533208",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533208"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533318",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533318"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533348",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533348"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533363",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533363"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533658",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533658"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533753",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533753"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1533818",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1533818"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534316",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534316"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534320",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534320"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534467",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534467"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534514",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534514"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534715",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534715"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534720",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534720"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534858",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534858"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534879",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534879"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534883",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534883"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534895",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534895"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534922",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534922"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534933",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534933"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534955",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534955"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1534957",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1534957"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535182",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535182"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535270",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535270"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535277",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535277"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535314",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535314"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535323",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535323"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535402",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535402"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535639",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535639"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535902",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535902"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535917",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535917"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535929",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535929"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535931",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535931"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535940",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535940"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1535976",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1535976"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536088",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536088"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536217",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536217"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536253",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536253"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536289",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536289"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536362",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536362"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536629",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536629"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536659",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536659"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1536839",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1536839"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537105",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537105"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537237",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537237"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537367",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537367"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537426",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537426"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537726",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537726"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537857",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537857"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537873",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537873"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537946",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537946"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1537955",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1537955"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538044",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538044"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538048",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538048"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538216",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538216"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538321",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538321"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538389",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538389"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538445",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538445"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538452",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538452"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538581",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538581"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538722",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538722"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538732",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538732"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538806",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538806"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538922",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538922"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538943",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538943"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538960",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538960"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538969",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538969"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538974",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538974"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538986",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538986"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538988",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538988"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1538995",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1538995"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539102",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539102"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539187",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539187"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539308",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539308"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539382",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539382"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539542",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539542"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539566",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539566"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539840",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539840"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539859",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539859"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539892",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539892"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1539987",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1539987"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540039",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540039"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540080",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540080"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540462",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540462"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540487",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540487"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540490",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540490"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540521",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540521"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540526",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540526"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540729",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540729"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540785",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540785"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540812",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540812"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540822",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540822"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540840",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540840"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540842",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540842"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540846",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540846"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540848",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540848"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540866",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540866"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540912",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540912"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540916",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540916"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1540976",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1540976"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541247",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541247"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541263",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541263"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541265",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541265"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541339",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541339"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541461",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541461"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541589",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541589"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1541946",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1541946"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542099",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542099"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542238",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542238"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542324",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542324"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542397",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542397"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542406",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542406"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542612",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542612"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542669",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542669"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542781",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542781"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542855",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542855"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542861",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542861"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1542868",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1542868"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543122",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543122"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543229",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543229"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543256",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543256"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543324",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543324"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543446",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543446"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543478",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543478"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543511",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543511"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543521",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543521"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543532",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543532"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543625",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543625"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543714",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543714"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543771",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543771"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543830",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543830"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1543869",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1543869"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544027",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544027"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544083",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544083"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544207",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544207"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544360",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544360"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544387",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544387"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544645",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544645"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544657",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544657"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544815",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544815"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1544903",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1544903"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545011",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545011"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545280",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545280"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1545828",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1545828"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546188",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546188"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546293",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546293"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546311",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546311"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546365",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546365"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546374",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546374"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1546854",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1546854"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547229",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547229"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547284",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547284"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547727",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547727"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547898",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547898"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547923",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547923"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1547944",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1547944"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548104",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548104"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548485",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548485"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548633",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548633"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548641",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548641"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1548720",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1548720"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1549491",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1549491"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1549971",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1549971"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1550140",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1550140"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1550148",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1550148"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1551775",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1551775"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1552165",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1552165"
-    },
-    {
-      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1552430",
-      "description": "https://bugzilla.redhat.com/show_bug.cgi?id=1552430"
-    }
-  ],
   "product_tree": {
     "branch": [
       {


### PR DESCRIPTION
As per discussion on mailing list:
https://www.oasis-open.org/apps/org/workgroup/csaf/email/archives/201805/msg00016.html
... this pull request updates the schema to have a top-level "document" element with children including "title", "references", "distribution", ...

Also updates the sample JSON documents to reflect this structure.