### PR TITLE
Tests

### DIFF
--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -328,6 +328,8 @@ _GTLS/SSL and crypto library_, OpenSSL Software Foundation, https://www.openssl.
 _Package URL (PURL)_, GitHub Project, https://github.com/package-url/purl-spec
 ###### [RFC3552]
 Rescorla, E. and B. Korver, "Guidelines for Writing RFC Text on Security Considerations", BCP 72, RFC 3552, DOI 10.17487/RFC3552, July 2003, https://www.rfc-editor.org/info/rfc3552.
+###### [RFC7231]
+Fielding, R. and J. Reschke, "Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content", RFC 7231, DOI 10.17487/RFC7231, June 2014, <https://www.rfc-editor.org/info/rfc7231>.
 ###### [RFC7464]
 N. Williams., "JavaScript Object Notation (JSON) Text Sequences", RFC 7464, DOI 10.17487/RFC7464, February 2015, http://www.rfc-editor.org/info/rfc7464.
 ###### [SCAP12]
@@ -4069,9 +4071,9 @@ Example which fails the test:
 
 ### 5.3.6 Use of non-self referencing URLs Failing to Resolve
 
-For each URL which is not in the category `self` it must be tested that it resolves with a HTTP status code less than 400.
+For each URL which is not in the category `self` it must be tested that it resolves with a HTTP status code from the 2xx (Successful) or 3xx (Redirection) class.
 
-> This test does not apply for any item in an array of type `references_t` with the category `self`.
+> This test does not apply for any item in an array of type `references_t` with the category `self`. For details about the HTTP status code classes see [RFC7231].
 
 The relevant paths for this test are:
 
@@ -4103,18 +4105,18 @@ Example which fails the test:
 ```
   "references": [
   {
-    "summary": "A URL that does not resolve with HTTP status code < 400",
+    "summary": "A URL that does not resolve with HTTP status code in the interval between (including) 200 and (excluding) 400.",
     "url": "http://example.invalid"
   }
 ```
 
-> The `category` is not set and therefore threated as its default value `external`. A request to that URL does not resolve with a status code less than 400.
+> The `category` is not set and therefore threated as its default value `external`. A request to that URL does not resolve with a status code from the 2xx (Successful) or 3xx (Redirection) class.
 
 ### 5.3.7 Use of self referencing URLs Failing to Resolve
 
 For each item in an array of type `references_t` with the category `self` it must be tested that the URL referenced resolves with a HTTP status code less than 400.
 
-> This test will most likely fail if the CSAF document is in a status before the initial release.
+> This test will most likely fail if the CSAF document is in a status before the initial release. For details about the HTTP status code classes see [RFC7231].
 
 The relevant paths for this test are:
 
