### PR TITLE
Replace CVRF mentions in examples

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -275,8 +275,8 @@
       "type": "string",
       "minLength": 1,
       "examples": [
-        "CVRFPID-0004",
-        "CVRFPID-0008"
+        "CSAFPID-0004",
+        "CSAFPID-0008"
       ]
     },
     "references_t": {

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -770,8 +770,8 @@ The value is a token required to identify a `full_product_name` so that it can b
 
 Examples:
 
-    CVRFPID-0004
-    CVRFPID-0008
+    CSAFPID-0004
+    CSAFPID-0008
 
 ### 3.1.10 References Type
 List of references (`references_t`) of value type `array` with 1 or more items of type Reference holds a list of Reference objects. 


### PR DESCRIPTION
- resolves #178
- change CVRF to CSAF in examples
- change prose to match schema