### PR TITLE
Add new CSAF sample data generated from released Red Hat advisories

### DIFF
--- a/csaf_2.0/examples/csaf/rhsa-2021_5186.json
+++ b/csaf_2.0/examples/csaf/rhsa-2021_5186.json
@@ -1,0 +1,319 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Critical"
+    },
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "Red Hat OpenShift Container Platform release 4.6.52 is now available with\nupdates to packages and images that fix several bugs and add enhancements.\n\nRed Hat Product Security has rated this update as having a security impact of Critical. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Red Hat OpenShift Container Platform is Red Hat's cloud computing\nKubernetes application platform solution designed for on-premise or private\ncloud deployments.\n\nSecurity Fix(es):\n\n* kube-reporting/hive: Incomplete fix for log4j CVE-2021-44228 and CVE-2021-45046 (CVE-2021-4125)\n\n* log4j: Remote code execution in Log4j 1.x when application is configured to use JMSAppender (CVE-2021-4104)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2021:5186",
+        "url": "https://access.redhat.com/errata/RHSA-2021:5186"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#critical",
+        "url": "https://access.redhat.com/security/updates/classification/#critical"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/vulnerabilities/RHSB-2021-009",
+        "url": "https://access.redhat.com/security/vulnerabilities/RHSB-2021-009"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/beta/2021/rhsa-2021_5186.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: OpenShift Container Platform 4.6.52 security update",
+    "tracking": {
+      "current_release_date": "2021-12-16T22:34:00Z",
+      "generator": {
+        "date": "2022-03-23T20:31:00Z",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.4.3"
+        }
+      },
+      "id": "RHSA-2021:5186",
+      "initial_release_date": "2021-12-16T22:34:00Z",
+      "revision_history": [
+        {
+          "date": "2021-12-16T22:34:00Z",
+          "number": "1",
+          "summary": "Current version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat OpenShift Container Platform 4.6",
+                "product": {
+                  "name": "Red Hat OpenShift Container Platform 4.6",
+                  "product_id": "8Base-RHOSE-4.6",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/a:redhat:openshift:4.6::el8"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat OpenShift Enterprise"
+          },
+          {
+            "category": "product_version",
+            "name": "openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+            "product": {
+              "name": "openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+              "product_id": "openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1"
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595",
+            "product": {
+              "name": "openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595",
+              "product_id": "openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream",
+            "product": {
+              "name": "openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream",
+              "product_id": "openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream"
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1 as a component of Red Hat OpenShift Container Platform 4.6",
+          "product_id": "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1"
+        },
+        "product_reference": "openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+        "relates_to_product_reference": "8Base-RHOSE-4.6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595 as a component of Red Hat OpenShift Container Platform 4.6",
+          "product_id": "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+        },
+        "product_reference": "openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595",
+        "relates_to_product_reference": "8Base-RHOSE-4.6"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream as a component of Red Hat OpenShift Container Platform 4.6",
+          "product_id": "8Base-RHOSE-4.6:openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream"
+        },
+        "product_reference": "openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream",
+        "relates_to_product_reference": "8Base-RHOSE-4.6"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2021-4104",
+      "cwe": {
+        "id": "CWE-20",
+        "name": "Improper Input Validation"
+      },
+      "discovery_date": "2021-12-13T00:00:00Z",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla",
+          "text": "https://bugzilla.redhat.com/show_bug.cgi?id=2031667"
+        }
+      ],
+      "notes": [
+        {
+          "category": "general",
+          "text": "log4j: Remote code execution in Log4j 1.x when application is configured to use JMSAppender",
+          "title": "Vulnerability Description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "8Base-RHOSE-4.6:openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream"
+        ],
+        "known_not_affected": [
+          "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+          "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "https://github.com/apache/logging-log4j2/pull/608#issuecomment-990494126",
+          "url": "https://github.com/apache/logging-log4j2/pull/608#issuecomment-990494126"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/apache/logging-log4j2/pull/608#issuecomment-991723301",
+          "url": "https://github.com/apache/logging-log4j2/pull/608#issuecomment-991723301"
+        },
+        {
+          "category": "external",
+          "summary": "https://lists.apache.org/thread/0x4zvtq92yggdgvwfgsftqrj4xx5w0nx",
+          "url": "https://lists.apache.org/thread/0x4zvtq92yggdgvwfgsftqrj4xx5w0nx"
+        },
+        {
+          "category": "external",
+          "summary": "https://www.openwall.com/lists/oss-security/2021/12/13/1",
+          "url": "https://www.openwall.com/lists/oss-security/2021/12/13/1"
+        },
+        {
+          "category": "external",
+          "summary": "CVE-2021-4104",
+          "url": "https://access.redhat.com/security/cve/CVE-2021-4104"
+        },
+        {
+          "category": "external",
+          "summary": "bz#2031667: CVE-2021-4104 log4j: Remote code execution in Log4j 1.x when application is configured to use JMSAppender",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2031667"
+        }
+      ],
+      "release_date": "2021-12-10T00:00:00Z",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For OpenShift Container Platform 4.6 see the following documentation, which\nwill be updated shortly for this release, for important instructions on how\nto upgrade your cluster and fully apply this asynchronous errata update:\n\nhttps://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html\n\nDetails on how to access this content are available at\nhttps://docs.openshift.com/container-platform/4.6/updating/updating-cluster-cli.html",
+          "product_ids": [
+            "8Base-RHOSE-4.6:openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream",
+            "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+            "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2021:5186"
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "date": "2021-12-13T00:00:00Z",
+          "details": "Moderate"
+        }
+      ],
+      "title": "CVE-2021-4104 log4j: Remote code execution in Log4j 1.x when application is configured to use JMSAppender"
+    },
+    {
+      "cve": "CVE-2021-4125",
+      "discovery_date": "2021-12-16T00:00:00Z",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla",
+          "text": "https://bugzilla.redhat.com/show_bug.cgi?id=2033121"
+        }
+      ],
+      "notes": [
+        {
+          "category": "general",
+          "text": "kube-reporting/hive: Incomplete fix for log4j CVE-2021-44228 and CVE-2021-45046",
+          "title": "Vulnerability Description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "8Base-RHOSE-4.6:openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream"
+        ],
+        "known_not_affected": [
+          "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+          "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "https://access.redhat.com/security/cve/CVE-2021-44228",
+          "url": "https://access.redhat.com/security/cve/CVE-2021-44228"
+        },
+        {
+          "category": "external",
+          "summary": "https://access.redhat.com/security/cve/CVE-2021-45046",
+          "url": "https://access.redhat.com/security/cve/CVE-2021-45046"
+        },
+        {
+          "category": "external",
+          "summary": "CVE-2021-4125",
+          "url": "https://access.redhat.com/security/cve/CVE-2021-4125"
+        },
+        {
+          "category": "external",
+          "summary": "bz#2033121: CVE-2021-4125 kube-reporting/hive: Incomplete fix for log4j CVE-2021-44228 and CVE-2021-45046",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2033121"
+        }
+      ],
+      "release_date": "2021-12-16T00:00:00Z",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For OpenShift Container Platform 4.6 see the following documentation, which\nwill be updated shortly for this release, for important instructions on how\nto upgrade your cluster and fully apply this asynchronous errata update:\n\nhttps://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html\n\nDetails on how to access this content are available at\nhttps://docs.openshift.com/container-platform/4.6/updating/updating-cluster-cli.html",
+          "product_ids": [
+            "8Base-RHOSE-4.6:openshift4/ose-metering-hive:v4.6.0-202112160147.p0.gf139e12.assembly.stream",
+            "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator-bundle:v4.6.0.202112161349.p0.gd74112d.assembly.art3595-1",
+            "8Base-RHOSE-4.6:openshift4/ose-metering-ansible-operator:v4.6.0-202112161349.p0.gd74112d.assembly.art3595"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2021:5186"
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "date": "2021-12-16T00:00:00Z",
+          "details": "Critical"
+        }
+      ],
+      "title": "CVE-2021-4125 kube-reporting/hive: Incomplete fix for log4j CVE-2021-44228 and CVE-2021-45046"
+    }
+  ]
+}