@@ -4129,12 +4131,12 @@ Example which fails the test:
   "references": [
   {
     "category": "self",
-    "summary": "A URL that does not resolve with HTTP status code < 400",
+    "summary": "A URL that does not resolve with HTTP status code in the interval between (including) 200 and (excluding) 400.",
     "url": "http://example.invalid"
   }
 ```
 
-> The `category` is `self` and a request to that URL does not resolve with a status code less than 400.
+> The `category` is `self` and a request to that URL does not resolve with a status code from the 2xx (Successful) or 3xx (Redirection) class.
 
 ### 5.3.8 Spell check
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3070,7 +3070,7 @@ Example which fails the test:
   }
 ```
 
-> A type is always required in a purl.
+> Any valid purl has a type component.
 
 ### 4.1.14 Sorted Revision History
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3835,6 +3835,36 @@ Recommendation:
 
 It is recommended to (also) use the CVSS v3.1.
 
+### 4.3.2 Use of CVSS v3.0
+
+For each item in the list of scores which contains the `cvss_v3` object it must be tested that CVSS v3.0 is not used.
+
+The relevant paths for this test are:
+
+```
+  /vulnerabilities[]/scores[]/cvss_v3/version
+  /vulnerabilities[]/scores[]/cvss_v3/vectorString
+```
+
+Example which fails the test:
+
+```
+  "cvss_v3": {
+    "version": "3.0",
+    "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+    "baseScore": 6.5,
+    "baseSeverity": "MEDIUM"
+  }
+```
+
+> The CVSS v3.0 is used.
+
+Recommendation:
+
+It is recommended to upgrade to CVSS v3.1.
+
+> A tool MAY implement the recommendation as quick fix. However, it SHALL recompute the `baseScore` and `baseSeverity`.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3873,6 +3873,32 @@ It is recommended to upgrade to CVSS v3.1.
 
 > A tool MAY implement the recommendation as quick fix. However, it SHALL recompute the `baseScore` and `baseSeverity`.
 
+### 4.3.3 Missing CVE
+
+It must be tested that the CVE number is given.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cve
+```
+
+Example which fails the test:
+
+```
+  "vulnerabilities": [
+    {
+      "title": "BlueKeep"
+    }
+  ]
+```
+
+> The CVE number is not given.
+
+Recommendation:
+
+It is recommended to provide a CVE number to support the users efforts to find more details about a vulnerability and potentially track it through multiple advisories. If no CVE exists for that vulnerability, it is recommended to get one assigned.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -4031,6 +4031,69 @@ Example which fails the test:
 
 > The `category` is `self` and a request to that URL does not resolve with a status code less than 400.
 
+### 4.3.8 Spell check
+
+If the document language is given it must be tested that a spell check for the given language does not find any mistakes. The test SHALL be skipped if not document language is set. It SHALL fail it the given language is not supported. The value of `/document/category` should not be tested if the CSAF document does not use the profile "Generic CSAF".
+
+The relevant paths for this test are:
+
+```
+  /document/acknowledgments[]/names[]
+  /document/acknowledgments[]/organization
+  /document/acknowledgments[]/summary
+  /document/aggregate_severity/text
+  /document/category
+  /document/distribution/text
+  /document/notes[]/audience
+  /document/notes[]/text
+  /document/notes[]/title
+  /document/publisher/issuing_authority
+  /document/publisher/name
+  /document/references[]/summary
+  /document/title
+  /document/tracking/aliases[]
+  /document/tracking/generator/engine/name
+  /document/tracking/revision_history[]/summary
+  /product_tree/branches[](/branches[])*/name
+  /product_tree/branches[](/branches[])*/product/name
+  /product_tree/branches[]/name
+  /product_tree/branches[]/product/name
+  /product_tree/full_product_names[]/name
+  /product_tree/product_groups[]/summary
+  /product_tree/relationships[]/full_product_name/name
+  /vulnerabilities[]/acknowledgments[]/names[]
+  /vulnerabilities[]/acknowledgments[]/organization
+  /vulnerabilities[]/acknowledgments[]/summary
+  /vulnerabilities[]/involvements[]/summary
+  /vulnerabilities[]/notes[]/audience
+  /vulnerabilities[]/notes[]/text
+  /vulnerabilities[]/notes[]/title
+  /vulnerabilities[]/references[]/summary
+  /vulnerabilities[]/remediations[]/details
+  /vulnerabilities[]/remediations[]/entitlements[]
+  /vulnerabilities[]/remediations[]/restart_required/details
+  /vulnerabilities[]/threats[]/details
+  /vulnerabilities[]/title
+```
+
+Example which fails the test:
+
+```
+  "document": {
+    // ...
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Secruity researchers found multiple vulnerabilities in XYZ."
+      }
+    ],
+    // ...
+  }
+```
+
+> There is a spelling mistake in `Secruity`.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3899,6 +3899,29 @@ Recommendation:
 
 It is recommended to provide a CVE number to support the users efforts to find more details about a vulnerability and potentially track it through multiple advisories. If no CVE exists for that vulnerability, it is recommended to get one assigned.
 
+### 4.3.4 Missing CWE
+
+It must be tested that the CWE is given.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cwe
+```
+
+Example which fails the test:
+
+```
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2019-0708",
+      "title": "BlueKeep"
+    }
+  ]
+```
+
+> The CWE number is not given.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3035,7 +3035,36 @@ Example which fails the test:
 
 > `TG` is not a valid language. It is the subtag for the region "Togo".
 
