### PR TITLE
Top level generic keywords for documentation (Revision)

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -588,10 +588,12 @@
             },
             "revision_history": {
               "title": "Revision history",
-              "description": "Contains all the information elements required to track the evolution of a CSAF document.",
+              "description": "Holds one revision item for each version of the CSAF document, including the initial one.",
               "type": "array",
               "minItems": 1,
               "items": {
+                "title": "Revision",
+                "description": "Contains all the information elements required to track the evolution of a CSAF document.",
                 "type": "object",
                 "required": [
                   "number",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -614,7 +614,10 @@
                     "title": "Summary of the revision",
                     "description": "Holds a single non-empty string representing a short description of the changes.",
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "examples": [
+                      "Initial version."
+                    ]
                   }
                 }
               }

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -1162,7 +1162,7 @@ Initial release date (`initial_release_date`) with value type `string` and forma
 
 ##### 3.2.1.11.6 Document Property - Tracking - Revision History
 
-The Revision History (`revision_history`) with value type `array` of 1 or more Revision History Entries contains all the information elements required to track the evolution of a CSAF document. 
+The Revision History (`revision_history`) with value type `array` of 1 or more Revision History Entries holds one revision item for each version of the CSAF document, including the initial one. 
 
         "revision_history": {
           // ...
@@ -1182,7 +1182,7 @@ The Revision History (`revision_history`) with value type `array` of 1 or more R
           }
         },
 
-Revision History Entry items are of type `object` with the three mandatory properties: Number (`number`), Date (`date`), and Summary (`summary`). 
+Each Revision contains all the information elements required to track the evolution of a CSAF document. Revision History Entry items are of type `object` with the three mandatory properties: Number (`number`), Date (`date`), and Summary (`summary`). 
 
 The Number (`number`) has value type Version (`version_t`). 
 


### PR DESCRIPTION
We were still missing the generic keywords for items of `document/tracking/revision_history`. The items are named `Revision`according to the CVRF 1.2 specification section [4.5.4.1](https://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/cs01/csaf-cvrf-v1.2-cs01.html#_Toc493508879).
This PR fixes that and adds an example for a summary of a revision.
It also adopts the schema.