### PR TITLE
Merge hickup c39df1f

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -12,6 +12,8 @@
         "names": {
           "title": "Names of entities being recognized",
           "description": "Typically the name of a person belonging to an organization",
+          "type": "array",
+          "minItems": 1,
           "examples": [
             "Johann Sebastian Bach",
             "Albert Einstein"
@@ -24,6 +26,8 @@
         "organizations": {
           "title": "List of contributing organizations",
           "description": "The list of contributing organizations",
+          "type": "array",
+          "minItems": 1,
           "examples": [
             "US-CERT",
             "Talos",


### PR DESCRIPTION
It looks like we lost some definitions at merge c39df1f914a61ea27361078bf6589b2d2dc8c199. This PR restores those lines.