-### 4.1.13 Sorted Revision History
+### 4.1.13 PURL
+
+It must be tested that given PURL is valid.
+
+The relevant paths for this test are:
+
+```
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/purl
+  /product_tree/full_product_names[]/product_identification_helper/purl
+  /product_tree/relationships[]/full_product_name/product_identification_helper/purl
+```
+
+Example which fails the test:
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A"
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "purl": "pkg:ExampleLibrary.Common@4.2.1337"
+      }
+    ]
+  }
+```
+
+> A type is always required in a purl.
+
+### 4.1.14 Sorted Revision History
 
 It must be tested that the value of `number` of items of the revision history are sorted ascending when the items are sorted ascending by `date`.
 
@@ -3064,7 +3093,7 @@ Example which fails the test:
 
 > The first item has a higher version number than the second.
 
-### 4.1.14 Translator
+### 4.1.15 Translator
 
 It must be tested that `/document/source_lang` is present and set if the value `translator` is used for `/document/publisher/category`.
 
@@ -3090,7 +3119,7 @@ Example which fails the test:
 
 > The element `source_lang` is present but not set.
 
-### 4.1.15 Latest Document Version
+### 4.1.16 Latest Document Version
 
 It must be tested that document version has the same value as the the `number` in the last item of Revision History when it is sorted ascending by `date`. Build metadata is ignored in the comparison.
 
@@ -3123,7 +3152,7 @@ Example which fails the test:
 
 > The value of `number` of the last item after sorting is `2`. However, the document version is `1`.
 
-### 4.1.16 Document Status Draft
+### 4.1.17 Document Status Draft
 
 It must be tested that document status is `draft` if the document version is `0` or `0.y.z` or contains the pre-release part.
 
@@ -3145,7 +3174,7 @@ Example which fails the test:
 
 > The `/document/tracking/version` is `0.9.5` but the document status is `final`.
 
-### 4.1.17 Released Revision History
+### 4.1.18 Released Revision History
 
 It must be tested that no item of the revision history has a `number` of `0` or `0.y.z` when the document status is `final` or `interim`.
 
@@ -3179,7 +3208,7 @@ Example which fails the test:
 
 > The document status is `final` but the revision history includes an item which has `0` as value for `number`.
 
-### 4.1.18 Revision History Entries for Pre-release Versions
+### 4.1.19 Revision History Entries for Pre-release Versions
 
 It must be tested that no item of the revision history has a `number` which includes pre-release information.
 
@@ -3208,7 +3237,7 @@ Example which fails the test:
 
 > The revision history contains an item which has a `number` that indicates that this is pre-release.
 
-### 4.1.19 Non-draft Document Version
+### 4.1.20 Non-draft Document Version
 
 It must be tested that document version does not contain a pre-release part if the document status is `final` or `interim`.
 
@@ -3230,7 +3259,7 @@ Example which fails the test:
 
 > The document status is `interim` but the document version contains the pre-release part `-alpha`.
 
-### 4.1.20 Missing Item in Revision History
+### 4.1.21 Missing Item in Revision History
 
 It must be tested that items of the revision history do not omit a version number when the items are sorted ascending by `date`. In the case of semantic versioning, this applies only to the Major version.
 
@@ -3259,7 +3288,7 @@ Example which fails the test:
 
 > The item for version `2` is missing.
 
-### 4.1.21 Multiple Definition in Revision History
+### 4.1.22 Multiple Definition in Revision History
 
 It must be tested that items of the revision history do not contain the same version number.
 
@@ -3288,7 +3317,7 @@ Example which fails the test:
 
 > The revision history contains two items with the version number `1`.
 
-### 4.1.22 Multiple Use of Same CVE
+### 4.1.23 Multiple Use of Same CVE
 
 It must be tested that a CVE is not used in multiple vulnerability items.
 
@@ -3313,7 +3342,7 @@ Example which fails the test:
 
 > The vulnerabilities array contains two items with the same CVE identifier `CVE-2017-0145`.
 
-### 4.1.23 Multiple Definition in Involvements
+### 4.1.24 Multiple Definition in Involvements
 
 It must be tested that items of the list of involements do not contain the tuple of `party` and `status` more than once at any `date`.
 
@@ -3346,7 +3375,7 @@ Example which fails the test:
 
 > The list of involements contains two items with the same tuple `party`, `status` and `date`.
 
-### 4.1.24 Multiple Use of Same Hash Algorithm
+### 4.1.25 Multiple Use of Same Hash Algorithm
 
 It must be tested that the same hash algorithm is not used multiple times in one item of hashes.
 
@@ -3390,7 +3419,7 @@ Example which fails the test:
 
 > The hash algorithm `sha256` is used two times in one item of hashes.
 
-### 4.1.25 Prohibited Document Category Name
+### 4.1.26 Prohibited Document Category Name
 
 It must be tested that the document category is not equal to the (case insensitive) name of any other profile than "Generic CSAF". This does not differentiate between underscore, dash or whitespace.
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -329,7 +329,7 @@ _Package URL (PURL)_, GitHub Project, https://github.com/package-url/purl-spec
 ###### [RFC3552]
 Rescorla, E. and B. Korver, "Guidelines for Writing RFC Text on Security Considerations", BCP 72, RFC 3552, DOI 10.17487/RFC3552, July 2003, https://www.rfc-editor.org/info/rfc3552.
 ###### [RFC7231]
-Fielding, R. and J. Reschke, "Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content", RFC 7231, DOI 10.17487/RFC7231, June 2014, <https://www.rfc-editor.org/info/rfc7231>.
+Fielding, R. and J. Reschke, "Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content", RFC 7231, DOI 10.17487/RFC7231, June 2014, https://www.rfc-editor.org/info/rfc7231.
 ###### [RFC7464]
 N. Williams., "JavaScript Object Notation (JSON) Text Sequences", RFC 7464, DOI 10.17487/RFC7464, February 2015, http://www.rfc-editor.org/info/rfc7464.
 ###### [SCAP12]

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3758,6 +3758,32 @@ Example which fails the test:
 
 > The hash algorithm `sha1` is used in one item of hashes without being accompanied by a second hash algorithm.
 
+### 4.2.10 Missing TLP label
+
+It must be tested that `/document/distribution/tlp/label` is present and valid.
+
+> TLP labels support the machine-readability and automated distribution.
+
+The relevant path for this test is:
+
+```
+  /document/distribution/tlp/label
+```
+
+Example which fails the test:
+
+```
+  "document": {
+    // ...
+    "distribution": {
+      "text": "Distribute freely."
+    },
+    // ...
+  }
+```
+
+> The CSAF document has no TLP label.
+
 ## 4.3 Informative Test
 
 Informative tests provide insights in common mistakes and bad practices. They MAY fail at a valid CSAF document. It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated. These tests may include information about recommended usage. A program MUST handle a test failure as a information.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -4205,7 +4205,7 @@ This section lists requirements and roles defined for distributing CSAF document
 
 ## 6.1 Requirements
 
-The requirements in this subsection are consecutively numbered to be able to refer to them directly. The order does not give any hint about the importance. Not all requirements have to be fulfilled - the sets are defined in section 5.2.
+The requirements in this subsection are consecutively numbered to be able to refer to them directly. The order does not give any hint about the importance. Not all requirements have to be fulfilled - the sets are defined in section 6.2.
 
 ### 6.1.1 Requirement 1: Valid CSAF document
 
@@ -4464,17 +4464,17 @@ The clauses, matching the targets one to one, are listed in separate sub-subsect
 
 Informative Comments:
 
->The order in which targets, and their corresponding clauses appear is somewhat arbitrary as there is no natural order on such diverse roles participating in the document exchanging ecosystem.
+> The order in which targets, and their corresponding clauses appear is somewhat arbitrary as there is no natural order on such diverse roles participating in the document exchanging ecosystem.
 >
->Except for the target **CSAF document**, all other 12 targets span a taxonomy of the complex CSAF ecosystems existing in and between diverse security advisory generating, sharing, and consuming communities.
+> Except for the target **CSAF document**, all other 15 targets span a taxonomy of the complex CSAF ecosystems existing in and between diverse security advisory generating, sharing, and consuming communities.
 >
->In any case, there are no capabilities organized in increasing quality levels for targets because the security advisory sharing communities follow the chain link model.
->Instead, a single minimum capability level for every target is given to maintain important goals of providing a common framework for security advisories:
+> In any case, there are no capabilities organized in increasing quality levels for targets because the security advisory sharing communities follow the chain link model.
+> Instead, a single minimum capability level for every target is given to maintain important goals of providing a common framework for security advisories:
 >
->* Fast production, sharing, and actionable consumption of security advisories
->* Consistent end to end automation through collaborating actors
->* Clear baseline across the communities per this specification
->* Additional per-community cooperative extensions which may flow back into future updates of this specification
+> * Fast production, sharing, and actionable consumption of security advisories
+> * Consistent end to end automation through collaborating actors
+> * Clear baseline across the communities per this specification
+> * Additional per-community cooperative extensions which may flow back into future updates of this specification
 
 ## 8.1 Conformance Targets
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3901,6 +3901,46 @@ Example which fails the test:
 
 > The CSAF document has no TLP label.
 
+### 5.2.11 Missing Canonical URL
+
+It must be tested that the CSAF document has canonical URL.
+
+> To implement this test it is demeeded sufficient that one item in `/document/references` fulfills all of the following:
+>
+> * It has the category `self`.
+> * The `url` starts with `https://`.
+> * The `url` ends with the valid filename for the CSAF document according to the rules in section 3 (cf. section 3.2.1.12.4).
+
+The relevant path for this test is:
+
+```
+  /document/references
+```
+
+Example which fails the test:
+
+```
+  "document": {
+    // ...
+    "references": [
+    {
+      "category": "self",
+      "summary": "A non-canonical URL.",
+      "url": "https://example.com/security/data/csaf/2021/ESA-2021-0001_1.json"
+    },
+    // ...
+    "tracking": {
+      // ...
+      "id": "ESA-2021-0001",
+      // ...
+      "version": "1"
+    },
+    // ...
+  }
+```
+
+> The only element where the `category` is `self` has a URL that does not fulfill the requirement of a valid filename for a CSAF document.
+
 ## 5.3 Informative Test
 
 Informative tests provide insights in common mistakes and bad practices. They MAY fail at a valid CSAF document. It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated. These tests may include information about recommended usage. A program MUST handle a test failure as a information.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2934,7 +2934,7 @@ Example which fails the test:
 
 > The required element `baseSeverity` is missing.
 
