### PR TITLE
Limit acknowledgment organization to a single string value

### DIFF
--- a/csaf_2.0/examples/cvrf-rhba-2018-0489-modified.json
+++ b/csaf_2.0/examples/cvrf-rhba-2018-0489-modified.json
@@ -9107,6 +9107,10 @@
       ],
       "acknowledgments": [
         {
+          "names": [
+            "Ben Parees"
+          ],
+          "organization": "Red Hat",
           "summary": "This issue was discovered by Ben Parees (Red Hat)."
         }
       ]
@@ -9577,6 +9581,10 @@
       ],
       "acknowledgments": [
         {
+          "names": [
+            "Jessica Forrester"
+          ],
+          "organization": "Red Hat",
           "summary": "This issue was discovered by Jessica Forrester (Red Hat)."
         }
       ]

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -32,22 +32,16 @@
               ]
             }
           },
-          "organizations": {
-            "title": "List of contributing organizations",
-            "description": "Contains the names of contributing organizations being recognized.",
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "title": "Contributing organization",
-              "description": "Contains the name of a single organization.",
-              "type": "string",
-              "minLength": 1,
-              "examples": [
-                "CISA",
-                "Talos",
-                "Google Project Zero"
-              ]
-            }
+          "organization": {
+            "title": "Contributing organization",
+            "description": "Contains the name of a contributing organization being recognized.",
+            "type": "string",
+            "minLength": 1,
+            "examples": [
+              "CISA",
+              "Talos",
+              "Google Project Zero"
+            ]
           },
           "summary": {
             "title": "Summary of the acknowledgment",

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -563,6 +563,8 @@ Value type is string with format URI (`uri`).
 
 ##### 3.1.1.5 Acknowledgments Type - Example
 
+Example:
+
 ```
 "acknowledgments": [
   {

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -593,6 +593,14 @@ Value type is string with format URI (`uri`).
   },
 ]
 ```
+The example above should lead to the following outcome in a human-readable advisory:
+
+> We thank the following parties for their efforts:
+> 
+> * Johann Sebastian Bach, Georg Philipp Telemann, Georg Friedrich Händel from Baroque composers for wonderful music
+> * CISA for coordination efforts (see: https://cisa.gov)
+> * BSI for assistance in coordination
+> * Antonio Vivaldi for influencing other composers
 
 ### 3.1.2 Branches Type
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2383,10 +2383,11 @@ Firstly, the program:
 
 Secondly, the program for all items of:
 
+* `/document/acknowledgment/organization` and `/vulernabilities[]/acknowledgment/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
 * `/document/publisher/name`: Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with. If both values are present, the program should prefer the latter one.
 * `/vulernabilities[]/scores[]`: If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in the arrays `known_affected`, `first_affected` and `last_affected`.
 * `/vulernabilities[]/scores[]`: If there are CVSSv3.0 and CVSSv3.1 Vectors available for the same product, the CVRF CSAF converter discards the CVSSv3.0 information and provide in CSAF only the CVSSv3.1 information.
-* `/product_tree/relationships[]`: If more than one prod:FullProductName instance is given, the CVRF CSAF converter converts the first one into the `full_product_name`. In addition that converter outputs a warning that information might be lost during conversion of product relationships.
+* `/product_tree/relationships[]`: If more than one prod:FullProductName instance is given, the CVRF CSAF converter converts the first one into the `full_product_name`. In addition the converter outputs a warning that information might be lost during conversion of product relationships.
 
 ### 5.1.6 Conformance Clause 6: CSAF content management system
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2383,7 +2383,7 @@ Firstly, the program:
 
 Secondly, the program for all items of:
 
-* `/document/acknowledgment/organization` and `/vulernabilities[]/acknowledgment/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
+* `/document/acknowledgments[]/organization` and `/vulernabilities[]/acknowledgments[]/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
 * `/document/publisher/name`: Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with. If both values are present, the program should prefer the latter one.
 * `/vulernabilities[]/scores[]`: If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in the arrays `known_affected`, `first_affected` and `last_affected`.
 * `/vulernabilities[]/scores[]`: If there are CVSSv3.0 and CVSSv3.1 Vectors available for the same product, the CVRF CSAF converter discards the CVSSv3.0 information and provide in CSAF only the CVSSv3.1 information.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -502,14 +502,14 @@ List of Acknowledgments (`acknowledgments_t`) type instances of value type array
 ```
 
 The value type of `Acknowledgment` is object with at least 1 and at most 4 properties. Every such element acknowledges contributions by describing those that contributed.
-The properties are: `names`, `organizations`, `summary`, and `urls`.
+The properties are: `names`, `organization`, `summary`, and `urls`.
 
 ```
         "properties": {
           "names": {
             // ...
           },
-          "organizations": {
+          "organization": {
             // ...
           },
           "summary": {
@@ -533,10 +533,9 @@ Examples:
     Albert Einstein
 ```
 
-#### 3.1.1.2 Acknowledgments Type - Organizations
+#### 3.1.1.2 Acknowledgments Type - Organization
 
-List of contributing organizations (`organizations`) has value type `array` with 1 or more items holds the names of contributing organizations being recognized.
-Every such item of value type `string` with 1 or more characters represents the name of a single organization.
+The contributing organization (`organization`) has value type `string` with 1 or more characters and holds the name of the contributing organization being recognized.
 
 Examples:
 
@@ -561,6 +560,39 @@ Example:
 List of URLs (`urls`) of acknowledgment is a container (value type `array`) for 1 or more `string` of type URL that specifies a list of URLs or location of the reference to be acknowledged.
 Any URL of acknowledgment contains the URL or location of the reference to be acknowledged.
 Value type is string with format URI (`uri`).
+
+##### 3.1.1.5 Acknowledgments Type - Example
+
+```
+"acknowledgments": [
+  {
+    "names": [
+      "Johann Sebastian Bach",
+      "Georg Philipp Telemann",
+      "Georg Friedrich Händel"
+    ],
+    "organization": "Baroque composers",
+    "summary": "wonderful music"
+  },
+  {
+    "organization": "CISA"
+    "summary": "coordination efforts",
+    "urls": [
+      "https://cisa.gov"
+    ]
+  },
+  {
+    "organization": "BSI",
+    "summary": "assistance in coordination"
+  },
+  {
+    "names": [
+      "Antonio Vivaldi"
+    ],
+    "summary": "influencing other composers"
+  },
+]
+```
 
 ### 3.1.2 Branches Type
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2383,7 +2383,7 @@ Firstly, the program:
 
 Secondly, the program for all items of:
 
-* `/document/acknowledgments[]/organization` and `/vulernabilities[]/acknowledgments[]/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
+* `/document/acknowledgments[]/organization` and `/vulnerabilities[]/acknowledgments[]/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
 * `/document/publisher/name`: Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with. If both values are present, the program should prefer the latter one.
 * `/vulernabilities[]/scores[]`: If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in the arrays `known_affected`, `first_affected` and `last_affected`.
 * `/vulernabilities[]/scores[]`: If there are CVSSv3.0 and CVSSv3.1 Vectors available for the same product, the CVRF CSAF converter discards the CVSSv3.0 information and provide in CSAF only the CVSSv3.1 information.


### PR DESCRIPTION
The previous value of an array allowed for ambiguous relationships between
names, URLs or summaries to any of the organization in the array.
Limiting this to a single organization per acknowledgment object makes the
association to names, URLs and a summary clear.

Resolves #227