### PR TITLE
Corrected scores sub schema, added cpe pattern, introduced canonical formatting via jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 <div>
 
 <h3>Contact</h3>
-<p>Please send questions or comments about <a href="https://www.oasis-open.org/resources/tcadmin/github-repositories-for-oasis-tc-members-chartered-work">OASIS TC GitHub repositories</a> to <a href="mailto:robin@oasis-open.org">Robin Cover</a> and <a href="mailto:chet.ensign@oasis-open.org">Chet Ensign</a>.  For questions about content in this repository, please contact the TC Chair or Co-Chairs as listed on the the CSAF TC's <a href="https://www.oasis-open.org/committees/csaf/">home page</a>.</p>
+<p>Please send questions or comments about <a href="https://www.oasis-open.org/resources/tcadmin/github-repositories-for-oasis-tc-members-chartered-work">OASIS TC GitHub repositories</a> to <a href="mailto:chet.ensign@oasis-open.org">Chet Ensign</a>.  For questions about content in this repository, please contact the TC Chair or Co-Chairs as listed on the the CSAF TC's <a href="https://www.oasis-open.org/committees/csaf/">home page</a>.</p>
 </div>
 
 

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -12,7 +12,10 @@
           "type": "array",
           "title": "Names of entities being recognized",
           "description": "Typically the name of a person belonging to an organization",
-          "examples": ["Johann Sebastian Bach", "Albert Einstein"],
+          "examples": [
+            "Johann Sebastian Bach",
+            "Albert Einstein"
+          ],
           "items": {
             "type": "string",
             "minLength": 1
@@ -22,7 +25,11 @@
           "type": "array",
           "title": "List of contributing organizations",
           "description": "The list of contributing organizations",
-          "examples": ["US-CERT", "Talos", "Google Project Zero"],
+          "examples": [
+            "US-CERT",
+            "Talos",
+            "Google Project Zero"
+          ],
           "items": {
             "type": "string",
             "minLength": 1
@@ -31,10 +38,12 @@
         "description": {
           "title": "Description of the acknowledgment",
           "description": "SHOULD represent any contextual details the document producers wish to make known about the acknowledgment or acknowledged parties",
-          "examples": ["First analysis of Coordinated Multi-Stream Attack (CMSA)"],
+          "examples": [
+            "First analysis of Coordinated Multi-Stream Attack (CMSA)"
+          ],
           "type": "string",
           "minLength": 1
-      },
+        },
         "urls": {
           "type": "array",
           "items": {
@@ -56,7 +65,16 @@
         "name": {
           "title": "Name of the branch",
           "description": "Contains the canonical descriptor or 'friendly name' of the branch.",
-          "examples": ["Microsoft", "Siemens", "Windows", "Office", "SIMATIC", "10", "365", "PCS 7"],
+          "examples": [
+            "Microsoft",
+            "Siemens",
+            "Windows",
+            "Office",
+            "SIMATIC",
+            "10",
+            "365",
+            "PCS 7"
+          ],
           "type": "string",
           "minLength": 1
         },
@@ -102,7 +120,10 @@
         "name": {
           "title": "Textual description of the product",
           "description": "The value of a Full Product Name element should be the product’s full canonical name, including version number and other attributes, as it would be used in a human-friendly document.",
-          "examples": ["Microsoft Host Integration Server 2006 Service Pack 1", "Cisco AnyConnect Secure Mobility Client 2.3.185"],
+          "examples": [
+            "Microsoft Host Integration Server 2006 Service Pack 1",
+            "Cisco AnyConnect Secure Mobility Client 2.3.185"
+          ],
           "type": "string",
           "minLength": 1
         },
@@ -111,6 +132,7 @@
           "title": "Common Platform Enumeration representation",
           "description": "The Common Platform Enumeration (CPE) attribute refers to a method for naming platforms external to this specification.",
           "type": "string",
+          "pattern": "^(?i)cpe:(/|\\d+\\.\\d+)[^:]*:?[^:]*:?[^:]*:?[^:]*:?[^:]*:?[^:]*:?[^:]*$",
           "minLength": 1
         }
       }
@@ -118,7 +140,13 @@
     "lang_t": {
       "title": "Language type",
       "description": "Identifies a language, corresponding to IETF BCP 47 / RFC 5646. See IETF language registry: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
-      "examples": ["de", "en", "fr", "frc", "jp"],
+      "examples": [
+        "de",
+        "en",
+        "fr",
+        "frc",
+        "jp"
+      ],
       "type": "string",
       "pattern": "^[a-zA-Z]{2,3}(-.+)?$"
     },
@@ -181,14 +209,21 @@
     "product_group_id_t": {
       "title": "Reference token for product group instance",
       "description": "Token required to identify a group of products so that it can be referred to from other parts in the document. There is no predefined or required format for the product_group_id as long as it uniquely identifies a group in the context of the current document.",
-      "examples": ["CSAFGID-0001", "CSAFGID-0002", "CSAFGID-0020"],
+      "examples": [
+        "CSAFGID-0001",
+        "CSAFGID-0002",
+        "CSAFGID-0020"
+      ],
       "type": "string",
       "minLength": 1
     },
     "product_id_t": {
       "title": "Reference token for product instance",
       "description": "Token required to identify a full_product_name so that it can be referred to from other parts in the document. There is no predefined or required format for the product_id as long as it uniquely identifies a product in the context of the current document.",
-      "examples": ["CVRFPID-0004", "CVRFPID-0008"],
+      "examples": [
+        "CVRFPID-0004",
+        "CVRFPID-0008"
+      ],
       "type": "string",
       "minLength": 1
     },
@@ -226,12 +261,17 @@
           "url",
           "description"
         ]
