### PR TITLE
Support for multiple ids in vulnerabilities

### DIFF
--- a/csaf_2.0/examples/csaf/CVE-2018-0171-modified.json
+++ b/csaf_2.0/examples/csaf/CVE-2018-0171-modified.json
@@ -2483,10 +2483,12 @@
   "vulnerabilities": [
     {
       "title": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability",
-      "id": {
-        "system_name": "Cisco Bug ID",
-        "text": "CSCvg76186"
-      },
+      "ids": [
+        {
+          "system_name": "Cisco Bug ID",
+          "text": "CSCvg76186"
+        }
+      ],
       "notes": [
         {
           "title": "Summary",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -1010,6 +1010,7 @@
             "description": "Gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).",
             "type": "array",
             "minItems": 1,
+            "uniqueItems": true,
             "items": {
               "title": "ID",
               "description": "Contains a single unique label or tracking ID for the vulnerability.",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -1007,7 +1007,7 @@
           },
           "ids": {
             "title": "List of IDs",
-            "description": "Gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).",
+            "description": "Represents a list of unique labels or tracking IDs for the vulnerability (if such information exists).",
             "type": "array",
             "minItems": 1,
             "uniqueItems": true,

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -1005,34 +1005,40 @@
             "type": "string",
             "format": "date-time"
           },
-          "id": {
-            "title": "ID",
-            "description": "Gives the document producer a place to publish a unique label or tracking ID for the vulnerability (if such information exists).",
-            "type": "object",
-            "required": [
-              "system_name",
-              "text"
-            ],
-            "properties": {
-              "system_name": {
-                "title": "System name",
-                "description": "Indicates the name of the vulnerability tracking or numbering system.",
-                "type": "string",
-                "minLength": 1,
-                "examples": [
-                  "Cisco Bug ID",
-                  "GitHub Issue"
-                ]
-              },
-              "text": {
-                "title": "Text",
-                "description": "Is unique label or tracking ID for the vulnerability (if such information exists).",
-                "type": "string",
-                "minLength": 1,
-                "examples": [
-                  "CSCso66472",
-                  "oasis-tcs/csaf#210"
-                ]
+          "ids": {
+            "title": "List of IDs",
+            "description": "Gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "title": "ID",
+              "description": "Contains a single unique label or tracking ID for the vulnerability.",
+              "type": "object",
+              "required": [
+                "system_name",
+                "text"
+              ],
+              "properties": {
+                "system_name": {
+                  "title": "System name",
+                  "description": "Indicates the name of the vulnerability tracking or numbering system.",
+                  "type": "string",
+                  "minLength": 1,
+                  "examples": [
+                    "Cisco Bug ID",
+                    "GitHub Issue"
+                  ]
+                },
+                "text": {
+                  "title": "Text",
+                  "description": "Is unique label or tracking ID for the vulnerability (if such information exists).",
+                  "type": "string",
+                  "minLength": 1,
+                  "examples": [
+                    "CSCso66472",
+                    "oasis-tcs/csaf#210"
+                  ]
+                }
               }
             }
           },

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -5859,8 +5859,7 @@ An array should not have more than:
   * `/vulnerabilities[]/acknowledgments`
   * `/vulnerabilities[]/acknowledgments[]/names`
   * `/vulnerabilities[]/acknowledgments[]/urls`
-  * `/vulnerabilities[]/id/system_name`
-  * `/vulnerabilities[]/id/text`
+  * `/vulnerabilities[]/ids`
   * `/vulnerabilities[]/remediations[]/entitlements`
 
 * 40 000 items for
@@ -5968,6 +5967,8 @@ A string should not have a length greater than:
   * `/vulnerabilities[]/cve`
   * `/vulnerabilities[]/cwe/id`
   * `/vulnerabilities[]/cwe/name`
+  * `/vulnerabilities[]/ids[]/system_name`
+  * `/vulnerabilities[]/ids[]/text`
   * `/vulnerabilities[]/notes[]/audience`
   * `/vulnerabilities[]/notes[]/title`
   * `/vulnerabilities[]/product_status/first_affected[]`

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2226,7 +2226,7 @@ Discovery date (`discovery_date`) of value type `string` with format `date-time`
 
 #### 3.2.3.5 Vulnerabilities Property - IDs
 
-List of IDs (`ids`) of value type `array` with one or more ID items of type `object` gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).
+List of IDs (`ids`) of value type `array` with one or more unique ID items of type `object` gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).
 
 ```
     "ids": {

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2224,13 +2224,22 @@ The Weakness name (`name`) has value type `string` with 1 or more characters and
 
 Discovery date (`discovery_date`) of value type `string` with format `date-time` holds the date and time the vulnerability was originally discovered.
 
-#### 3.2.3.5 Vulnerabilities Property - ID
+#### 3.2.3.5 Vulnerabilities Property - IDs
 
-ID (`id`) of value type `object` with the two mandatory properties System Name (`system_name`) and Text (`text`) gives the document producer a place to publish a unique label or tracking ID for the vulnerability (if such information exists).
+List of IDs (`ids`) of value type `array` with one or more ID items of type `object` gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).
 
 ```
-    "id": {
+    "ids": {
       // ...
+      "items": {
+        // ...
+      }
+    },
+```
+
+Every ID item of value type `object` with the two mandatory properties System Name (`system_name`) and Text (`text`) contains a single unique label or tracking ID for the vulnerability.
+
+```
       "properties": {
         "system_name": {
           // ...
@@ -2239,7 +2248,6 @@ ID (`id`) of value type `object` with the two mandatory properties System Name (
           // ...
         }
       }
-    },
 ```
 
 System name (`system_name`) of value type `string` with 1 or more characters indicates the name of the vulnerability tracking or numbering system.

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -5441,6 +5441,7 @@ Secondly, the program fulfills the following for all items of:
 * `/document/publisher/name` and `/document/publisher/namespace`: Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with. If values from both sources are present, the program should prefer the latter one. The program SHALL NOT use hard-coded values.
 * `/product_tree/relationships[]`: If more than one `prod:FullProductName` instance is given, the CVRF CSAF converter converts the first one into the `full_product_name`. In addition, the converter outputs a warning that information might be lost during conversion of product relationships.
 * `/vulnerabilities[]/cwe`: If more than one `vuln:CWE` instance is given, the CVRF CSAF converter converts the first one into `cwe`. In addition, the converter outputs a warning that information might be lost during conversion of the CWE.
+* `/vulnerabilities[]/ids`: If a `vuln:ID` element is given, the CVRF CSAF converter converts it into the first item of the `ids` array.
 * `/vulnerabilities[]/scores[]`: If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in the arrays `known_affected`, `first_affected` and `last_affected`.
 * `/vulnerabilities[]/scores[]`: If there are CVSS v3.0 and CVSS v3.1 Vectors available for the same product, the CVRF CSAF converter discards the CVSS v3.0 information and provide in CSAF only the CVSS v3.1 information.
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -2226,7 +2226,7 @@ Discovery date (`discovery_date`) of value type `string` with format `date-time`
 
 #### 3.2.3.5 Vulnerabilities Property - IDs
 
-List of IDs (`ids`) of value type `array` with one or more unique ID items of type `object` gives the document producer a place to publish unique labels or tracking IDs for the vulnerability (if such information exists).
+List of IDs (`ids`) of value type `array` with one or more unique ID items of type `object` represents a list of unique labels or tracking IDs for the vulnerability (if such information exists).
 
 ```
     "ids": {
@@ -2787,7 +2787,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
     * `/vulnerabilities[]/product_status/under_investigation`
   * at least one of
     * `/vulnerabilities[]/cve`
-    * `/vulnerabilities[]/id`
+    * `/vulnerabilities[]/ids`
   * `/vulnerabilities[]/notes`
     > Provides details about the vulnerability.
 * For each item in
@@ -3938,7 +3938,7 @@ The relevant paths for this test are:
 
 #### 6.1.27.8 Vulnerability ID
 
-For each item in `/vulnerabilities` it must be tested that at least one of the elements `cve` or `id` is present.
+For each item in `/vulnerabilities` it must be tested that at least one of the elements `cve` or `ids` is present.
 
 The relevant value for `/document/category` is:
 
@@ -3950,7 +3950,7 @@ The relevant paths for this test are:
 
 ```
   /vulnerabilities[]/cve
-  /vulnerabilities[]/id
+  /vulnerabilities[]/ids
 ```
 
 *Example 74 which fails the test:*
@@ -3963,7 +3963,7 @@ The relevant paths for this test are:
   ]
 ```
 
-> None of the elements `cve` or `id` is present.
+> None of the elements `cve` or `ids` is present.
 
 #### 6.1.27.9 Impact Statement
 

--- a/notes/whats-new-csaf-v2.0-cn01.md
+++ b/notes/whats-new-csaf-v2.0-cn01.md
@@ -372,6 +372,7 @@ This informative appendix provides a mapping by path between the elements in CSA
 * `/document/tracking/revision_history[]/number`: See conversion rule in [section 9.1.5 of CSAF specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#915-conformance-clause-5-cvrf-csaf-converter).
 * `/document/tracking/version`: See conversion rule in [section 9.1.5 of CSAF specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#915-conformance-clause-5-cvrf-csaf-converter).
 * `/product_tree/relationships[]/full_product_name`: See conversion rule in [section 9.1.5 of CSAF specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#915-conformance-clause-5-cvrf-csaf-converter).
+* `/vulnerabilities[]/ids`: The IDs element was changed into an array to be able to contain multiple IDs. See conversion rule in [section 9.1.5 of CSAF specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#915-conformance-clause-5-cvrf-csaf-converter).
 * `/vulnerabilities[]/remediations[]/category`: The CVRF CSAF Vulnerability Remediation Type `Will Not Fix` was renamed into `no_fix_planned`.
 * `/vulnerabilities[]/scores[]`: See conversion rules in [section 9.1.5 of CSAF specification](https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html#915-conformance-clause-5-cvrf-csaf-converter). **Note:** As the way changed how products are tied to score values, score values from `vuln:ScoreSetV2` and `vuln:ScoreSetV3` SHOULD be joined if the address the same product set. Therefore, the number of score elements can be different from `Count(vuln:ScoreSetV2 or vuln:ScoreSetV3)`.
 
@@ -588,9 +589,10 @@ This informative appendix provides a mapping by path between the elements in CSA
 | `/vulnerabilities[i]/cwe/id` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:CWE/@ID` |  |
 | `/vulnerabilities[i]/cwe/name` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:CWE/text()` |  |
 | `/vulnerabilities[i]/discovery_date` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:DiscoveryDate/text()` | |
-| `/vulnerabilities[i]/id` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID` | |
-| `/vulnerabilities[i]/id/system_name` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID/@SystemName` |  |
-| `/vulnerabilities[i]/id/text` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID/text()` |  |
+| `/vulnerabilities[i]/ids` |  | see E.2 |
+| `/vulnerabilities[i]/ids[0]` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID` | |
+| `/vulnerabilities[i]/ids[0]/system_name` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID/@SystemName` |  |
+| `/vulnerabilities[i]/ids[0]/text` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:ID/text()` |  |
 | `/vulnerabilities[i]/involvements` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:Involvements` |  |
 | `/vulnerabilities[i]/involvements[j]` | `/cvrf:cvrfdoc/vuln:Vulnerability[i+1]/vuln:Involvements/vuln:Involvement[j+1]` | |
 | `/vulnerabilities[i]/involvements[j]/date` |  | see E.1 |


### PR DESCRIPTION
- fix #388 
- change `id` into `ids` of type `array`
- adopt specification
- adopt example
- add conversion rule
- adopt Appendix C
- enforce uniqueness