### PR TITLE
Product numbers

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -233,18 +233,6 @@
                 }
               }
             },
-            "product_numbers": {
-              "title": "List of product numbers",
-              "description": "Contains a list of parts, or full product numbers.",
-              "type": "array",
-              "minItems": 1,
-              "items": {
-                "title": "Product number",
-                "description": "Contains a part, or a full product number which is used in the ordering process to identify the component.",
-                "type": "string",
-                "minLength": 1
-              }
-            },
             "purl": {
               "$comment": "TODO: This should have a full regular expression to enforce purl syntax.",
               "title": "package URL representation",
@@ -262,6 +250,18 @@
               "items": {
                 "title": "Serial number",
                 "description": "Contains a part, or a full serial number of the component to identify.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "skus": {
+              "title": "List of stock keeping units",
+              "description": "Contains a list of parts, or full stock keeping units.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Stock keeping unit",
+                "description": "Contains a part, or a full stock keeping unit (SKU) which is used in the ordering process to identify the component.",
                 "type": "string",
                 "minLength": 1
               }

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -234,7 +234,6 @@
               }
             },
             "product_numbers": {
-              "$comment": "TODO: Add remark in prose that this should only be used if relationships are used (to decouple hard- and software), or the product numbers change during update.",
               "title": "List of product numbers",
               "description": "Contains a list of parts, or full product numbers.",
               "type": "array",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -233,6 +233,19 @@
                 }
               }
             },
