### PR TITLE
Integration of Traffic Light Protocol (TLP)

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -234,6 +234,21 @@
               "type": "string",
               "minLength": 1
             }
+          },
+          "dependencies": {
+            "tlp": {
+              "properties": {
+                "url": {
+                  "title": "URL of TLP version",
+                  "description": "Provides a URL where to find the textual description of the TLP version which is used in this document. Default is the URL to the definition by FIRST.",
+                  "default": "https://www.first.org/tlp/",
+                  "examples": ["https://www.first.org/tlp/", "https://www.us-cert.gov/tlp", "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Kritis/Merkblatt_TLP.pdf"],
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "required": ["url"]
+            }
           }
         },
         "lang": {

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -225,7 +225,12 @@
               "title": "Traffic Light Protocol (TLP)",
               "description": "Provides the TLP classification of the document.",
               "type": "string",
-              "enum": ["RED", "AMBER", "GREEN", "WHITE"]
+              "enum": [
+                "RED",
+                "AMBER",
+                "GREEN",
+                "WHITE"
+              ]
             },
             "text": {
               "title": "Description",


### PR DESCRIPTION
- resolves issue related to oasis-tcs/csaf#22
- add "url" as new field as discussed in TC meeting 20200527
- "url" is a dependency - it must be present if "tlp" is set
- "url" default is https://www.first.org/tlp/
- add generic keywords "title", "description" to the definition
- add examples