### PR TITLE
Remove trailing spaces following commas in changes.csv example

### DIFF
--- a/csaf_2.0/prose/csaf-v2-editor-draft.md
+++ b/csaf_2.0/prose/csaf-v2-editor-draft.md
@@ -5821,10 +5821,10 @@ The file changes.csv MUST contain the filename as well as the value of `/documen
 *Examples 129:*
 
 ```
-2020/example_company_-_2020-yh4711.json,"2020-07-01T10:09:07Z"
-2018/example_company_-_2018-yh2312.json,"2020-07-01T10:09:01Z"
-2019/example_company_-_2019-yh3234.json,"2019-04-17T15:08:41Z"
-2018/example_company_-_2018-yh2312.json,"2019-03-01T06:01:00Z"
+"2020/example_company_-_2020-yh4711.json","2020-07-01T10:09:07Z"
+"2018/example_company_-_2018-yh2312.json","2020-07-01T10:09:01Z"
+"2019/example_company_-_2019-yh3234.json","2019-04-17T15:08:41Z"
+"2018/example_company_-_2018-yh2312.json","2019-03-01T06:01:00Z"
 ```
 
 ### 7.1.14 Requirement 14: Directory listings


### PR DESCRIPTION
There should be no space trailing the commas in the changes.csv example. Trailing spaces following commas are considered part of the field per RFC4180.