### PR TITLE
Title page nits remediations subsections

### DIFF
--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -6,7 +6,7 @@
 
 ## Committee Specification Draft 01 /<br>Public Review Draft 01
 
-## 24 July 2021
+## 25 July 2021
 
 #### Technical Committee:
 [OASIS Common Security Advisory Framework (CSAF) TC](https://www.oasis-open.org/committees/csaf/)
@@ -24,19 +24,21 @@ In Memory of Eric Johnson, TIBCO Software inc., an active member of the OASIS CS
 #### Additional artifacts:
 This prose specification is one component of a Work Product that also includes:
 
-* JSON schema: csaf.json
-* Other parts (list titles and/or file names)
-* `(Note: Any normative computer language definitions that are part of the Work Product, such as XML instances, schemas and Java(TM) code, including fragments of such, must be (a) well formed and valid, (b) provided in separate plain text files, (c) referenced from the Work Product; and (d) where any definition in these separate files disagrees with the definition found in the specification, the definition in the separate file prevails. Remove this note before submitting for publication.)`
+* Aggregator JSON schema: [aggregator_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/csd01/aggregator_json_schema.json)
+* CSAF JSON schema: [csaf_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/csd01/csaf_json_schema.json)
+* Provider JSON schema: [provider_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/csd01/provider_json_schema.json)
 
 #### Related work:
 This specification replaces or supersedes:
 
-* The CSAF Common Vulnerability Reporting Framework (CVRF) Version 1.2. http://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/csprd01/csaf-cvrf-v1.2-csprd01.html
+* The CSAF Common Vulnerability Reporting Framework (CVRF) Version 1.2. https://docs.oasis-open.org/csaf/csaf-cvrf/v1.2/csprd01/csaf-cvrf-v1.2-csprd01.html
 
-This specification is related to:
+#### Declared JSON namespaces:
 
-* Related specifications (include hyperlink, preferably to HTML format) \
-`(remove "Related work" section or the "replaces" or "related" subsections if no entries)`
+* [https://docs.oasis-open.org/csaf/csaf/v2.0/aggregator_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/aggregator_json_schema.json)
+* [https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf_json_schema.json)
+* [https://docs.oasis-open.org/csaf/csaf/v2.0/provider_json_schema.json](https://docs.oasis-open.org/csaf/csaf/v2.0/provider_json_schema.json)
+
 
 #### Abstract:
 The Common Security Advisory Framework (CSAF) Version 2.0 is the definitive reference for the language which supports creation, update, and interoperable exchange of security advisories as structured information on products, vulnerabilities and the status of impact and remediation among interested parties.
@@ -52,10 +54,10 @@ Note that any machine-readable content ([Computer Language Definitions](https://
 
 #### URI patterns:
 Initial publication URI:  
-https://docs.oasis-open.org/tc-name/wp-abbrev-xxxxx/v1.0/csd01/wp-abbrev-xxxxx-v1.0-csd01.html
+https://docs.oasis-open.org/tc-name/wp-abbrev-xxxxx/v2.0/csd01/wp-abbrev-xxxxx-v2.0-csd01.html
 
 Permanent "Latest version" URI:  
-https://docs.oasis-open.org/tc-name/wp-abbrev-xxxxx/v1.0/wp-abbrev-xxxxx-v1.0.html
+https://docs.oasis-open.org/tc-name/wp-abbrev-xxxxx/v2.0/wp-abbrev-xxxxx-v2.0.html
 
 (Note: Publication URIs are managed by OASIS TC Administration; please don't modify.)
 
@@ -64,7 +66,7 @@ When referencing this specification the following citation format should be used
 
 **[csaf-v2.0]**
 
-_Common Security Advisory Framework Version 2.0_. Edited by Langley Rock and Stefan Hagen. 00 Month 2021. OASIS Committee Specification Draft 01 / Public Review Draft 01. this-version.html. Latest version: latest-version.html.
+_Common Security Advisory Framework Version 2.0_. Edited by Langley Rock, Stefan Hagen, and Thomas Schmidt. 25 July 2021. OASIS Committee Specification Draft 01 / Public Review Draft 01. this-version.html. Latest version: latest-version.html.
 
 
 -------
@@ -2470,6 +2472,8 @@ In addition, any Remediation may expose the six optional properties Date (`date`
       }
 ```
 
+##### 3.2.3.11.1 Vulnerabilities Property - Remediations - Category
+
 Category of the remediation (`category`) of value type `string` and `enum` specifies the category which this remediation belongs to.
 Valid values are:
 
@@ -2491,9 +2495,15 @@ The value `none_available` indicates that there is currently no fix available. T
 
 The value `no_fix_planned` indicates that there is no fix for the vulnerability and it is not planned to provide one at any time. This is often the case when a product has been orphaned, declared end-of-life, or otherwise deprecated. The description should contain details about why there will be no fix issued.
 
+##### 3.2.3.11.2 Vulnerabilities Property - Remediations - Date
+
 Date of the remediation (`date`) of value type `string` with format `date-time` contains the date from which the remediation is available.
 
+##### 3.2.3.11.3 Vulnerabilities Property - Remediations - Details
+
 Details of the remediation (`details`) of value type `string` with 1 or more characters contains a thorough human-readable discussion of the remediation.
+
+##### 3.2.3.11.4 Vulnerabilities Property - Remediations - Entitlements
 
 List of entitlements (`entitlements`) of value type `array` with 1 or more items of type Entitlement of the remediation as `string` with 1 or more characters contains a list of entitlements.
 
@@ -2508,9 +2518,15 @@ List of entitlements (`entitlements`) of value type `array` with 1 or more items
 
 Every Entitlement of the remediation contains any possible vendor-defined constraints for obtaining fixed software or hardware that fully resolves the vulnerability.
 
+##### 3.2.3.11.5 Vulnerabilities Property - Remediations - Group IDs
+
 Group IDs (`group_ids`) are of value type Product Groups (`product_groups_t`).
 
+##### 3.2.3.11.6 Vulnerabilities Property - Remediations - Product IDs
+
 Product IDs (`product_ids`) are of value type Products (`products_t`).
+
+##### 3.2.3.11.7 Vulnerabilities Property - Remediations - Restart Required
 
 Restart required by remediation (`restart_required`) of value type `object` with the 1 mandatory property Category (`category`) and the optional property Details (`details`) provides information on category of restart is required by this remediation to become effective.
 
@@ -2556,6 +2572,8 @@ The values must be used as follows:
 * `system`: The whole system which the machine resides on which the vulnerable component is installed needs to be restarted. This may include multiple security zones. This could be the case for a major system upgrade in an ICS system or a protocol change.
 
 Additional restart information (`details`) of value type `string` with 1 or more characters provides additional information for the restart. This can include details on procedures, scope or impact.
+
+##### 3.2.3.11.8 Vulnerabilities Property - Remediations - URL
 
 URL (`url`) of value type `string` with format `uri` contains the URL where to obtain the remediation.
 
@@ -5680,7 +5698,7 @@ Zach | Turk | Microsoft
 
 | Revision | Date | Editor | Changes Made |
 | :--- | :--- | :--- | :--- |
-| csaf-v2.0-wd20210724-dev | 2021-07-24 | Stefan Hagen and Thomas Schmidt| Preparing next Editor revision for TC review and submittal as CSD for public review|
+| csaf-v2.0-wd20210725-dev | 2021-07-25 | Stefan Hagen and Thomas Schmidt| Preparing next Editor revision for TC review and submittal as CSD for public review|
 
 # Appendix C. Guidance on the Size of CSAF Documents
 


### PR DESCRIPTION
This change set is considered of editorial scope only.

Completed title page (closes #328) and added remediation subsections (optimizing #306).

To achieve the former, I :

* Added artifacts to relevant section and removed boilerplate
* Added namespaces to relevant (made-up) section to support TC admins finding the best ways to express this - we are not XML anymore
* Bumped the date
* Completed the list of editors in the preferred citation text
* Added the magic `s` to the good ole `http` URL of the related work (the CVRF v1.2 spec) 
* Replaced the `v1.0` indicators in the this and latest spec pottier sections to ensure the publication chain notices we do publish `v2.0` (with a different name than `v1.2`)

The latter is completing the removal of the requirement/conformance statement marker from the typographical conventions section in #306 as section `3.2.3.11 Vulnerabilities Property - Remediations` has specific normative statements across quite some properties. The sub sectioning per property allows for unanimous references.

@santosomar, @tschmidtb51 - I suggest we merge this PR soon, so we have this as CSD candidate for the members to read "in one piece" on the default branch.