-> A tool MAY implement add one or more of the missing properties `version`, `baseScore` and `baseSeverity` based on the values given in `vectorString` as quick fix.
+> A tool MAY add one or more of the missing properties `version`, `baseScore` and `baseSeverity` based on the values given in `vectorString` as quick fix.
 
 ### 4.1.9 Invalid CVSS computation
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3674,6 +3674,48 @@ Example which fails the test:
 
 > The list of involements contains an item which does not contain the property `date`.
 
+### 4.2.8 Use of MD5 as the only Hash Algorithm
+
+It must be tested that the hash algorithm `md5` is not the only one present.
+
+> Since collision attacks exist for MD5 such value should be accompanied by a second cryptographically stronger hash. This will allow users to double check the results.
+
+The relevant paths for this test are:
+
+```
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/hashes[]/file_hashes
+  /product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes
+  /product_tree/relationships[]/full_product_name/product_identification_helper/hashes[]/file_hashes
+```
+
+Example which fails the test:
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A"
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "md5",
+                  "value": "6ae24620ea9656230f49234efd078935"
+                }
+              ],
+              "filename": "product_a.so"
+            }
+          ]
+         }
+      }
+    ]
+  }
+```
+
+> The hash algorithm `md5` is used in one item of hashes without being accompanied by a second hash algorithm.
+
 ## 4.3 Informative Test
 
 Informative tests provide insights in common mistakes and bad practices. They MAY fail at a valid CSAF document. It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated. These tests may include information about recommended usage. A program MUST handle a test failure as a information.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -1478,7 +1478,7 @@ The single valid value for this `enum` is:
 
 #### 3.2.1.5 Document Property - Distribution
 
-Rules for sharing document (`distribution`) of value type `object` with at least 1 of the 2 properties Text (`text`) and Traffic Light Protocol TLP (`tlp`) describes any constraints on how this document might be shared.
+Rules for sharing document (`distribution`) of value type `object` with at least 1 of the 2 properties Text (`text`) and Traffic Light Protocol (TLP) (`tlp`) describes any constraints on how this document might be shared.
 
 ```
     "distribution": {
@@ -1493,6 +1493,8 @@ Rules for sharing document (`distribution`) of value type `object` with at least
       }
     },
 ```
+
+If both values are present, the TLP information SHOULD be preferred as this aids in automation.
 
 ##### 3.2.1.5.1 Document Property - Distribution - Text
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3716,6 +3716,48 @@ Example which fails the test:
 
 > The hash algorithm `md5` is used in one item of hashes without being accompanied by a second hash algorithm.
 
+### 4.2.9 Use of SHA-1 as the only Hash Algorithm
+
+It must be tested that the hash algorithm `sha1` is not the only one present.
+
+> Since collision attacks exist for SHA-1 such value should be accompanied by a second cryptographically stronger hash. This will allow users to double check the results.
+
+The relevant paths for this test are:
+
+```
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/hashes[]/file_hashes
+  /product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes
+  /product_tree/relationships[]/full_product_name/product_identification_helper/hashes[]/file_hashes
+```
+
+Example which fails the test:
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A"
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha1",
+                  "value": "e067035314dd8673fe1c9fc6b01414fe0950fdc4"
+                }
+              ],
+              "filename": "product_a.so"
+            }
+          ]
+         }
+      }
+    ]
+  }
+```
+
+> The hash algorithm `sha1` is used in one item of hashes without being accompanied by a second hash algorithm.
+
 ## 4.3 Informative Test
 
 Informative tests provide insights in common mistakes and bad practices. They MAY fail at a valid CSAF document. It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated. These tests may include information about recommended usage. A program MUST handle a test failure as a information.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2909,7 +2909,7 @@ Example which fails the test:
   ]
 ```
 
-> Two CVSSv3.1 scores are given for `CSAFPID-9080700`.
+> Two CVSS v3.1 scores are given for `CSAFPID-9080700`.
 
 ### 4.1.8 Invalid CVSS
 
@@ -3789,6 +3789,51 @@ Example which fails the test:
 ## 4.3 Informative Test
 
 Informative tests provide insights in common mistakes and bad practices. They MAY fail at a valid CSAF document. It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated. These tests may include information about recommended usage. A program MUST handle a test failure as a information.
+
+### 4.3.1 Use of CVSS v2 as the only Scoring System
+
+For each item in the list of scores which contains the `cvss_v2` object it must be tested that is not the only scoring item present. The test SHALL pass if a second scoring object is available.
+
+The relevant path for this test is:
+
+```
+    /vulnerabilities[]/scores
+```
+
+Example which fails the test:
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          }
+        }
+      ]
+    }
+  ]
+```
+
+> There is only a CVSS v2 score given for `CSAFPID-9080700`.
+
+Recommendation:
+
+It is recommended to (also) use the CVSS v3.1.
 
 # 5 Profiles
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3962,6 +3962,49 @@ Example which fails the test:
 
 > The length of the hash value is only 32 characters long.
 