--- a/csaf_2.0/examples/csaf/rhsa-2021_5217.json
+++ b/csaf_2.0/examples/csaf/rhsa-2021_5217.json
@@ -1,0 +1,185 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "A security update is now available for Red Hat Single Sign-On 7.5 from the Customer Portal.\n\nRed Hat Product Security has rated this update as having a security impact of Important. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Red Hat Single Sign-On 7.5 is a standalone server, based on the Keycloak project, that provides authentication and standards-based single sign-on capabilities for web and mobile applications.\n\nThis is an asynchronous patch for Red Hat Single Sign-On 7.5, and includes one security fix.\n\nSecurity Fix:\n\n* keycloak: Incorrect authorization allows unpriviledged users to create other users (CVE-2021-4133)\n\nFor more details about the security issue(s), including the impact, a CVSS score, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2021:5217",
+        "url": "https://access.redhat.com/errata/RHSA-2021:5217"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#important",
+        "url": "https://access.redhat.com/security/updates/classification/#important"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=securityPatches&product=core.service.rhsso&version=7.5",
+        "url": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=securityPatches&product=core.service.rhsso&version=7.5"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/",
+        "url": "https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/beta/2021/rhsa-2021_5217.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: Red Hat Single Sign-On 7.5.0 security update",
+    "tracking": {
+      "current_release_date": "2021-12-20T16:16:00Z",
+      "generator": {
+        "date": "2022-03-23T20:31:00Z",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.4.3"
+        }
+      },
+      "id": "RHSA-2021:5217",
+      "initial_release_date": "2021-12-20T16:16:00Z",
+      "revision_history": [
+        {
+          "date": "2021-12-20T16:16:00Z",
+          "number": "1",
+          "summary": "Current version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "Red Hat Single Sign-On",
+            "product": {
+              "name": "Red Hat Single Sign-On",
+              "product_id": "Red Hat Single Sign-On"
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "acknowledgments": [
+        {
+          "names": [
+            "Grzegorz Soba\u0144ski"
+          ],
+          "organization": "MLabs"
+        }
+      ],
+      "cve": "CVE-2021-4133",
+      "cwe": {
+        "id": "CWE-863",
+        "name": "Incorrect Authorization"
+      },
+      "discovery_date": "2021-12-17T00:00:00Z",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla",
+          "text": "https://bugzilla.redhat.com/show_bug.cgi?id=2033602"
+        }
+      ],
+      "notes": [
+        {
+          "category": "general",
+          "text": "Keycloak: Incorrect authorization allows unpriviledged users to create other users",
+          "title": "Vulnerability Description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "Red Hat Single Sign-On"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "https://github.com/keycloak/keycloak/issues/9247",
+          "url": "https://github.com/keycloak/keycloak/issues/9247"
+        },
+        {
+          "category": "external",
+          "summary": "https://github.com/keycloak/keycloak/security/advisories/GHSA-83x4-9cwr-5487",
+          "url": "https://github.com/keycloak/keycloak/security/advisories/GHSA-83x4-9cwr-5487"
+        },
+        {
+          "category": "external",
+          "summary": "CVE-2021-4133",
+          "url": "https://access.redhat.com/security/cve/CVE-2021-4133"
+        },
+        {
+          "category": "external",
+          "summary": "bz#2033602: CVE-2021-4133 Keycloak: Incorrect authorization allows unpriviledged users to create other users",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2033602"
+        }
+      ],
+      "release_date": "2021-12-16T17:05:00Z",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "Before applying the update, back up your existing installation, including all applications, configuration files, databases and database settings, and so on.\n\nThe References section of this erratum contains a download link (you must log in to download the update).",
+          "product_ids": [
+            "Red Hat Single Sign-On"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2021:5217"
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "date": "2021-12-17T00:00:00Z",
+          "details": "Important"
+        }
+      ],
+      "title": "CVE-2021-4133 Keycloak: Incorrect authorization allows unpriviledged users to create other users"
+    }
+  ]
+}

