### PR TITLE
Public openpgp key

### DIFF
--- a/csaf_2.0/examples/provider-metadata/example-01-provider-metadata.json
+++ b/csaf_2.0/examples/provider-metadata/example-01-provider-metadata.json
@@ -17,7 +17,7 @@
   "list_on_CSAF_aggregators": true,
   "metadata_version": "2.0",
   "mirror_on_CSAF_aggregators": true,
-  "pgp_keys": [
+  "public_openpgp_keys": [
     {
       "fingerprint": "8F5F267907B2C4559DB360DB2294BA7D2B2298B1",
       "url": "https://keys.example.net/vks/v1/by-fingerprint/8F5F267907B2C4559DB360DB2294BA7D2B2298B1"

--- a/csaf_2.0/json_schema/provider_json_schema.json
+++ b/csaf_2.0/json_schema/provider_json_schema.json
@@ -164,13 +164,13 @@
       "type": "boolean",
       "default": true
     },
-    "pgp_keys": {
-      "title": "List of PGP keys",
-      "description": "Contains a list of pgp keys used to sign CSAF documents.",
+    "public_openpgp_keys": {
+      "title": "List of public OpenPGP keys",
+      "description": "Contains a list of OpenPGP keys used to sign CSAF documents.",
       "type": "array",
       "items": {
         "title": "PGP keys",
-        "description": "Contains all information about a pgp keys used to sign CSAF documents.",
+        "description": "Contains all information about an OpenPGP key used to sign CSAF documents.",
         "type": "object",
         "required": [
           "url"
@@ -178,7 +178,7 @@
         "properties": {
           "fingerprint": {
             "title": "Fingerprint of the key",
-            "description": "Contains the fingerprint of the pgp key.",
+            "description": "Contains the fingerprint of the OpenPGP key.",
             "type": "string",
             "minLength": 40,
             "pattern": "^[0-9a-fA-F]{40,}$"

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -5145,6 +5145,8 @@ File name of signature file: example_company_-_2019-yh3234.json.asc
 
 The public part of the PGP key used to sign the CSAF documents MUST be available. It SHOULD also be available at a public key server.  
 
+> For example, the public part of the OpenPGP key could be placed in a directory `openpgp` adjacent to the `provider-metadata.json`.
+
 ### 7.1.21 Requirement 21: List of CSAF providers
 
 The file `aggregator.json` MUST be present and valid according to the JSON schema [CSAF aggregator](https://docs.oasis-open.org/csaf/csaf/v2.0/aggregator_json_schema.json). It MUST not be stored adjacent to a `provider-metadata.json`.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -4903,7 +4903,7 @@ The party MUST provide a valid `provider-metadata.json` according to the schema 
     "list_on_CSAF_aggregators": true,
     "metadata_version": "2.0",
     "mirror_on_CSAF_aggregators": true,
-    "pgp_keys": [
+    "public_openpgp_keys": [
       {
         "fingerprint": "8F5F267907B2C4559DB360DB2294BA7D2B2298B1",
         "url": "https://keys.example.net/vks/v1/by-fingerprint/8F5F267907B2C4559DB360DB2294BA7D2B2298B1"


### PR DESCRIPTION
- fix #397 
- rename `pgp_keys` with `public_openpgp_keys`
- adopt titles and descriptions
- adopt example
- suggest a location for OpenPGP keys