+### 4.3.6 Use of non-self referencing URLs Failing to Resolve
+
+For each URL which is not in the category `self` it must be tested that it resolves with a HTTP status code less than 400.
+
+> This test does not apply for any item in an array of type `references_t` with the category `self`.
+
+The relevant paths for this test are:
+
+```
+  /document/acknowledgments[]/urls[]
+  /document/aggregate_severity/namespace
+  /document/distribution/tlp/url
+  /document/references[]/url
+  /document/publisher/namespace
+  /product_tree/branches[]/product/product_identification_helper/sbom_urls[]
+  /product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/namespace
+  /product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/uri
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/sbom_urls[]
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/x_generic_uris[]/namespace
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/x_generic_uris[]/uri
+  /product_tree/full_product_names[]/product_identification_helper/sbom_urls[]
+  /product_tree/full_product_names[]/product_identification_helper/x_generic_uris[]/namespace
+  /product_tree/full_product_names[]/product_identification_helper/x_generic_uris[]/uri
+  /product_tree/relationships[]/full_product_name/product_identification_helper/sbom_urls[]
+  /product_tree/relationships[]/full_product_name/product_identification_helper/x_generic_uris[]/namespace
+  /product_tree/relationships[]/full_product_name/product_identification_helper/x_generic_uris[]/uri
+  /vulnerabilities[]/acknowledgments[]/urls[]
+  /vulnerabilities[]/references[]/url
+  /vulnerabilities[]/remediations[]/url
+```
+
+Example which fails the test:
+
+```
+  "references": [
+  {
+    "summary": "A URL that does not resolve with HTTP status code < 400",
+    "url": "http://example.invalid"
+  }
+```
+
+> The `category` is not set and therefore threated as its default value `external`. A request to that URL does not resolve with a status code less than 400.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2967,7 +2967,7 @@ Example which fails the test:
 
 > Neither `baseScore` nor `baseSeverity` has the correct value according to the specification.
 
