### PR TITLE
CSAF_version artifact

### DIFF
--- a/csaf_2.0/examples/CVE-2018-0171-modified.json
+++ b/csaf_2.0/examples/CVE-2018-0171-modified.json
@@ -2,6 +2,7 @@
   "document": {
     "title": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability",
     "type": "Cisco Security Advisory",
+    "csaf_version": "2.0",
     "publisher": {
       "contact_details": "Emergency Support:\n+1 877 228 7302 (toll-free within North America)\n+1 408 525 6532 (International direct-dial)\nNon-emergency Support:\nEmail: psirt@cisco.com\nSupport requests that are received via e-mail are typically acknowledged within 48 hours.",
       "issuing_authority": "Cisco product security incident response is the responsibility of the Cisco Product Security Incident Response Team (PSIRT). The Cisco PSIRT is a dedicated, global team that manages the receipt, investigation, and public reporting of security vulnerability information that is related to Cisco products and networks. The on-call Cisco PSIRT works 24x7 with Cisco customers, independent security researchers, consultants, industry organizations, and other vendors to identify possible security issues with Cisco products and networks.\nMore information can be found in Cisco Security Vulnerability Policy available at http://www.cisco.com/web/about/security/psirt/security_vulnerability_policy.html"

--- a/csaf_2.0/examples/cvrf-rhba-2018-0489-modified.json
+++ b/csaf_2.0/examples/cvrf-rhba-2018-0489-modified.json
@@ -3,6 +3,7 @@
     "lang": "en",
     "title": "Red Hat Bug Fix Advisory: Red Hat OpenShift Container Platform 3.9 RPM Release Advisory",
     "type": "Security Advisory",
+    "csaf_version": "2.0",
     "publisher": {
       "contact_details": "secalert@redhat.com",
       "issuing_authority": "Red Hat Product Security"

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -210,6 +210,7 @@
       "title": "Document level meta-data",
       "description": "Captures the meta-data about this document describing a particular set of security advisories.",
       "required": [
+        "csaf_version",
         "title",
         "publisher",
         "type",
@@ -232,6 +233,12 @@
               "type": "string"
             }
           }
+        },
+        "csaf_version": {
+          "title": "CSAF version",
+          "description": "Gives the version of the CSAF specification which the document was generated for.",
+          "type": "string",
+          "enum": ["2.0"]
         },
         "distribution": {
           "title": "Rules for sharing document",


### PR DESCRIPTION
- resolves #23 
- add "csaf_version" with value "2.0"
- add "csaf_version" n required fields of "document"
- add generic keywords for documentation
- add "csaf_version" in examples to fix tests