### PR TITLE
Run Actions on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 jobs:
   json-test_job:


### PR DESCRIPTION
Currently, we only run the actions during `push`. As a result, we don't see whether a PR might break the tests. Therefore, I suggest to add PRs to the triggers of actions.