### PR TITLE
Alternative to JSON Schema 2020-12 #294

### DIFF
--- a/.github/actions/json-test/Dockerfile
+++ b/.github/actions/json-test/Dockerfile
@@ -10,15 +10,16 @@ ARG DEBIAN_FRONTEND="noninteractive"
 # install all necessary software components
 RUN apt-get update -q \
  && apt-get install -y --no-install-recommends -qq \
+    git \
     python3 \
-    python3-jsonschema \
     python3-simplejson \
     python3-jsonpath-rw \
     python3-pip \
     python3-setuptools \
     python3-wheel
 
-RUN pip3 install jsonschema[format] --upgrade
+RUN pip3 install --upgrade pip \
+ && pip3 install git+https://github.com/anexia-it/jsonschema@draft2020-12#egg=jsonschema[format]
 
 COPY entrypoint.sh /
 

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.0/json_schema/csaf_json_schema.json",
   "title": "Common Security Advisory Framework",
   "description": "Representation of security advisory information as a JSON document.",
   "type": "object",
-  "definitions": {
+  "$defs": {
     "acknowledgments_t": {
       "title": "List of acknowledgments",
       "description": "Contains a list of acknowledgment elements.",
@@ -84,7 +84,7 @@
         ],
         "properties": {
           "branches": {
-            "$ref": "#/definitions/branches_t"
+            "$ref": "#/$defs/branches_t"
           },
           "category": {
             "title": "Category of the branch",
@@ -121,7 +121,7 @@
             ]
           },
           "product": {
-            "$ref": "#/definitions/full_product_name_t"
+            "$ref": "#/$defs/full_product_name_t"
           }
         }
       }
@@ -146,14 +146,14 @@
           ]
         },
         "product_id": {
-          "$ref": "#/definitions/product_id_t"
+          "$ref": "#/$defs/product_id_t"
         },
         "product_identification_helper": {
           "title": "Helper to identify the product",
           "description": "Provides at least one method which aids in identifying the product in an asset database.",
           "type": "object",
           "minProperties": 1,
-          "properties": { 
+          "properties": {
             "cpe": {
               "$comment": "TODO: This should have a full regular expression to enforce CPE syntax.",
               "title": "Common Platform Enumeration representation",
@@ -404,7 +404,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "$ref": "#/definitions/product_group_id_t"
+        "$ref": "#/$defs/product_group_id_t"
       }
     },
     "product_id_t": {
@@ -424,7 +424,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "$ref": "#/definitions/product_id_t"
+        "$ref": "#/$defs/product_id_t"
       }
     },
     "references_t": {
@@ -497,7 +497,7 @@
       ],
       "properties": {
         "acknowledgments": {
-          "$ref": "#/definitions/acknowledgments_t"
+          "$ref": "#/$defs/acknowledgments_t"
         },
         "aggregate_severity": {
           "title": "Aggregate severity",
@@ -600,12 +600,12 @@
         "lang": {
           "title": "Document language",
           "description": "Identifies the language used by this document, corresponding to IETF BCP 47 / RFC 5646.",
-          "$ref": "#/definitions/lang_t"
+          "$ref": "#/$defs/lang_t"
         },
         "notes": {
           "title": "Notes associated with the whole document.",
           "description": "Holds notes about this set of vulnerabilities.",
-          "$ref": "#/definitions/notes_t"
+          "$ref": "#/$defs/notes_t"
         },
         "publisher": {
           "title": "Publisher",
@@ -669,12 +669,12 @@
           }
         },
         "references": {
-          "$ref": "#/definitions/references_t"
+          "$ref": "#/$defs/references_t"
         },
         "source_lang": {
           "title": "Source language",
           "description": "If this copy of the document is a translation then the value of this property describes from which language this document was translated.",
-          "$ref": "#/definitions/lang_t"
+          "$ref": "#/$defs/lang_t"
         },
         "title": {
           "title": "Title of this document",
@@ -808,7 +808,7 @@
                     "format": "date-time"
                   },
                   "number": {
-                    "$ref": "#/definitions/version_t"
+                    "$ref": "#/$defs/version_t"
                   },
                   "summary": {
                     "title": "Summary of the revision",
@@ -833,7 +833,7 @@
               ]
             },
             "version": {
-              "$ref": "#/definitions/version_t"
+              "$ref": "#/$defs/version_t"
             }
           }
         }
