### PR TITLE
JSON schema namespace in HTTPS

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.0/json_schema/csaf_json_schema.json",
   "title": "Common Security Advisory Framework",
   "description": "Representation of security advisory information as a JSON document.",


### PR DESCRIPTION
Addressing #245 

As a best practice, the JSON Schema reference should be in HTTPS instead of HTTP. In other words, changing:
```
"$schema": "http://json-schema.org/draft-07/schema#",
```
to

```
"$schema": "https://json-schema.org/draft-07/schema#",
```