### PR TITLE
Prohibit trailing white spaces 

### DIFF
--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -788,6 +788,7 @@
               "title": "Unique identifier for the document",
               "description": "The ID is a simple label that provides for a wide range of numbering values, types, and schemes. Its value SHOULD be assigned and maintained by the original document issuing authority.",
               "type": "string",
+              "pattern": "^[\\S](.*[\\S])?$",
               "minLength": 1,
               "examples": [
                 "Example Company - 2019-YH3234",

--- a/csaf_2.0/json_schema/csaf_json_schema.json
+++ b/csaf_2.0/json_schema/csaf_json_schema.json
@@ -207,8 +207,8 @@
                           "title": "Value of the cryptographic hash",
                           "description": "Contains the cryptographic hash value in hexadecimal representation.",
                           "type": "string",
-                          "minLength": 32,
                           "pattern": "^[0-9a-fA-F]{32,}$",
+                          "minLength": 32,
                           "examples": [
                             "37df33cb7464da5c7f077f4d56a32bc84987ec1d85b234537c1c1a4d4fc8d09dc29e2e762cb5203677bf849a2855a0283710f1f5fe1d6ce8d5ac85c645d0fcb3",
                             "4775203615d9534a8bfca96a93dc8b461a489f69124a130d786b42204f3341cc",

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -1888,7 +1888,13 @@ Engine version (`version`) of value type `string` with 1 or more characters cont
 
 ##### 3.2.1.12.4 Document Property - Tracking - ID
 
-Unique identifier for the document (`id`) of value type `string` with 1 or more characters holds the Identifier.
+Unique identifier for the document (`id`) of value type `string` with 1 or more characters with `pattern` (regular expression):
+
+```
+    ^[\\S](.*[\\S])?$
+```
+
+Unique identifier for the document holds the Identifier.
 The ID is a simple label that provides for a wide range of numbering values, types, and schemes.
 Its value SHOULD be assigned and maintained by the original document issuing authority. It MUST be unique for that organisation.
 

--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -1895,6 +1895,9 @@ Unique identifier for the document (`id`) of value type `string` with 1 or more 
 ```
 
 Unique identifier for the document holds the Identifier.
+
+> It SHALL NOT start or end with a white space and SHALL NOT contain a line break.
+
 The ID is a simple label that provides for a wide range of numbering values, types, and schemes.
 Its value SHOULD be assigned and maintained by the original document issuing authority. It MUST be unique for that organisation.
 


### PR DESCRIPTION
- resolves https://github.com/oasis-tcs/csaf/issues/440
- add restriction that Document Tracking ID can't start or end with white space nor have a line break inside
- add informative comment about regex
- correct order in JSON schema for pattern 