### PR TITLE
Publisher properties - alignment of title and name

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -416,6 +416,8 @@
           "description": "Notes about this set of vulnerabilities should be added here."
         },
         "publisher": {
+          "title": "Publisher",
+          "description": "Provides information about the publisher of the document.",
           "type": "object",
           "required": [
             "type"

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -423,7 +423,7 @@
           "properties": {
             "contact_details": {
               "type": "string",
-              "title": "How to contact",
+              "title": "Contact details",
               "description": "Information on how to contact the publisher, possibly including details such as web sites, email addresses, phone numbers, and postal mail addresses.",
               "examples": [
                 "Example Company can be reached at contact_us@example.com, or via our website at https://www.example.com/contact."
@@ -431,7 +431,7 @@
               "minLength": 1
             },
             "issuing_authority": {
-              "title": "What authority",
+              "title": "Issuing authority",
               "description": "The name of the issuing party and their authority to release the document, in particular, the party's constituency and responsibilities or other obligations.",
               "type": "string",
               "minLength": 1


### PR DESCRIPTION
- resolves #114
- rename title of "contact_details" and "issuing_authority"
- add generic keywords for documentation