### PR TITLE
Editorial

### DIFF
--- a/csaf_2.0/test/validator/data/mandatory/OASIS_CSAF_TC-CSAF_2_0-2021-6-1-33-01.json
+++ b/csaf_2.0/test/validator/data/mandatory/OASIS_CSAF_TC-CSAF_2_0-2021-6-1-33-01.json
@@ -1,6 +1,6 @@
 {
   "document": {
-    "category": "csaf_vex",
+    "category": "csaf_base",
     "csaf_version": "2.0",
     "publisher": {
       "category": "other",


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#466
- correct document category to csaf_base as test is profile independent