--- a/csaf_2.0/examples/csaf/rhsa-2022_0011.json
+++ b/csaf_2.0/examples/csaf/rhsa-2022_0011.json
@@ -1,0 +1,427 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "lang": "en",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "An update for telnet is now available for Red Hat Enterprise Linux 7.6 Advanced Update Support, Red Hat Enterprise Linux 7.6 Telco Extended Update Support, and Red Hat Enterprise Linux 7.6 Update Services for SAP Solutions.\n\nRed Hat Product Security has rated this update as having a security impact of Important. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+        "title": "Topic"
+      },
+      {
+        "category": "general",
+        "text": "Telnet is a popular protocol for logging in to remote systems over the Internet. The telnet-server packages include a telnet service that supports remote logins into the host machine. The telnet service is disabled by default.\n\nSecurity Fix(es):\n\n* telnet-server: no bounds checks in nextitem() function allows to remotely execute arbitrary code (CVE-2020-10188)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+        "title": "Details"
+      },
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "references": [
+      {
+        "category": "self",
+        "summary": "https://access.redhat.com/errata/RHSA-2022:0011",
+        "url": "https://access.redhat.com/errata/RHSA-2022:0011"
+      },
+      {
+        "category": "external",
+        "summary": "https://access.redhat.com/security/updates/classification/#important",
+        "url": "https://access.redhat.com/security/updates/classification/#important"
+      },
+      {
+        "category": "self",
+        "summary": "Canonical URL",
+        "url": "https://access.redhat.com/security/data/csaf/beta/2022/rhsa-2022_0011.json"
+      }
+    ],
+    "title": "Red Hat Security Advisory: telnet security update",
+    "tracking": {
+      "current_release_date": "2022-01-04T08:38:00Z",
+      "generator": {
+        "date": "2022-03-23T20:31:00Z",
+        "engine": {
+          "name": "Red Hat SDEngine",
+          "version": "3.4.3"
+        }
+      },
+      "id": "RHSA-2022:0011",
+      "initial_release_date": "2022-01-04T08:38:00Z",
+      "revision_history": [
+        {
+          "date": "2022-01-04T08:38:00Z",
+          "number": "1",
+          "summary": "Current version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Server AUS (v. 7.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Server AUS (v. 7.6)",
+                  "product_id": "7Server-7.6.AUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_aus:7.6::server"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Server E4S (v. 7.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Server E4S (v. 7.6)",
+                  "product_id": "7Server-7.6.E4S",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_e4s:7.6::server"
+                  }
+                }
+              },
+              {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux Server TUS (v. 7.6)",
+                "product": {
+                  "name": "Red Hat Enterprise Linux Server TUS (v. 7.6)",
+                  "product_id": "7Server-7.6.TUS",
+                  "product_identification_helper": {
+                    "cpe": "cpe:/o:redhat:rhel_tus:7.6::server"
+                  }
+                }
+              }
+            ],
+            "category": "product_family",
+            "name": "Red Hat Enterprise Linux"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "telnet-1:0.17-65.el7_6.src",
+                "product": {
+                  "name": "telnet-1:0.17-65.el7_6.src",
+                  "product_id": "telnet-1:0.17-65.el7_6.src"
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "src"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "telnet-1:0.17-65.el7_6.x86_64",
+                "product": {
+                  "name": "telnet-1:0.17-65.el7_6.x86_64",
+                  "product_id": "telnet-1:0.17-65.el7_6.x86_64"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+                "product": {
+                  "name": "telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+                  "product_id": "telnet-debuginfo-1:0.17-65.el7_6.x86_64"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "telnet-server-1:0.17-65.el7_6.x86_64",
+                "product": {
+                  "name": "telnet-server-1:0.17-65.el7_6.x86_64",
+                  "product_id": "telnet-server-1:0.17-65.el7_6.x86_64"
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "x86_64"
+          },
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "telnet-1:0.17-65.el7_6.ppc64le",
+                "product": {
+                  "name": "telnet-1:0.17-65.el7_6.ppc64le",
+                  "product_id": "telnet-1:0.17-65.el7_6.ppc64le"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "telnet-debuginfo-1:0.17-65.el7_6.ppc64le",
+                "product": {
+                  "name": "telnet-debuginfo-1:0.17-65.el7_6.ppc64le",
+                  "product_id": "telnet-debuginfo-1:0.17-65.el7_6.ppc64le"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "telnet-server-1:0.17-65.el7_6.ppc64le",
+                "product": {
+                  "name": "telnet-server-1:0.17-65.el7_6.ppc64le",
+                  "product_id": "telnet-server-1:0.17-65.el7_6.ppc64le"
+                }
+              }
+            ],
+            "category": "architecture",
+            "name": "ppc64le"
+          }
+        ],
+        "category": "vendor",
+        "name": "Red Hat"
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.src as a component of Red Hat Enterprise Linux Server AUS (v. 7.6)",
+          "product_id": "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.src"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.src",
+        "relates_to_product_reference": "7Server-7.6.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server AUS (v. 7.6)",
+          "product_id": "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-debuginfo-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server AUS (v. 7.6)",
+          "product_id": "7Server-7.6.AUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-server-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server AUS (v. 7.6)",
+          "product_id": "7Server-7.6.AUS:telnet-server-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-server-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.AUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.ppc64le as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.ppc64le"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.ppc64le",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.src as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.src"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.src",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-debuginfo-1:0.17-65.el7_6.ppc64le as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.ppc64le"
+        },
+        "product_reference": "telnet-debuginfo-1:0.17-65.el7_6.ppc64le",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-debuginfo-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-server-1:0.17-65.el7_6.ppc64le as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.ppc64le"
+        },
+        "product_reference": "telnet-server-1:0.17-65.el7_6.ppc64le",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-server-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server E4S (v. 7.6)",
+          "product_id": "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-server-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.E4S"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.src as a component of Red Hat Enterprise Linux Server TUS (v. 7.6)",
+          "product_id": "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.src"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.src",
+        "relates_to_product_reference": "7Server-7.6.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server TUS (v. 7.6)",
+          "product_id": "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-debuginfo-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server TUS (v. 7.6)",
+          "product_id": "7Server-7.6.TUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.TUS"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "telnet-server-1:0.17-65.el7_6.x86_64 as a component of Red Hat Enterprise Linux Server TUS (v. 7.6)",
+          "product_id": "7Server-7.6.TUS:telnet-server-1:0.17-65.el7_6.x86_64"
+        },
+        "product_reference": "telnet-server-1:0.17-65.el7_6.x86_64",
+        "relates_to_product_reference": "7Server-7.6.TUS"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2020-10188",
+      "cwe": {
+        "id": "CWE-119",
+        "name": "Improper Restriction of Operations within the Bounds of a Memory Buffer"
+      },
+      "discovery_date": "2020-03-06T00:00:00Z",
+      "ids": [
+        {
+          "system_name": "Red Hat Bugzilla",
+          "text": "https://bugzilla.redhat.com/show_bug.cgi?id=1811673"
+        }
+      ],
+      "notes": [
+        {
+          "category": "general",
+          "text": "telnet-server: no bounds checks in nextitem() function allows to remotely execute arbitrary code",
+          "title": "Vulnerability Description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.src",
+          "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.AUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.AUS:telnet-server-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.ppc64le",
+          "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.src",
+          "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.ppc64le",
+          "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.ppc64le",
+          "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.src",
+          "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.TUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+          "7Server-7.6.TUS:telnet-server-1:0.17-65.el7_6.x86_64"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "CVE-2020-10188",
+          "url": "https://access.redhat.com/security/cve/CVE-2020-10188"
+        },
+        {
+          "category": "external",
+          "summary": "bz#1811673: CVE-2020-10188 telnet-server: no bounds checks in nextitem() function allows to remotely execute arbitrary code",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1811673"
+        }
+      ],
+      "release_date": "2020-02-28T00:00:00Z",
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "For details on how to apply this update, which includes the changes described in this advisory, refer to:\n\nhttps://access.redhat.com/articles/11258",
+          "product_ids": [
+            "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.src",
+            "7Server-7.6.AUS:telnet-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.AUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.AUS:telnet-server-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.ppc64le",
+            "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.src",
+            "7Server-7.6.E4S:telnet-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.ppc64le",
+            "7Server-7.6.E4S:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.ppc64le",
+            "7Server-7.6.E4S:telnet-server-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.src",
+            "7Server-7.6.TUS:telnet-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.TUS:telnet-debuginfo-1:0.17-65.el7_6.x86_64",
+            "7Server-7.6.TUS:telnet-server-1:0.17-65.el7_6.x86_64"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2022:0011"
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "date": "2020-03-06T00:00:00Z",
+          "details": "Important"
+        }
+      ],
+      "title": "CVE-2020-10188 telnet-server: no bounds checks in nextitem() function allows to remotely execute arbitrary code"
+    }
+  ]
+}


### PR DESCRIPTION
@sthagen @tolim @tschmidtb51 This PR includes updated CSAF sample data generated by Red Hat, based on some of our existing advisories. It's intended to replace the earlier sample data, which was a draft version and no longer matches what we intend to publish. The three files each represent a different format of CSAF data, based on the underlying advisory type.

The first file, "rhsa-2021_5186.json" is an advisory for Red Hat container products (in this case, Openshift Container Platform).

The second file, "rhsa-2021-5217.json", is an advisory for Red Hat middleware products (in this case, Single Sign-On / Keycloak).

The third file, "rhsa-2022-0011.json", is an advisory for traditional Red Hat products that ship RPM packages (in this case, versions of Red Hat Enterprise Linux Server that ship the telnet RPM package).

Could you please briefly review the contents of each file, and let me know any suggestions or thoughts you may have? All our data passes JSONSchema validation and the tests defined in the CSAF 2.0 spec, but given the complexity the extra review would be very appreciated.

I can also give more details about each advisory type if wanted: what the differences in format are, why certain information is included or excluded, the way Red Hat uses certain fields, and so on.

@mprpic This is the same sample data you already reviewed, so no need for you to look again unless you want to.