@@ -846,7 +846,7 @@
       "minProperties": 1,
       "properties": {
         "branches": {
-          "$ref": "#/definitions/branches_t"
+          "$ref": "#/$defs/branches_t"
         },
         "full_product_names": {
           "title": "List of full product names",
@@ -854,7 +854,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/definitions/full_product_name_t"
+            "$ref": "#/$defs/full_product_name_t"
           }
         },
         "product_groups": {
@@ -872,7 +872,7 @@
             ],
             "properties": {
               "group_id": {
-                "$ref": "#/definitions/product_group_id_t"
+                "$ref": "#/$defs/product_group_id_t"
               },
               "product_ids": {
                 "title": "List of Product IDs",
@@ -881,7 +881,7 @@
                 "minItems": 2,
                 "uniqueItems": true,
                 "items": {
-                  "$ref": "#/definitions/product_id_t"
+                  "$ref": "#/$defs/product_id_t"
                 }
               },
               "summary": {
@@ -926,13 +926,13 @@
                 ]
               },
               "full_product_name": {
-                "$ref": "#/definitions/full_product_name_t"
+                "$ref": "#/$defs/full_product_name_t"
               },
               "product_reference": {
-                "$ref": "#/definitions/product_id_t"
+                "$ref": "#/$defs/product_id_t"
               },
               "relates_to_product_reference": {
-                "$ref": "#/definitions/product_id_t"
+                "$ref": "#/$defs/product_id_t"
               }
             }
           }
@@ -951,7 +951,7 @@
         "minProperties": 1,
         "properties": {
           "acknowledgments": {
-            "$ref": "#/definitions/acknowledgments_t"
+            "$ref": "#/$defs/acknowledgments_t"
           },
           "cve": {
             "title": "CVE",
@@ -1085,7 +1085,7 @@
             }
           },
           "notes": {
-            "$ref": "#/definitions/notes_t"
+            "$ref": "#/$defs/notes_t"
           },
           "product_status": {
             "title": "Product status",
@@ -1096,47 +1096,47 @@
               "first_affected": {
                 "title": "First affected",
                 "description": "These are the first versions of the releases known to be affected by the vulnerability.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "first_fixed": {
                 "title": "First fixed",
                 "description": "These versions contain the first fix for the vulnerability but may not be the recommended fixed versions.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "fixed": {
                 "title": "Fixed",
                 "description": "These versions contain a fix for the vulnerability but may not be the recommended fixed versions.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "known_affected": {
                 "title": "Known affected",
                 "description": "These versions are known to be affected by the vulnerability.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "known_not_affected": {
                 "title": "Known not affected",
                 "description": "These versions are known not to be affected by the vulnerability.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "last_affected": {
                 "title": "Last affected",
                 "description": "These are the last versions in a release train known to be affected by the vulnerability. Subsequently released versions would contain a fix for the vulnerability.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "recommended": {
                 "title": "Recommended",
                 "description": "These versions have a fix for the vulnerability and are the vendor-recommended versions for fixing the vulnerability.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               },
               "under_investigation": {
                 "title": "Under investigation",
                 "description": "It is not known yet whether these versions are or are not affected by the vulnerability. However, it is still under investigation - the result will be provided in a later release of the document.",
-                "$ref": "#/definitions/products_t"
+                "$ref": "#/$defs/products_t"
               }
             }
           },
           "references": {
-            "$ref": "#/definitions/references_t"
+            "$ref": "#/$defs/references_t"
           },
           "release_date": {
             "title": "Release date",
@@ -1195,10 +1195,10 @@
                   }
                 },
                 "group_ids": {
-                  "$ref": "#/definitions/product_groups_t"
+                  "$ref": "#/$defs/product_groups_t"
                 },
                 "product_ids": {
-                  "$ref": "#/definitions/products_t"
+                  "$ref": "#/$defs/products_t"
                 },
                 "restart_required": {
                   "title": "Restart required by remediation",
@@ -1269,7 +1269,7 @@
                   ]
                 },
                 "products": {
-                  "$ref": "#/definitions/products_t"
+                  "$ref": "#/$defs/products_t"
                 }
               }
             }
