### PR TITLE
Gh fix deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           python3-wheel
         pip3 install jsonschema[format]
     - name: Check jsonschema version
-      run: jsonschema --version
+      run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test examples against CSAF schema
       run: ./csaf_2.0/test/csaf_schema/run_tests.sh
     - name: Test VEX examples against CSAF schema

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Test examples against Aggregator schema
       run: ./csaf_2.0/test/aggregator_schema/run_tests.sh
     - name: Upload strict JSON schema artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: strict-schemas
         path: |

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -20,7 +20,7 @@ jobs:
           python3-wheel
         pip3 install jsonschema[format]
     - name: Check jsonschema version
-      run: jsonschema --version
+      run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test validator/data/mandatory against schema
       run: ./csaf_2.0/test/validator/run_tests.sh mandatory
     - name: Test validator/data/optional against schema


### PR DESCRIPTION
- fix #645 
- update upload action to v3
- replace `jsonschema --version` with python command to query metadata
