### PR TITLE
Fix GH Actions

### DIFF
--- a/.github/actions/json-test/Dockerfile
+++ b/.github/actions/json-test/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update -q \
     python3-setuptools \
     python3-wheel
 
-RUN pip3 install --upgrade pip \
- && pip3 install jsonschema[format]
+RUN pip3 install jsonschema[format]
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
- resolves failing GH Actions
- update docker file to use release jsonschema instead of GitHub repo

CC @tlimmer seem to be fixed