-> A tool MAY implement setting the correct values as computed according to the specification as quick fix.
+> A tool MAY set the correct values as computed according to the specification as quick fix.
 
 ### 4.1.10 Inconsistent CVSS
 
@@ -3001,7 +3001,7 @@ Example which fails the test:
 
 > The values in CVSS vector differs from values of the properties `attackVector`, `scope` and `availabilityImpact`.
 
-> A tool MAY implement setting the values from the `vectorString` as quick fix.
+> A tool MAY overwrite contradicting values according to the `vectorString` as quick fix.
 
 ### 4.1.11 CWE
 
@@ -3489,7 +3489,7 @@ Example which fails the test:
 
 > `CSAFPID-9080700` was defined but never used.
 
-> A tool MAY implement the removal of the unused definition as quick fix. However, such quick fix SHALL not be applied if the test was skipped.
+> A tool MAY remove of the unused definition as quick fix. However, such quick fix SHALL not be applied if the test was skipped.
 
 ### 4.2.2 Missing Remediation
 
@@ -3871,7 +3871,7 @@ Recommendation:
 
 It is recommended to upgrade to CVSS v3.1.
 
-> A tool MAY implement the recommendation as quick fix. However, it SHALL recompute the `baseScore` and `baseSeverity`.
+> A tool MAY implement the recommendation as quick fix. However, if such quick fix is supported the tool SHALL also recompute the `baseScore` and `baseSeverity`. The same applies for `temporalScore` and `temporalSeverity` respectively `environmentalScore` and `environmentalSeverity` if the necessary fields for computing their value are present and set.
 
 ### 4.3.3 Missing CVE
 