-        }
+      }
     },
     "version_t": {
       "title": "Version",
       "description": "Sepcifies a version string with a simple hierarchical counter model to denote clearly the evolution of the content of the document. Format must be understood as 'major.minor.patch.build' version.",
-      "examples": ["1", "0.9", "1.4.3", "2.40.0.320002"],
+      "examples": [
+        "1",
+        "0.9",
+        "1.4.3",
+        "2.40.0.320002"
+      ],
       "type": "string",
       "pattern": "^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*)){0,3}$"
     }
@@ -258,7 +298,7 @@
             "$ref": "#/definitions/acknowledgment_t"
           }
         },
-        "aggregate_severity" : {
+        "aggregate_severity": {
           "type": "object",
           "properties": {
             "namespace": {
@@ -273,7 +313,9 @@
           "title": "CSAF version",
           "description": "Gives the version of the CSAF specification which the document was generated for.",
           "type": "string",
-          "enum": ["2.0"]
+          "enum": [
+            "2.0"
+          ]
         },
         "distribution": {
           "title": "Rules for sharing document",
@@ -283,7 +325,11 @@
             "text": {
               "title": "Description",
               "description": "Provides a textual description of additional constraints.",
-              "examples": ["Share only on a need-to-know-basis only.", "Distribute freely.", "Copyright 2019, Example Company, All Rights Reserved."],
+              "examples": [
+                "Share only on a need-to-know-basis only.",
+                "Distribute freely.",
+                "Copyright 2019, Example Company, All Rights Reserved."
+              ],
               "type": "string",
               "minLength": 1
             },
@@ -310,7 +356,10 @@
                   "title": "URL of TLP version",
                   "description": "Provides a URL where to find the textual description of the TLP version which is used in this document. Default is the URL to the definition by FIRST.",
                   "default": "https://www.first.org/tlp/",
-                  "examples": ["https://www.us-cert.gov/tlp", "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Kritis/Merkblatt_TLP.pdf"],
+                  "examples": [
+                    "https://www.us-cert.gov/tlp",
+                    "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Kritis/Merkblatt_TLP.pdf"
+                  ],
                   "type": "string",
                   "format": "uri"
                 }
@@ -343,7 +392,9 @@
               "type": "string",
               "title": "How to contact",
               "description": "Information on how to contact the publisher, possibly including details such as web sites, email addresses, phone numbers, and postal mail addresses.",
-              "examples": ["Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."],
+              "examples": [
+                "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
+              ],
               "minLength": 1
             },
             "issuing_authority": {
@@ -378,8 +429,10 @@
         "title": {
           "title": "Title of this document",
           "description": "This SHOULD be a canonical name for the document, and sufficiently unique to distinguish it from similar documents.",
-          "examples": ["Example Company Cross-Site-Scripting Vulnerability in Example Generator",
-            "Cisco IPv6 Crafted Packet Denial of Service Vulnerability"],
+          "examples": [
+            "Example Company Cross-Site-Scripting Vulnerability in Example Generator",
+            "Cisco IPv6 Crafted Packet Denial of Service Vulnerability"
+          ],
           "type": "string",
           "minLength": 1
         },
@@ -397,7 +450,11 @@
             "id": {
               "title": "Unique identifier for the document",
               "description": "The ID is a simple label that provides for a wide range of numbering values, types, and schemes. Its value SHOULD be assigned and maintained by the original document issuing authority.",
-              "examples": ["Example Company - 2019-YH3234", "RHBA-2019:0024", "cisco-sa-20190513-secureboot"],
+              "examples": [
+                "Example Company - 2019-YH3234",
+                "RHBA-2019:0024",
+                "cisco-sa-20190513-secureboot"
+              ],
               "type": "string"
             },
             "aliases": {
@@ -406,13 +463,15 @@
                 "type": "string",
                 "title": "Alternate name",
                 "description": "Alternate names for the same vulnerability.",
-                "examples": ["CVE-2019-12345"],
+                "examples": [
+                  "CVE-2019-12345"
+                ],
                 "minLength": 1
               }
             },
             "current_release_date": {
               "title": "Current release date",
-              "description" : "The date of the current revision of this document was released",
+              "description": "The date of the current revision of this document was released",
               "type": "string",
               "format": "date-time"
             },
@@ -510,7 +569,10 @@
               "description": {
                 "title": "Description of the product group",
                 "description": "Gives a short, optional description of the group.",
-                "examples": ["The x64 versions of the operating system.", "Products supporting Modbus."],
+                "examples": [
+                  "The x64 versions of the operating system.",
+                  "Products supporting Modbus."
+                ],
                 "type": "string",
                 "minLength": 1
               },
@@ -541,10 +603,10 @@
                 }
               },
               "product_reference": {
-                "$ref": "#/definitions/product_id_t"     
+                "$ref": "#/definitions/product_id_t"
               },
               "relates_to_product_reference": {
-                "$ref": "#/definitions/product_id_t"    
+                "$ref": "#/definitions/product_id_t"
               },
               "relationship_type": {
                 "title": "Relationship type",
@@ -593,18 +655,49 @@
           },
           "scores": {
             "type": "array",
-            "items": {
-              "product_ids": "#/definitions/products_t",
-              "cvss_v20": {
-                "$ref": "https://www.first.org/cvss/cvss-v2.0.json"
-              },
-              "cvss_v30": {
-                "$ref": "https://www.first.org/cvss/cvss-v3.0.json"
-              },
-              "cvss_v31": {
-                "$ref": "https://www.first.org/cvss/cvss-v3.1.json"
+            "minItems": 0,
+            "items": [
+              {
+                "anyOf": [
+                  {
+                    "type": "array",
+                    "minItems": 0,
+                    "items": {
+                      "$ref": "#/definitions/products_t",
+                      "examples": [
+                        "CVRFID_123",
+                        "CSAFID_0815"
+                      ],
+                      "default": ""
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "cvss_v20": {
+                        "$ref": "https://www.first.org/cvss/cvss-v2.0.json"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "cvss_v30": {
+                        "$ref": "https://www.first.org/cvss/cvss-v3.0.json"
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "cvss_v31": {
+                        "$ref": "https://www.first.org/cvss/cvss-v3.1.json"
+                      }
+                    }
+                  }
+                ]
               }
-            }
+            ]
           },
           "discovery_date": {
             "type": "string",


### PR DESCRIPTION
I had to resolve some merge conflicts from the schema changes introduced in the ten or so pull requests merged into the default branch at oasis-tcs/csaf a few hours ago.

## TL;DR

This change essentially adds two things:

1. An initial CPE pattern without adjusting the minimal length of the string field etc.
2. A corrected scores sub schema.

## Details:

The defect of the sub schema for the `scores` array was simply, that we used keys of no meaning to any validator, so all documents simply passed, without conforming to our intent.

By wrapping all possible array items and these as a whole in turn also in an `anyOf` element, we should accept any ordering of correctly structured elements in such a `scores` array of documents.

During merge conflict resolution I kept the freshly introduced minimal length of arrays to 1 (albeit not convinced as some use cases profit from empty arrays and I am far away from the trenches here on my mountain ... :wink:)

To ease future comparisons across schema variants I introduced a canonical format for the schema file via jq.
This leads to some changes esp. with examples that are only layout.