@@ -1311,10 +1311,10 @@
                   "minLength": 1
                 },
                 "group_ids": {
-                  "$ref": "#/definitions/product_groups_t"
+                  "$ref": "#/$defs/product_groups_t"
                 },
                 "product_ids": {
-                  "$ref": "#/definitions/products_t"
+                  "$ref": "#/$defs/products_t"
                 }
               }
             }

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -451,10 +451,10 @@ Delegation to industry best practices technologies is used in referencing schema
 
 The CSAF schema describes how to represent security advisory information as a JSON document.
 
-The CSAF schema Version 2.0 builds on the JSON Schema draft 2019-09 rules.
+The CSAF schema Version 2.0 builds on the JSON Schema draft 2020-12 rules.
 
 ```
-    "$schema": "https://json-schema.org/draft/2019-09/schema"
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
 ```
 
 The schema identifier is (before publication):
@@ -2730,7 +2730,7 @@ Mandatory tests MUST NOT fail at a valid CSAF document. A program MUST handle a 
 
 ### 6.1.1 Missing Definition of Product ID
 
-For each element of type `/definitions/product_id_t` which is not inside a Full Product Name (type: `full_product_name_t`) and therefore reference an element within the `product_tree` it must be tested that the Full Product Name element with the matching `product_id` exists. The same applies for all items of elements of type `/definitions/products_t`.
+For each element of type `/$defs/product_id_t` which is not inside a Full Product Name (type: `full_product_name_t`) and therefore reference an element within the `product_tree` it must be tested that the Full Product Name element with the matching `product_id` exists. The same applies for all items of elements of type `/$defs/products_t`.
 
 The relevant paths for this test are:
 
@@ -2771,7 +2771,7 @@ Example which fails the test:
 
 ### 6.1.2 Multiple Definition of Product ID
 
-For each Product ID (type `/definitions/product_id_t`) in Full Product Name elements (type: `/definitions/full_product_name_t`) it must be tested that the `product_id` was not already defined within the same document.
+For each Product ID (type `/$defs/product_id_t`) in Full Product Name elements (type: `/$defs/full_product_name_t`) it must be tested that the `product_id` was not already defined within the same document.
 
 The relevant paths for this test are:
 
@@ -2802,7 +2802,7 @@ Example which fails the test:
 
 ### 6.1.3 Circular Definition of Product ID
 
-For each new defined Product ID (type `/definitions/product_id_t`) in items of relationships (`/product_tree/relationships`) it must be tested that the `product_id` does not end up in a cirle.
+For each new defined Product ID (type `/$defs/product_id_t`) in items of relationships (`/product_tree/relationships`) it must be tested that the `product_id` does not end up in a cirle.
 
 The relevant path for this test is:
 
@@ -2840,7 +2840,7 @@ Example which fails the test:
 
 ### 6.1.4 Missing Definition of Product Group ID
 
-For each element of type `/definitions/product_group_id_t` which is not inside a Product Group (`/product_tree/product_groups[]`) and therefore reference an element within the `product_tree` it must be tested that the Product Group element with the matching `group_id` exists. The same applies for all items of elements of type `/definitions/product_groups_t`.
+For each element of type `/$defs/product_group_id_t` which is not inside a Product Group (`/product_tree/product_groups[]`) and therefore reference an element within the `product_tree` it must be tested that the Product Group element with the matching `group_id` exists. The same applies for all items of elements of type `/$defs/product_groups_t`.
 
 The relevant paths for this test are:
 
@@ -2879,7 +2879,7 @@ Example which fails the test:
 
 ### 6.1.5 Multiple Definition of Product Group ID
 
-For each Product Group ID (type `/definitions/product_group_id_t`) Product Group elements (`/product_tree/product_groups[]`) it must be tested that the `group_id` was not already defined within the same document.
+For each Product Group ID (type `/$defs/product_group_id_t`) Product Group elements (`/product_tree/product_groups[]`) it must be tested that the `group_id` was not already defined within the same document.
 
 The relevant path for this test is:
 
@@ -3156,7 +3156,7 @@ Example which fails the test:
 
 ### 6.1.12 Language
 