@@ -4007,7 +4007,7 @@ Example which fails the test:
 
 ### 4.3.7 Use of self referencing URLs Failing to Resolve
 
-For each item in an array of type `references_t` with the category `self` it must be tested that the URL referenced resolves with a HTTP status code less than 400. 
+For each item in an array of type `references_t` with the category `self` it must be tested that the URL referenced resolves with a HTTP status code less than 400.
 
 > This test will most likely fail if the CSAF document is in a status before the initial release.
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -4005,6 +4005,32 @@ Example which fails the test:
 
 > The `category` is not set and therefore threated as its default value `external`. A request to that URL does not resolve with a status code less than 400.
 
+### 4.3.7 Use of self referencing URLs Failing to Resolve
+
+For each item in an array of type `references_t` with the category `self` it must be tested that the URL referenced resolves with a HTTP status code less than 400. 
+
+> This test will most likely fail if the CSAF document is in a status before the initial release.
+
+The relevant paths for this test are:
+
+```
+  /document/references[]/url
+  /vulnerabilities[]/references[]/url
+```
+
+Example which fails the test:
+
+```
+  "references": [
+  {
+    "category": "self",
+    "summary": "A URL that does not resolve with HTTP status code < 400",
+    "url": "http://example.invalid"
+  }
+```
+
+> The `category` is `self` and a request to that URL does not resolve with a status code less than 400.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2934,6 +2934,8 @@ Example which fails the test:
 
 > The required element `baseSeverity` is missing.
 
