### PR TITLE
Publisher namespace

### DIFF
--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -4527,7 +4527,6 @@ A string should not have a length greater than:
   * `/document/notes[]/audience`
   * `/document/notes[]/title`
   * `/document/publisher/name`
-  * `/document/publisher/vendor_id`
   * `/document/source_lang`
   * `/document/title`
   * `/document/tracking/aliases[]`


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#267
- remove `vendor_id` in appendix C