-For each element of type `/definitions/language_t` it must be tested that the language code is valid and exists.
+For each element of type `/$defs/language_t` it must be tested that the language code is valid and exists.
 
 The relevant paths for this test are:
 
@@ -3983,7 +3983,7 @@ Optional tests SHOULD NOT fail at a valid CSAF document without a good reason. F
 
 ### 6.2.1 Unused Definition of Product ID
 
-For each Product ID (type `/definitions/product_id_t`) in Full Product Name elements (type: `/definitions/full_product_name_t`) it must be tested that the `product_id` is referenced somewhere within the same document.
+For each Product ID (type `/$defs/product_id_t`) in Full Product Name elements (type: `/$defs/full_product_name_t`) it must be tested that the `product_id` is referenced somewhere within the same document.
 
 This test SHALL be skipped for CSAF documents conforming the profile "Informational Advisory".
 
@@ -4014,7 +4014,7 @@ Example which fails the test:
 
 ### 6.2.2 Missing Remediation
 
-For each Product ID (type `/definitions/product_id_t`) in the Product Status groups Affected and Under investigation it must be tested that a remediation exists.
+For each Product ID (type `/$defs/product_id_t`) in the Product Status groups Affected and Under investigation it must be tested that a remediation exists.
 
 > The remediation might be of the category `none_available` or `no_fixed_planned`.
 
@@ -4053,7 +4053,7 @@ Example which fails the test:
 
 ### 6.2.3 Missing Score
 
-For each Product ID (type `/definitions/product_id_t`) in the Product Status groups Affected it must be tested that a score object exists which covers this product.
+For each Product ID (type `/$defs/product_id_t`) in the Product Status groups Affected it must be tested that a score object exists which covers this product.
 
 The relevant paths for this test are:
 
@@ -5045,7 +5045,7 @@ Firstly, the program:
 
 Secondly, the program fulfills the following for all items of:
 
-* type `/definitions/version_t`: If any element doesn't match the semantic versioning, replace the all elements of type `/definitions/version_t` with the corresponding integer version. For that, CVRF CSAF converter sorts the items of `/document/tracking/revision_history` by `number` ascending according to the rules of CVRF. Then, it replaces the value of `number` with the index number in the array (starting with 1). The value of `/document/tracking/version` is replaced by value of `number` of the corresponding revision item. The match must be calculated by the original values used in the CVRF document.
+* type `/$defs/version_t`: If any element doesn't match the semantic versioning, replace the all elements of type `/$defs/version_t` with the corresponding integer version. For that, CVRF CSAF converter sorts the items of `/document/tracking/revision_history` by `number` ascending according to the rules of CVRF. Then, it replaces the value of `number` with the index number in the array (starting with 1). The value of `/document/tracking/version` is replaced by value of `number` of the corresponding revision item. The match must be calculated by the original values used in the CVRF document.
 * `/document/acknowledgments[]/organization` and `/vulnerabilities[]/acknowledgments[]/organization`: If more than one cvrf:Organization instance is given, the CVRF CSAF converter converts the first one into the `organization`. In addition the converter outputs a warning that information might be lost during conversion of document or vulnerability acknowledgment.
 * `/document/publisher/name` and `/document/publisher/namespace`: Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with. If values from both sources are present, the program should prefer the latter one. The program SHALL NOT use hard-coded values.
 * `/vulnerabilities[]/scores[]`: If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in the arrays `known_affected`, `first_affected` and `last_affected`.

--- a/csaf_2.0/test/validator.py
+++ b/csaf_2.0/test/validator.py
@@ -19,4 +19,4 @@ with open(json_input, 'r') as f:
     input_obj = json.loads(input_data)
 
 
-jsonschema.validate(input_obj, schema, format_checker=jsonschema.draft7_format_checker)
+jsonschema.validate(input_obj, schema, format_checker=jsonschema.draft202012_format_checker)


### PR DESCRIPTION
Technically I did not find a way to push to the existing JSON Schema 2020-12 #294 PR and thus created a branch on this repo with the changes from @tschmidtb51 `json-2020-12` branch and applied two minimally invasive fixes:

1. provide `git` to the Debian image
2. added the proposed install steps for the intermediate validator - thanks to @nezhar (Harald Nezbeda)

I propose to merge this PR instead of #294 - closes #92 