### PR TITLE
Hashes

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -168,50 +168,66 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "title": "Cryptographic hash",
-                "description": "Contains all information to identify a file based on its cryptographic hash value.",
+                "title": "Cryptographic hashes",
+                "description": "Contains all information to identify a file based on its cryptographic hash values.",
                 "type": "object",
                 "required": [
-                  "algorithm",
-                  "file",
-                  "value"
+                  "file_hashes",
+                  "file_name"
                 ],
                 "properties": {
-                  "algorithm": {
-                    "title": "Algorithm of the cryptographic hash",
-                    "description": "Contains the name of the cryptographic hash algorithm used to calculate the value.",
-                    "type": "string",
-                    "default": "SHA-3",
-                    "minLength": 1,
-                    "examples": [
-                      "SHA-256",
-                      "SHA-384",
-                      "SHA-512",
-                      "SHA-3",
-                      "BLAKE3"
-                    ]
+                  "file_hashes": {
+                    "title": "List of file hashes",
+                    "description": "Contains a list of cryptographic hashes for this file.",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "title": "File hash",
+                      "description": "Contains one hash value and algorithm of the file to be identified.",
+                      "type": "object",
+                      "required": [
+                        "algorithm",
+                        "value"
+                      ],
+                      "properties": {
+                        "algorithm": {
+                          "title": "Algorithm of the cryptographic hash",
+                          "description": "Contains the name of the cryptographic hash algorithm used to calculate the value.",
+                          "type": "string",
+                          "default": "SHA-3",
+                          "minLength": 1,
+                          "examples": [
+                            "SHA-256",
+                            "SHA-384",
+                            "SHA-512",
+                            "SHA-3",
+                            "BLAKE3"
+                          ]
+                        },
+                        "value": {
+                          "title": "Value of the cryptographic hash",
+                          "description": "Contains the cryptographic hash value in hexadecimal representation.",
+                          "type": "string",
+                          "minLength": 64,
+                          "pattern": "^[0-9a-fA-F]{64,}$",
+                          "examples": [
+                            "4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc",
+                            "9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c",
+                            "37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3"
+                          ]
+                        }
+                      }
+                    }
                   },
-                  "file": {
+                  "file_name": {
                     "title": "Filename",
-                    "description": "Contains the name of the file which is identified by the hash value.",
+                    "description": "Contains the name of the file which is identified by the hash values.",
                     "type": "string",
                     "minLength": 1,
                     "examples": [
                       "WINWORD.EXE",
                       "msotadddin.dll",
                       "sudoers.so"
-                    ]
-                  },
-                  "value": {
-                    "title": "Value of the cryptographic hash",
-                    "description": "Contains the cryptographic hash value in hexadecimal representation.",
-                    "type": "string",
-                    "minLength": 64,
-                    "pattern": "^[0-9a-fA-F]{64,}$",
-                    "examples": [
-                      "4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc",
-                      "9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c",
-                      "37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3"
                     ]
                   }
                 }

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -208,8 +208,8 @@
                           "title": "Value of the cryptographic hash",
                           "description": "Contains the cryptographic hash value in hexadecimal representation.",
                           "type": "string",
-                          "minLength": 64,
-                          "pattern": "^[0-9a-fA-F]{64,}$",
+                          "minLength": 32,
+                          "pattern": "^[0-9a-fA-F]{32,}$",
                           "examples": [
                             "4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc",
                             "9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -194,14 +194,14 @@
                           "title": "Algorithm of the cryptographic hash",
                           "description": "Contains the name of the cryptographic hash algorithm used to calculate the value.",
                           "type": "string",
-                          "default": "SHA-3",
+                          "default": "sha256",
                           "minLength": 1,
                           "examples": [
-                            "SHA-256",
-                            "SHA-384",
-                            "SHA-512",
-                            "SHA-3",
-                            "BLAKE3"
+                            "sha256",
+                            "sha384",
+                            "sha512",
+                            "sha3-512",
+                            "blake2b512"
                           ]
                         },
                         "value": {

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -173,7 +173,7 @@
                 "type": "object",
                 "required": [
                   "file_hashes",
-                  "file_name"
+                  "filename"
                 ],
                 "properties": {
                   "file_hashes": {
@@ -219,7 +219,7 @@
                       }
                     }
                   },
-                  "file_name": {
+                  "filename": {
                     "title": "Filename",
                     "description": "Contains the name of the file which is identified by the hash values.",
                     "type": "string",

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -793,14 +793,14 @@ List of hashes (`hashes`) of value type `array` holding at least one item contai
 ```
 
 Cryptographic hashes of value type `object` contains all information to identify a file based on its cryptographic hash values.
-Any cryptographic hashes object has the 2 mandatory properties `file_hashes` and `file_name`.
+Any cryptographic hashes object has the 2 mandatory properties `file_hashes` and `filename`.
 
 ```
         "properties": {
           "file_hashes": {
             // ...
           },
-          "file_name": {
+          "filename": {
             // ...
           }
         }
@@ -859,7 +859,7 @@ Examples:
     37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3
 ```
 
-The file name representation (`file_name`) of type `string` with one or more characters contains the name of the file which is identified by the hash value.
+The filename representation (`filename`) of type `string` with one or more characters contains the name of the file which is identified by the hash value.
 
 Examples:
 
@@ -868,6 +868,8 @@ Examples:
     msotadddin.dll
     sudoers.so
 ```
+
+If the value of the hash matches and the filename does not, a user should prefer the hash value. In such cases, the filename should be used as informational property.
 
 ##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - PURL
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -843,10 +843,10 @@ Examples:
     BLAKE3
 ```
 
-The Value of the cryptographic hash representation (`value`) of value type `string` of 64 or more characters with `pattern` (regular expression):
+The Value of the cryptographic hash representation (`value`) of value type `string` of 32 or more characters with `pattern` (regular expression):
 
 ```
-    ^[0-9a-fA-F]{64,}$
+    ^[0-9a-fA-F]{32,}$
 ```
 
 The Value of the cryptographic hash attribute contains the cryptographic hash value in hexadecimal representation.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -306,6 +306,8 @@ _Data elements and interchange formats — Information interchange — Represent
 ###### [ISO29147]
 _Information technology — Security techniques — Vulnerability disclosure_, International Standard, ISO 29147:2014(E), February 15, 2014,
 https://www.iso.org/standard/45170.html.
+###### [OPENSSL]
+_GTLS/SSL and crypto library_, OpenSSL Software Foundation, https://www.openssl.org/.
 ###### [PURL]
 _Package URL (PURL)_, GitHub Project, https://github.com/package-url/purl-spec
 ###### [RFC3552]
@@ -313,18 +315,15 @@ Rescorla, E. and B. Korver, "Guidelines for Writing RFC Text on Security Conside
 ###### [RFC7464]
 N. Williams., "JavaScript Object Notation (JSON) Text Sequences", RFC 7464, DOI 10.17487/RFC7464, February 2015, http://www.rfc-editor.org/info/rfc7464.
 ###### [SCAP12]
-_The Technical Specification for the Security Content Automation Protocol (SCAP): SCAP Version 1.2_, D. Waltermire, S. Quinn, K. Scarfone, A. Halbardier, Editors, NIST Spec. Publ. 800‑126 rev. 2, September 2011, 
-http://dx.doi.org/10.6028/NIST.SP.800-126r2.
+_The Technical Specification for the Security Content Automation Protocol (SCAP): SCAP Version 1.2_, D. Waltermire, S. Quinn, K. Scarfone, A. Halbardier, Editors, NIST Spec. Publ. 800‑126 rev. 2, September 2011, http://dx.doi.org/10.6028/NIST.SP.800-126r2.
 ###### [XML]
-_Extensible Markup Language (XML) 1.0 (Fifth Edition)_, T. Bray, J. Paoli, M. Sperberg-McQueen, E. Maler, F. Yergeau, Editors, W3C Recommendation, November 26, 2008, http://www.w3.org/TR/2008/REC-xml-20081126/. 
+_Extensible Markup Language (XML) 1.0 (Fifth Edition)_, T. Bray, J. Paoli, M. Sperberg-McQueen, E. Maler, F. Yergeau, Editors, W3C Recommendation, November 26, 2008, http://www.w3.org/TR/2008/REC-xml-20081126/.
 Latest version available at http://www.w3.org/TR/xml.
 ###### [XML-Schema-1]
-_W3C XML Schema Definition Language (XSD) 1.1 Part 1: Structures_, S. Gao, M. Sperberg-McQueen, H. Thompson, N. Mendelsohn, D. Beech, M. Maloney, Editors, W3C Recommendation, April 5, 2012, 
-http://www.w3.org/TR/2012/REC-xmlschema11-1-20120405/. 
+_W3C XML Schema Definition Language (XSD) 1.1 Part 1: Structures_, S. Gao, M. Sperberg-McQueen, H. Thompson, N. Mendelsohn, D. Beech, M. Maloney, Editors, W3C Recommendation, April 5, 2012, http://www.w3.org/TR/2012/REC-xmlschema11-1-20120405/.
 Latest version available at http://www.w3.org/TR/xmlschema11-1/.
 ###### [XML-Schema-2]
-_W3C XML Schema Definition Language (XSD) 1.1 Part 2_: Datatypes W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes, D. Peterson, S. Gao, A. Malhotra, M. Sperberg-McQueen, H. Thompson, Paul V. Biron, Editors, W3C Recommendation, April 5, 2012, 
-http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/. 
+_W3C XML Schema Definition Language (XSD) 1.1 Part 2_: Datatypes W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes, D. Peterson, S. Gao, A. Malhotra, M. Sperberg-McQueen, H. Thompson, Paul V. Biron, Editors, W3C Recommendation, April 5, 2012, http://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/.
 Latest version available at http://www.w3.org/TR/xmlschema11-2/.
 
 ## 1.5 Typographical Conventions
@@ -843,7 +842,7 @@ Examples:
       blake2b512
 ```
 
-These values are derived from the currently supported digests OpenSSL. Leading dashs were removed.
+These values are derived from the currently supported digests OpenSSL [OPENSSL]. Leading dashs were removed.
 
 > The command `openssl dgst -list` (Version 1.1.1f from 2020-03-31) outputs the following:
 >

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -792,15 +792,36 @@ List of hashes (`hashes`) of value type `array` holding at least one item contai
     }
 ```
 
-A cryptographic hash of value type `object` contains a list of cryptographic hashes usable to identify files.
-Any cryptographic hash object has the 3 mandatory properties `algorithm`, `file`, and `value`.
+Cryptographic hashes of value type `object` contains all information to identify a file based on its cryptographic hash values.
+Any cryptographic hashes object has the 2 mandatory properties `file_hashes` and `file_name`.
+
+```
+        "properties": {
+          "file_hashes": {
+            // ...
+          },
+          "file_name": {
+            // ...
+          }
+        }
+```
+
+List of file hashes (`file_hashes`) of value type `array` holding at least one item contains a list of cryptographic hashes for this file.
+
+```
+    "file_hashes": {
+      // ...
+      "items": {
+        // ...
+      }
+    }
+```
+
+Each File hash of value type `object` contains one hash value and algorithm of the file to be identified. Any File hash object has the 2 mandatory properties `algorithm` and `value`.
 
 ```
         "properties": {
           "algorithm": {
-            // ...
-          },
-          "file": {
             // ...
           },
           "value": {
@@ -822,16 +843,6 @@ Examples:
     BLAKE3
 ```
 
-The file representation (`file`) of type `string` with one or more characters contains the name of the file which is identified by the hash value.
-
-Examples:
-
-```
-    WINWORD.EXE
-    msotadddin.dll
-    sudoers.so
-```
-
 The Value of the cryptographic hash representation (`value`) of value type `string` of 64 or more characters with `pattern` (regular expression):
 
 ```
@@ -846,6 +857,16 @@ Examples:
     4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc
     9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c
     37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3
+```
+
+The file name representation (`file_name`) of type `string` with one or more characters contains the name of the file which is identified by the hash value.
+
+Examples:
+
+```
+    WINWORD.EXE
+    msotadddin.dll
+    sudoers.so
 ```
 
 ##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - PURL

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -876,7 +876,7 @@ Examples:
     37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3
 ```
 
-The filename representation (`filename`) of type `string` with one or more characters contains the name of the file which is identified by the hash value.
+The filename representation (`filename`) of type `string` with one or more characters contains the name of the file which is identified by the hash values.
 
 Examples:
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -831,17 +831,34 @@ Each File hash of value type `object` contains one hash value and algorithm of t
 ```
 
 The algorithm of the cryptographic hash representation (`algorithm`) of type `string` with one or more characters contains the name of the cryptographic hash algorithm used to calculate the value.
-The default value for `algorithm` is `SHA-3`.
+The default value for `algorithm` is `sha256`.
 
 Examples:
 
 ```
-    SHA-256
-    SHA-384
-    SHA-512
-    SHA-3
-    BLAKE3
+      sha256
+      sha384
+      sha512
+      sha3-512
+      blake2b512
 ```
+
+These values are derived from the currently supported digests OpenSSL. Leading dashs were removed.
+
+> The command `openssl dgst -list` (Version 1.1.1f from 2020-03-31) outputs the following:
+>
+>```
+>  Supported digests:
+>  -blake2b512                -blake2s256                -md4                      
+>  -md5                       -md5-sha1                  -ripemd                   
+>  -ripemd160                 -rmd160                    -sha1                     
+>  -sha224                    -sha256                    -sha3-224                 
+>  -sha3-256                  -sha3-384                  -sha3-512                 
+>  -sha384                    -sha512                    -sha512-224               
+>  -sha512-256                -shake128                  -shake256                 
+>  -sm3                       -ssl3-md5                  -ssl3-sha1                
+>  -whirlpool
+>```
 
 The Value of the cryptographic hash representation (`value`) of value type `string` of 32 or more characters with `pattern` (regular expression):
 


### PR DESCRIPTION
- resolves comments from #208 and #209
- provide an array with hashes for each filename
- add remark about interpretation of filename mismatch at hash match
- change default value to `sha256`
- use digest list from OpenSSL