+> A tool MAY implement add one or more of the missing properties `version`, `baseScore` and `baseSeverity` based on the values given in `vectorString` as quick fix.
+
 ### 4.1.9 Invalid CVSS computation
 
 It must be tested that the given CVSS object has the values computed correctly according to the definition.
@@ -2964,6 +2966,8 @@ Example which fails the test:
 ```
 
 > Neither `baseScore` nor `baseSeverity` has the correct value according to the specification.
+
+> A tool MAY implement setting the correct values as computed according to the specification as quick fix.
 
 ### 4.1.10 Inconsistent CVSS
 
@@ -2996,6 +3000,8 @@ Example which fails the test:
 ```
 
 > The values in CVSS vector differs from values of the properties `attackVector`, `scope` and `availabilityImpact`.
+
+> A tool MAY implement setting the values from the `vectorString` as quick fix.
 
 ### 4.1.11 CWE
 
@@ -3482,6 +3488,8 @@ Example which fails the test:
 ```
 
 > `CSAFPID-9080700` was defined but never used.
+
+> A tool MAY implement the removal of the unused definition as quick fix. However, such quick fix SHALL not be applied if the test was skipped.
 
 ### 4.2.2 Missing Remediation
 
@@ -4527,8 +4535,13 @@ A program satisfies the "CSAF basic validator" conformance profile if the progra
 
 * reads documents and performs a check against the JSON schema.
 * performs all mandatory tests as given in section 4.1.
+* does not change the CSAF documents.
 
-A CSAF basic validator may provide an additional function to only run one or more selected mandatory tests.
+A CSAF basic validator may provide one or more additional functions:
+
+* Only run one or more selected mandatory tests.
+* Apply quick fixes as specified in the standard.
+* Apply additional quick fixes as implemented by the vendor.
 
 ### 8.1.15 Conformance Clause 15: CSAF extended validator
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3976,7 +3976,7 @@ Recommendation:
 
 It is recommended to upgrade to CVSS v3.1.
 
-> A tool MAY implement the recommendation as quick fix. However, if such quick fix is supported the tool SHALL also recompute the `baseScore` and `baseSeverity`. The same applies for `temporalScore` and `temporalSeverity` respectively `environmentalScore` and `environmentalSeverity` if the necessary fields for computing their value are present and set.
+> A tool MAY upgrade to CVSS v3.1 as quick fix. However, if such quick fix is supported the tool SHALL also recompute the `baseScore` and `baseSeverity`. The same applies for `temporalScore` and `temporalSeverity` respectively `environmentalScore` and `environmentalSeverity` if the necessary fields for computing their value are present and set.
 
 ### 5.3.3 Missing CVE
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -3922,6 +3922,46 @@ Example which fails the test:
 
 > The CWE number is not given.
 
+### 4.3.5 Use of Short Hash
+
+It must be tested that the length of the hash value is not shorter than 64 characters.
+
+The relevant paths for this test are:
+
+```
+  /product_tree/branches[](/branches[])*/product/product_identification_helper/hashes[]/file_hashes[]/value
+  /product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes[]/value
+  /product_tree/relationships[]/full_product_name/product_identification_helper/hashes[]/file_hashes[]/value
+```
+
+Example which fails the test:
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A"
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "md4",
+                  "value": "3202b50e2e5b2fcd75e284c3d9d5f8d6"
+                }
+              ],
+              "filename": "product_a.so"
+            }
+          ]
+         }
+      }
+    ]
+  }
+```
+
+> The length of the hash value is only 32 characters long.
+
 # 5 Profiles
 
 CSAF documents do not have many required fields as they can be used for different purposes. To ensure a common understanding which fields are required in a use case the standard defines profiles. Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose. The value of `/document/category` is used to identify a CSAF document's profile. Each profile extends the generic profile **Generic CSAF** making additional fields from the standard mandatory. Any other optional field from the standard can also be added to a CSAF document which conforms with a profile without breaking conformance with the profile. One and only exempt is when the profile requires not to have a certain set of fields.


### PR DESCRIPTION
- addresses part of #195
- add more tests
- switch places of Tests and Profiles to avoid forward referencing
- fix section referencing
- rephrase conformance target "CSAF producer" to use definition of "CSAF document"
- rephrase conformance target "CSAF document" to allow data streams