+            "product_numbers": {
+              "$comment": "TODO: Add remark in prose that this should only be used if relationships are used (to decouple hard- and software), or the product numbers change during update.",
+              "title": "List of product numbers",
+              "description": "Contains a list of parts, or full product numbers.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "title": "Product number",
+                "description": "Contains a part, or a full product number which is used in the ordering process to identify the component.",
+                "type": "string",
+                "minLength": 1
+              }
+            },
             "purl": {
               "$comment": "TODO: This should have a full regular expression to enforce purl syntax.",
               "title": "package URL representation",

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -753,7 +753,7 @@ Product ID (`product_id`) holds a value of type Product ID (`product_id_t`).
 #### 3.1.3.3 Full Product Name Type - Product Identification Helper
 
 Helper to identify the product (`product_identification_helper`) of value type `object` provides in its properties at least one method which aids in identifying the product in an asset database.
-Of the given five properties `cpe`, `hashes`, `purl`, `serial_numbers`, and `x_generic_uris`, one is mandatory.
+Of the given five properties `cpe`, `hashes`, `purl`, `serial_numbers`, `skus` and `x_generic_uris`, one is mandatory.
 
 ```
     "product_identification_helper": {
@@ -769,6 +769,9 @@ Of the given five properties `cpe`, `hashes`, `purl`, `serial_numbers`, and `x_g
           // ...
         },
         "serial_numbers": {
+          // ...
+        },
+        "skus": {
           // ...
         },
         "x_generic_uris": {
@@ -896,29 +899,6 @@ Examples:
 
 If the value of the hash matches and the filename does not, a user should prefer the hash value. In such cases, the filename should be used as informational property.
 
-##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - Product numbers
-
-The list of product numbers (`product_numbers`) of value type `array` with 1 or more items contains a list of parts, or full product numbers.
-
-A list of product numbers SHOULD only be used if the list of relationships is used to decouple e.g. hardware from the software, or the product numbers change during update. In the latter case the remediations SHALL include the new product number is or a description how it can be obtained.
-
-> The use of the list of relationships in the first case is important. Otherwise, the end user is unable to identify which version (the affected or the not affected / fixed one) is used.
-
-```
-    "product_numbers": {
-        //...  
-      "items": {
-        //...  
-      }
-    }
-```
-
-Any given product number of value type `string` with at least 1 character represents a part, or a full product number of the component to identify.
-
-If a part of a product number of the component to identify is given, it SHOULD begin with the first character of the product number and stop at any point.
-Characters which should not be matched MUST be replaced by either `?` (for a single character) or `*` (for zero or more characters).  
-Two `*` MUST NOT follow each other.
-
 ##### 3.1.3.3.4 Full Product Name Type - Product Identification Helper - PURL
 
 The package URL (PURL) representation (`purl`) is a `string` of 4 or more characters with `pattern` (regular expression):
@@ -939,6 +919,27 @@ Any given serial number of value type `string` with at least 1 character represe
 
 ```
     "serial_numbers": {
+        //...
+      "items": {
+        //...
+      }
+    }
+```
+
+If a part of a serial number of the component to identify is given, it SHOULD begin with the first character of the serial number and stop at any point.
+Characters which should not be matched MUST be replaced by either `?` (for a single character) or `*` (for zero or more characters).  
+Two `*` MUST NOT follow each other.
+
+##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - SKUs
+
+The list of stock keeping units (`skus`) of value type `array` with 1 or more items contains a list of parts, or full stock keeping units.
+
+A list of stock keeping units SHOULD only be used if the list of relationships is used to decouple e.g. hardware from the software, or the stock keeping units change during update. In the latter case the remediations SHALL include the new stock keeping units is or a description how it can be obtained.
+
+> The use of the list of relationships in the first case is important. Otherwise, the end user is unable to identify which version (the affected or the not affected / fixed one) is used.
+
+```
+    "skus": {
         //...  
       "items": {
         //...  
@@ -946,7 +947,11 @@ Any given serial number of value type `string` with at least 1 character represe
     }
 ```
 
-If a part of a serial number of the component to identify is given, it SHOULD begin with the first character of the serial number and stop at any point.
+Any given stock keeping unit of value type `string` with at least 1 character represents a part, or a full stock keeping unit (SKU) of the component to identify.
+
+> Sometimes this is also called "item number", "article number" or "product number".
+
+If a part of a stock keeping unit of the component to identify is given, it SHOULD begin with the first character of the stock keeping unit and stop at any point.
 Characters which should not be matched MUST be replaced by either `?` (for a single character) or `*` (for zero or more characters).  
 Two `*` MUST NOT follow each other.
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -754,7 +754,7 @@ Product ID (`product_id`) holds a value of type Product ID (`product_id_t`).
 #### 3.1.3.3 Full Product Name Type - Product Identification Helper
 
 Helper to identify the product (`product_identification_helper`) of value type `object` provides in its properties at least one method which aids in identifying the product in an asset database.
-Of the given five properties `cpe`, `hashes`, `purl`, `serial_numbers`, `skus` and `x_generic_uris`, one is mandatory.
+Of the given seven properties `cpe`, `hashes`, `purl`, `sbom_urls`, `serial_numbers`, `skus` and `x_generic_uris`, one is mandatory.
 
 ```
     "product_identification_helper": {

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -896,7 +896,30 @@ Examples:
 
 If the value of the hash matches and the filename does not, a user should prefer the hash value. In such cases, the filename should be used as informational property.
 
-##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - PURL
+##### 3.1.3.3.3 Full Product Name Type - Product Identification Helper - Product numbers
+
+The list of product numbers (`product_numbers`) of value type `array` with 1 or more items contains a list of parts, or full product numbers.
+
+A list of product numbers SHOULD only be used if the list of relationships is used to decouple e.g. hardware from the software, or the product numbers change during update. In the latter case the remediations SHALL include the new product number is or a description how it can be obtained.
+
+> The use of the list of relationships in the first case is important. Otherwise, the end user is unable to identify which version (the affected or the not affected / fixed one) is used.
+
+```
+    "product_numbers": {
+        //...  
+      "items": {
+        //...  
+      }
+    }
+```
+
+Any given product number of value type `string` with at least 1 character represents a part, or a full product number of the component to identify.
+
+If a part of a product number of the component to identify is given, it SHOULD begin with the first character of the product number and stop at any point.
+Characters which should not be matched MUST be replaced by either `?` (for a single character) or `*` (for zero or more characters).  
+Two `*` MUST NOT follow each other.
+
+##### 3.1.3.3.4 Full Product Name Type - Product Identification Helper - PURL
 
 The package URL (PURL) representation (`purl`) is a `string` of 4 or more characters with `pattern` (regular expression):
 
@@ -906,7 +929,7 @@ The package URL (PURL) representation (`purl`) is a `string` of 4 or more charac
 
 This package URL (PURL) attribute refers to a method for reliably identifying and locating software packages external to this specification. See [PURL] for details.
 
-##### 3.1.3.3.4 Full Product Name Type - Product Identification Helper - Serial Numbers
+##### 3.1.3.3.5 Full Product Name Type - Product Identification Helper - Serial Numbers
 
 The list of serial numbers (`serial_numbers`) of value type `array` with 1 or more items contains a list of parts, or full serial numbers.
 
@@ -927,7 +950,7 @@ If a part of a serial number of the component to identify is given, it SHOULD be
 Characters which should not be matched MUST be replaced by either `?` (for a single character) or `*` (for zero or more characters).  
 Two `*` MUST NOT follow each other.
 
-##### 3.1.3.3.5 Full Product Name Type - Product Identification Helper - Generic URIs
+##### 3.1.3.3.6 Full Product Name Type - Product Identification Helper - Generic URIs
 
 List of generic URIs (`x_generic_uris`) of value type `array` with at least 1 item contains a list of identifiers which are either vendor-specific or derived from a standard not yet supported.
 


### PR DESCRIPTION
- addresses parts of #126
- add `product_numbers` (from the ordering process) to `product_identification_helper`

Reasoning: This information is usually available if you buy new equipment. [Wago](https://cert.vde.com/de-de/advisories/vde-2021-014), [Endress+Hauser](https://cert.vde.com/de-de/advisories/vde-2021-010), [PEPPERL+FUCHS](https://cert.vde.com/de-de/advisories/vde-2021-018), [Weidmüller](https://cert.vde.com/de-de/advisories/vde-2021-016),... already include them in their current advisories.