### PR TITLE
Add CVSS 4.0

### DIFF
--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -1350,6 +1350,9 @@
                     }
                   ]
                 },
+                "cvss_v4": {
+                  "$ref": "https://www.first.org/cvss/cvss-v4.0.json"
+                },
                 "products": {
                   "$ref": "#/$defs/products_t"
                 }

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -135,6 +135,8 @@ Secondly, the program fulfills the following for all items of:
   `first_affected` and `last_affected` into `product_ids`.
   If none of these arrays exist, the CVRF CSAF converter outputs an error that no matching Product ID was found for this remediation element.
 * `/vulnerabilities[]/scores[]`:
+  * For any CVSS v4 element, the CVRF CSAF converter MUST compute the `baseSeverity` from the `baseScore` according to
+    the rules of the applicable CVSS standard. (CSAF CVRF v1.2 predates CVSS v4.0.)
   * For any CVSS v3 element, the CVRF CSAF converter MUST compute the `baseSeverity` from the `baseScore` according to
     the rules of the applicable CVSS standard.
   * If no `product_id` is given, the CVRF CSAF converter appends all Product IDs which are listed under `../product_status` in
@@ -145,7 +147,8 @@ Secondly, the program fulfills the following for all items of:
     A CVRF CSAF converter MAY offer a configuration option to delete such elements.
   * If there are CVSS v3.0 and CVSS v3.1 Vectors available for the same product, the CVRF CSAF converter discards
     the CVSS v3.0 information and provide in CSAF only the CVSS v3.1 information.
-  * To determine, which minor version of CVSS v3 is used, the CVRF CSAF converter uses the following steps:
+  * To determine, which minor version of CVSS v3 is used and to evaluate a CVSS v4 that was wrongly inserted in a CVSS v3 element,
+    the CVRF CSAF converter uses the following steps:
     1. Retrieve the CVSS version from the CVSS vector, if present.
 
         *Example 1:*

--- a/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
@@ -37,6 +37,8 @@ Delegation to industry best practices technologies is used in referencing schema
 * Platform Data:
   * Common Platform Enumeration (CPE) Version 2.3 [cite](#CPE23-N)
 * Vulnerability Scoring:
+  * Common Vulnerability Scoring System (CVSS) Version 4.0 [cite](#CVSS40)
+    * JSON Schema Reference https://www.first.org/cvss/cvss-v4.0.json
   * Common Vulnerability Scoring System (CVSS) Version 3.1 [cite](#CVSS31)
     * JSON Schema Reference https://www.first.org/cvss/cvss-v3.1.json
   * Common Vulnerability Scoring System (CVSS) Version 3.0 [cite](#CVSS30)

--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -211,6 +211,7 @@ A string SHOULD NOT have a length greater than:
   * `/vulnerabilities[]/remediations[]/product_ids[]`
   * `/vulnerabilities[]/scores[]/cvss_v2/vectorString`
   * `/vulnerabilities[]/scores[]/cvss_v3/vectorString`
+  * `/vulnerabilities[]/scores[]/cvss_v4/vectorString`
   * `/vulnerabilities[]/scores[]/products[]`
   * `/vulnerabilities[]/threats[]/group_ids[]`
   * `/vulnerabilities[]/threats[]/product_ids[]`
@@ -337,6 +338,42 @@ It seems to be safe to assume that the length of each value is not greater than 
 * `/vulnerabilities[]/scores[]/cvss_v3/modifiedIntegrityImpact` (11)
 * `/vulnerabilities[]/scores[]/cvss_v3/modifiedAvailabilityImpact` (11)
 * `/vulnerabilities[]/scores[]/cvss_v3/environmentalSeverity` (8)
+* `/vulnerabilities[]/scores[]/cvss_v4/version` (3)
+* `/vulnerabilities[]/scores[]/cvss_v4/attackVector` (8)
+* `/vulnerabilities[]/scores[]/cvss_v4/attackComplexity` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/attackRequirements` (7)
+* `/vulnerabilities[]/scores[]/cvss_v4/privilegesRequired` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/userInteraction` (7)
+* `/vulnerabilities[]/scores[]/cvss_v4/vulnConfidentialityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/vulnIntegrityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/vulnAvailabilityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/subConfidentialityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/subIntegrityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/subAvailabilityImpact` (4)
+* `/vulnerabilities[]/scores[]/cvss_v4/exploitMaturity` (16)
+* `/vulnerabilities[]/scores[]/cvss_v4/confidentialityRequirement` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/integrityRequirement` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/availabilityRequirement` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedAttackVector` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedAttackComplexity` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedAttackRequirements` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedPrivilegesRequired` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedUserInteraction` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedVulnConfidentialityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedVulnIntegrityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedVulnAvailabilityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedSubConfidentialityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedSubIntegrityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/modifiedSubAvailabilityImpact` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/Safety` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/Automatable` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/Recovery` (13)
+* `/vulnerabilities[]/scores[]/cvss_v4/valueDensity` (12)
+* `/vulnerabilities[]/scores[]/cvss_v4/vulnerabilityResponseEffort` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/providerUrgency` (11)
+* `/vulnerabilities[]/scores[]/cvss_v4/baseSeverity` (8)
+* `/vulnerabilities[]/scores[]/cvss_v4/threatSeverity` (8)
+* `/vulnerabilities[]/scores[]/cvss_v4/environmentalSeverity` (8)
 * `/vulnerabilities[]/threats[]/category` (14)
 
 ## Date

--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -36,6 +36,9 @@ CVSS30
 CVSS31
 :    _Common Vulnerability Scoring System v3.1: Specification Document_, FIRST.Org, Inc., June 2019, https://www.first.org/cvss/v3-1/cvss-v31-specification_r1.pdf.
 
+CVSS40
+:    _Common Vulnerability Scoring System v4.0: Specification Document_, FIRST.Org, Inc., 09 November 2023, https://www.first.org/cvss/v4-0/cvss-v40-specification.pdf.
+
 CWE
 :    _Common Weakness Enumeration (CWE) – A Community-Developed List of Software Weakness Types_, MITRE, 2005, http://cwe.mitre.org/about/.
 

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-03-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-03-vulnerabilities.md
@@ -662,8 +662,8 @@ List of scores (`scores`) of value type `array` with 1 or more items of type sco
     },
 ```
 
-Value type of every such Score item is `object` with the mandatory property `products` and the optional properties `cvss_v2` and
-`cvss_v3` specifies information about (at least one) score of the vulnerability and for which products the given value applies.
+Value type of every such Score item is `object` with the mandatory property `products` and the optional properties `cvss_v2`,
+`cvss_v3` and `cvss_v4` specifies information about (at least one) score of the vulnerability and for which products the given value applies.
 Each Score item has at least 2 properties.
 
 ```
@@ -675,7 +675,10 @@ Each Score item has at least 2 properties.
             "oneOf": [
               // ...
             ]
-          }
+          },
+          "cvss_v4": {
+            // ...
+          },
           "products": {
             // ...
           }
@@ -688,6 +691,8 @@ The property CVSS v2 (`cvss_v2`) holding a CVSS v2.0 value abiding by the schema
 The property CVSS v3 (`cvss_v3`) holding a CVSS v3.x value abiding by one of the schemas at
 [https://www.first.org/cvss/cvss-v3.0.json](https://www.first.org/cvss/cvss-v3.0.json) or
 [https://www.first.org/cvss/cvss-v3.1.json](https://www.first.org/cvss/cvss-v3.1.json).
+
+The property CVSS v4 (`cvss_v4`) holding a CVSS v4.0 value abiding by the schema at [https://www.first.org/cvss/cvss-v4.0.json](https://www.first.org/cvss/cvss-v4.0.json).
 
 Product IDs (`products`) of value type `products_t` with 1 or more items indicates for which products the given scores apply.
 A score object SHOULD reflect the associated product's status (for example,

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-08-invalid-cvss.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-08-invalid-cvss.md
@@ -7,6 +7,7 @@ The relevant paths for this test are:
 ```
   /vulnerabilities[]/scores[]/cvss_v2
   /vulnerabilities[]/scores[]/cvss_v3
+  /vulnerabilities[]/scores[]/cvss_v4
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
@@ -16,6 +16,12 @@ The relevant paths for this test are:
   /vulnerabilities[]/scores[]/cvss_v3/temporalSeverity
   /vulnerabilities[]/scores[]/cvss_v3/environmentalScore
   /vulnerabilities[]/scores[]/cvss_v3/environmentalSeverity
+  /vulnerabilities[]/scores[]/cvss_v4/baseScore
+  /vulnerabilities[]/scores[]/cvss_v4/baseSeverity
+  /vulnerabilities[]/scores[]/cvss_v4/threatScore
+  /vulnerabilities[]/scores[]/cvss_v4/threatSeverity
+  /vulnerabilities[]/scores[]/cvss_v4/environmentalScore
+  /vulnerabilities[]/scores[]/cvss_v4/environmentalSeverity
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-10-inconsistent-cvss.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-10-inconsistent-cvss.md
@@ -7,6 +7,7 @@ The relevant paths for this test are:
 ```
   /vulnerabilities[]/scores[]/cvss_v2
   /vulnerabilities[]/scores[]/cvss_v3
+  /vulnerabilities[]/scores[]/cvss_v4
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -610,8 +610,8 @@ The relevant path for this test is:
 > Neither the `environmentalScore` nor the properties `modifiedIntegrityImpact`, `modifiedAvailabilityImpact`, `modifiedConfidentialityImpact` nor
 > the corresponding attributes in the `vectorString` have been set.
 
-> A tool MAY set the properties `modifiedIntegrityImpact`, `modifiedAvailabilityImpact`, `modifiedConfidentialityImpact` accordingly and
-> compute the `environmentalScore` as quick fix.
+> A tool MAY set the properties `modifiedIntegrityImpact`, `modifiedAvailabilityImpact`, `modifiedConfidentialityImpact` (respectively their
+> equivalents according to the CVSS version used) accordingly and compute the `environmentalScore` as quick fix.
 
 ### Additional Properties
 

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -413,3 +413,45 @@ The relevant paths for this test are:
 > The product version starts with a `v`.
 
 -------
+
+### Missing CVSS v4.0
+
+For each item in the list of scores it MUST be tested that a `cvss_v4` object is present.
+
+The relevant path for this test is:
+
+```
+    /vulnerabilities[]/scores
+```
+
+*Example 1 (which fails the test):*
+
+```
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+```
+
+> There is no CVSS v4.0 score given for `CSAFPID-9080700`.

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -50,7 +50,7 @@ The relevant path for this test is:
 
 Recommendation:
 
-It is recommended to (also) use the CVSS v3.1.
+It is recommended to (also) use the CVSS v4.0.
 
 ### Use of CVSS v3.0
 

--- a/csaf_2.1/referenced_schema/first/cvss-v4.0.json
+++ b/csaf_2.1/referenced_schema/first/cvss-v4.0.json
@@ -1,0 +1,387 @@
+{
+  "license": [
+      "Copyright (c) 2023, FIRST.ORG, INC.",
+      "All rights reserved.",
+      "",
+      "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+      "following conditions are met:",
+      "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+      "   disclaimer.",
+      "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+      "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+      "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+      "   products derived from this software without specific prior written permission.",
+      "",
+      "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+      "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+      "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+      "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+      "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+      "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+      "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  ],
+
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Schema for Common Vulnerability Scoring System version 4.0",
+  "$id": "https://www.first.org/cvss/cvss-v4.0.json?20231011",
+  "type": "object",
+  "definitions": {
+      "attackVectorType": {
+          "type": "string",
+          "enum": [ "NETWORK", "ADJACENT", "LOCAL", "PHYSICAL" ]
+      },
+      "modifiedAttackVectorType": {
+          "type": "string",
+          "enum": [ "NETWORK", "ADJACENT", "LOCAL", "PHYSICAL", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "attackComplexityType": {
+          "type": "string",
+          "enum": [ "HIGH", "LOW" ]
+      },
+      "modifiedAttackComplexityType": {
+          "type": "string",
+          "enum": [ "HIGH", "LOW", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "attackRequirementsType": {
+          "type": "string",
+          "enum": [ "NONE", "PRESENT" ]
+      },
+      "modifiedAttackRequirementsType": {
+          "type": "string",
+          "enum": [ "NONE", "PRESENT", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "privilegesRequiredType": {
+          "type": "string",
+          "enum": [ "HIGH", "LOW", "NONE" ]
+      },
+      "modifiedPrivilegesRequiredType": {
+          "type": "string",
+          "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "userInteractionType": {
+          "type": "string",
+          "enum": [ "NONE", "PASSIVE", "ACTIVE" ]
+      },
+      "modifiedUserInteractionType": {
+          "type": "string",
+          "enum": [ "NONE", "PASSIVE", "ACTIVE", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "vulnCiaType": {
+          "type": "string",
+          "enum": [ "NONE", "LOW", "HIGH" ]
+      },
+      "modifiedVulnCiaType": {
+          "type": "string",
+          "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "subCiaType": {
+          "type": "string",
+          "enum": [ "NONE", "LOW", "HIGH" ]
+      },
+      "modifiedSubCType": {
+          "type": "string",
+          "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "modifiedSubIaType": {
+          "type": "string",
+          "enum": [ "NONE", "LOW", "HIGH", "SAFETY", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "exploitMaturityType": {
+          "type": "string",
+          "enum": [ "UNREPORTED", "PROOF_OF_CONCEPT", "ATTACKED", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "ciaRequirementType": {
+          "type": "string",
+          "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "safetyType": {
+          "type": "string",
+          "enum": [ "NEGLIGIBLE", "PRESENT", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "automatableType": {
+          "type": "string",
+          "enum": [ "NO", "YES", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "recoveryType": {
+          "type": "string",
+          "enum": [ "AUTOMATIC", "USER", "IRRECOVERABLE", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "valueDensityType": {
+          "type": "string",
+          "enum": [ "DIFFUSE", "CONCENTRATED", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "vulnerabilityResponseEffortType": {
+          "type": "string",
+          "enum": [ "LOW", "MODERATE", "HIGH", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "providerUrgencyType": {
+          "type": "string",
+          "enum": [ "CLEAR", "GREEN", "AMBER", "RED", "NOT_DEFINED" ],
+          "default": "NOT_DEFINED"
+      },
+      "noneScoreType": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 0.0
+      },
+      "lowScoreType": {
+          "type": "number",
+          "minimum": 0.1,
+          "maximum": 3.9,
+          "multipleOf": 0.1
+      },
+      "mediumScoreType": {
+          "type": "number",
+          "minimum": 4.0,
+          "maximum": 6.9,
+          "multipleOf": 0.1
+      },
+      "highScoreType": {
+          "type": "number",
+          "minimum": 7.0,
+          "maximum": 8.9,
+          "multipleOf": 0.1
+      },
+      "criticalScoreType": {
+          "type": "number",
+          "minimum": 9.0,
+          "maximum": 10,
+          "multipleOf": 0.1
+      },
+      "noneSeverityType": {
+          "const": "NONE"
+      },
+      "lowSeverityType": {
+          "const": "LOW"
+      },
+      "mediumSeverityType": {
+          "const": "MEDIUM"
+      },
+      "highSeverityType": {
+          "const": "HIGH"
+      },
+      "criticalSeverityType": {
+          "const": "CRITICAL"
+      }
+  },
+  "properties": {
+      "version": {
+          "description": "CVSS Version",
+          "type": "string",
+          "enum": [ "4.0" ]
+      },
+      "vectorString": {
+          "type": "string",
+          "pattern": "^CVSS:4[.]0\/AV:[NALP]\/AC:[LH]\/AT:[NP]\/PR:[NLH]\/UI:[NPA]\/VC:[HLN]\/VI:[HLN]\/VA:[HLN]\/SC:[HLN]\/SI:[HLN]\/SA:[HLN](\/E:[XAPU])?(\/CR:[XHML])?(\/IR:[XHML])?(\/AR:[XHML])?(\/MAV:[XNALP])?(\/MAC:[XLH])?(\/MAT:[XNP])?(\/MPR:[XNLH])?(\/MUI:[XNPA])?(\/MVC:[XNLH])?(\/MVI:[XNLH])?(\/MVA:[XNLH])?(\/MSC:[XNLH])?(\/MSI:[XNLHS])?(\/MSA:[XNLHS])?(\/S:[XNP])?(\/AU:[XNY])?(\/R:[XAUI])?(\/V:[XDC])?(\/RE:[XLMH])?(\/U:(X|Clear|Green|Amber|Red))?$"
+      },
+      "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+      "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+      "attackRequirements":             { "$ref": "#/definitions/attackRequirementsType" },
+      "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+      "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+      "vulnConfidentialityImpact":      { "$ref": "#/definitions/vulnCiaType" },
+      "vulnIntegrityImpact":            { "$ref": "#/definitions/vulnCiaType" },
+      "vulnAvailabilityImpact":         { "$ref": "#/definitions/vulnCiaType" },
+      "subConfidentialityImpact":       { "$ref": "#/definitions/subCiaType" },
+      "subIntegrityImpact":             { "$ref": "#/definitions/subCiaType" },
+      "subAvailabilityImpact":          { "$ref": "#/definitions/subCiaType" },
+      "exploitMaturity":                { "$ref": "#/definitions/exploitMaturityType" },
+      "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+      "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+      "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+      "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+      "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+      "modifiedAttackRequirements":     { "$ref": "#/definitions/modifiedAttackRequirementsType" },
+      "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+      "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+      "modifiedVulnConfidentialityImpact":  { "$ref": "#/definitions/modifiedVulnCiaType" },
+      "modifiedVulnIntegrityImpact":        { "$ref": "#/definitions/modifiedVulnCiaType" },
+      "modifiedVulnAvailabilityImpact":     { "$ref": "#/definitions/modifiedVulnCiaType" },
+      "modifiedSubConfidentialityImpact":   { "$ref": "#/definitions/modifiedSubCType"  },
+      "modifiedSubIntegrityImpact":         { "$ref": "#/definitions/modifiedSubIaType" },
+      "modifiedSubAvailabilityImpact":      { "$ref": "#/definitions/modifiedSubIaType" },
+      "Safety":                         { "$ref": "#/definitions/safetyType" },
+      "Automatable":                    { "$ref": "#/definitions/automatableType" },
+      "Recovery":                       { "$ref": "#/definitions/recoveryType" },
+      "valueDensity":                   { "$ref": "#/definitions/valueDensityType" },
+      "vulnerabilityResponseEffort":    { "$ref": "#/definitions/vulnerabilityResponseEffortType" },
+      "providerUrgency":                { "$ref": "#/definitions/providerUrgencyType" }
+  },
+  "allOf": [
+      {
+          "anyOf": [{
+              "properties": {
+                "baseScore" : {
+                  "$ref": "#/definitions/noneScoreType"
+                },
+                "baseSeverity" : {
+                  "$ref": "#/definitions/noneSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "baseScore" : {
+                  "$ref": "#/definitions/lowScoreType"
+                },
+                "baseSeverity" : {
+                  "$ref": "#/definitions/lowSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "baseScore" : {
+                  "$ref": "#/definitions/mediumScoreType"
+                },
+                "baseSeverity" : {
+                  "$ref": "#/definitions/mediumSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "baseScore" : {
+                  "$ref": "#/definitions/highScoreType"
+                },
+                "baseSeverity" : {
+                  "$ref": "#/definitions/highSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "baseScore" : {
+                  "$ref": "#/definitions/criticalScoreType"
+                },
+                "baseSeverity" : {
+                  "$ref": "#/definitions/criticalSeverityType"
+                }
+              }
+            }]
+      },
+      {
+          "anyOf": [{
+              "properties": {
+                "threatScore" : {
+                  "$ref": "#/definitions/noneScoreType"
+                },
+                "threatSeverity" : {
+                  "$ref": "#/definitions/noneSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "threatScore" : {
+                  "$ref": "#/definitions/lowScoreType"
+                },
+                "threatSeverity" : {
+                  "$ref": "#/definitions/lowSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "threatScore" : {
+                  "$ref": "#/definitions/mediumScoreType"
+                },
+                "threatSeverity" : {
+                  "$ref": "#/definitions/mediumSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "threatScore" : {
+                  "$ref": "#/definitions/highScoreType"
+                },
+                "threatSeverity" : {
+                  "$ref": "#/definitions/highSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "threatScore" : {
+                  "$ref": "#/definitions/criticalScoreType"
+                },
+                "threatSeverity" : {
+                  "$ref": "#/definitions/criticalSeverityType"
+                }
+              }
+            }
+          ]
+      },
+      {
+          "anyOf": [
+              {
+              "properties": {
+                "environmentalScore" : {
+                  "$ref": "#/definitions/noneScoreType"
+                },
+                "environmentalSeverity" : {
+                  "$ref": "#/definitions/noneSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "environmentalScore" : {
+                  "$ref": "#/definitions/lowScoreType"
+                },
+                "environmentalSeverity" : {
+                  "$ref": "#/definitions/lowSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "environmentalScore" : {
+                  "$ref": "#/definitions/mediumScoreType"
+                },
+                "environmentalSeverity" : {
+                  "$ref": "#/definitions/mediumSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "environmentalScore" : {
+                  "$ref": "#/definitions/highScoreType"
+                },
+                "environmentalSeverity" : {
+                  "$ref": "#/definitions/highSeverityType"
+                }
+              }
+            },
+            {
+              "properties": {
+                "environmentalScore" : {
+                  "$ref": "#/definitions/criticalScoreType"
+                },
+                "environmentalSeverity" : {
+                  "$ref": "#/definitions/criticalSeverityType"
+                }
+              }
+            }
+          ]
+      }
+  ],
+  "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
+++ b/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
@@ -1,0 +1,566 @@
+{
+  "$id": "https://www.first.org/cvss/cvss-v4.0.json?20231011",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "baseScore": {
+              "$ref": "#/definitions/noneScoreType"
+            },
+            "baseSeverity": {
+              "$ref": "#/definitions/noneSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "baseScore": {
+              "$ref": "#/definitions/lowScoreType"
+            },
+            "baseSeverity": {
+              "$ref": "#/definitions/lowSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "baseScore": {
+              "$ref": "#/definitions/mediumScoreType"
+            },
+            "baseSeverity": {
+              "$ref": "#/definitions/mediumSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "baseScore": {
+              "$ref": "#/definitions/highScoreType"
+            },
+            "baseSeverity": {
+              "$ref": "#/definitions/highSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "baseScore": {
+              "$ref": "#/definitions/criticalScoreType"
+            },
+            "baseSeverity": {
+              "$ref": "#/definitions/criticalSeverityType"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "threatScore": {
+              "$ref": "#/definitions/noneScoreType"
+            },
+            "threatSeverity": {
+              "$ref": "#/definitions/noneSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "threatScore": {
+              "$ref": "#/definitions/lowScoreType"
+            },
+            "threatSeverity": {
+              "$ref": "#/definitions/lowSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "threatScore": {
+              "$ref": "#/definitions/mediumScoreType"
+            },
+            "threatSeverity": {
+              "$ref": "#/definitions/mediumSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "threatScore": {
+              "$ref": "#/definitions/highScoreType"
+            },
+            "threatSeverity": {
+              "$ref": "#/definitions/highSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "threatScore": {
+              "$ref": "#/definitions/criticalScoreType"
+            },
+            "threatSeverity": {
+              "$ref": "#/definitions/criticalSeverityType"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "anyOf": [
+        {
+          "properties": {
+            "environmentalScore": {
+              "$ref": "#/definitions/noneScoreType"
+            },
+            "environmentalSeverity": {
+              "$ref": "#/definitions/noneSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "environmentalScore": {
+              "$ref": "#/definitions/lowScoreType"
+            },
+            "environmentalSeverity": {
+              "$ref": "#/definitions/lowSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "environmentalScore": {
+              "$ref": "#/definitions/mediumScoreType"
+            },
+            "environmentalSeverity": {
+              "$ref": "#/definitions/mediumSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "environmentalScore": {
+              "$ref": "#/definitions/highScoreType"
+            },
+            "environmentalSeverity": {
+              "$ref": "#/definitions/highSeverityType"
+            }
+          }
+        },
+        {
+          "properties": {
+            "environmentalScore": {
+              "$ref": "#/definitions/criticalScoreType"
+            },
+            "environmentalSeverity": {
+              "$ref": "#/definitions/criticalSeverityType"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "attackComplexityType": {
+      "enum": [
+        "HIGH",
+        "LOW"
+      ],
+      "type": "string"
+    },
+    "attackRequirementsType": {
+      "enum": [
+        "NONE",
+        "PRESENT"
+      ],
+      "type": "string"
+    },
+    "attackVectorType": {
+      "enum": [
+        "NETWORK",
+        "ADJACENT",
+        "LOCAL",
+        "PHYSICAL"
+      ],
+      "type": "string"
+    },
+    "automatableType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NO",
+        "YES",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "ciaRequirementType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "criticalScoreType": {
+      "maximum": 10,
+      "minimum": 9.0,
+      "multipleOf": 0.1,
+      "type": "number"
+    },
+    "criticalSeverityType": {
+      "const": "CRITICAL"
+    },
+    "exploitMaturityType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "UNREPORTED",
+        "PROOF_OF_CONCEPT",
+        "ATTACKED",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "highScoreType": {
+      "maximum": 8.9,
+      "minimum": 7.0,
+      "multipleOf": 0.1,
+      "type": "number"
+    },
+    "highSeverityType": {
+      "const": "HIGH"
+    },
+    "lowScoreType": {
+      "maximum": 3.9,
+      "minimum": 0.1,
+      "multipleOf": 0.1,
+      "type": "number"
+    },
+    "lowSeverityType": {
+      "const": "LOW"
+    },
+    "mediumScoreType": {
+      "maximum": 6.9,
+      "minimum": 4.0,
+      "multipleOf": 0.1,
+      "type": "number"
+    },
+    "mediumSeverityType": {
+      "const": "MEDIUM"
+    },
+    "modifiedAttackComplexityType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "HIGH",
+        "LOW",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedAttackRequirementsType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NONE",
+        "PRESENT",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedAttackVectorType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NETWORK",
+        "ADJACENT",
+        "LOCAL",
+        "PHYSICAL",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedPrivilegesRequiredType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "HIGH",
+        "LOW",
+        "NONE",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedSubCType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NONE",
+        "LOW",
+        "HIGH",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedSubIaType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NONE",
+        "LOW",
+        "HIGH",
+        "SAFETY",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedUserInteractionType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NONE",
+        "PASSIVE",
+        "ACTIVE",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "modifiedVulnCiaType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NONE",
+        "LOW",
+        "HIGH",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "noneScoreType": {
+      "maximum": 0.0,
+      "minimum": 0.0,
+      "type": "number"
+    },
+    "noneSeverityType": {
+      "const": "NONE"
+    },
+    "privilegesRequiredType": {
+      "enum": [
+        "HIGH",
+        "LOW",
+        "NONE"
+      ],
+      "type": "string"
+    },
+    "providerUrgencyType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "CLEAR",
+        "GREEN",
+        "AMBER",
+        "RED",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "recoveryType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "AUTOMATIC",
+        "USER",
+        "IRRECOVERABLE",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "safetyType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "NEGLIGIBLE",
+        "PRESENT",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "subCiaType": {
+      "enum": [
+        "NONE",
+        "LOW",
+        "HIGH"
+      ],
+      "type": "string"
+    },
+    "userInteractionType": {
+      "enum": [
+        "NONE",
+        "PASSIVE",
+        "ACTIVE"
+      ],
+      "type": "string"
+    },
+    "valueDensityType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "DIFFUSE",
+        "CONCENTRATED",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    },
+    "vulnCiaType": {
+      "enum": [
+        "NONE",
+        "LOW",
+        "HIGH"
+      ],
+      "type": "string"
+    },
+    "vulnerabilityResponseEffortType": {
+      "default": "NOT_DEFINED",
+      "enum": [
+        "LOW",
+        "MODERATE",
+        "HIGH",
+        "NOT_DEFINED"
+      ],
+      "type": "string"
+    }
+  },
+  "license": [
+    "Copyright (c) 2023, FIRST.ORG, INC.",
+    "All rights reserved.",
+    "",
+    "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+    "following conditions are met:",
+    "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+    "   disclaimer.",
+    "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+    "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+    "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+    "   products derived from this software without specific prior written permission.",
+    "",
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+    "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+    "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+    "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+    "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+    "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+    "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  ],
+  "properties": {
+    "Automatable": {
+      "$ref": "#/definitions/automatableType"
+    },
+    "Recovery": {
+      "$ref": "#/definitions/recoveryType"
+    },
+    "Safety": {
+      "$ref": "#/definitions/safetyType"
+    },
+    "attackComplexity": {
+      "$ref": "#/definitions/attackComplexityType"
+    },
+    "attackRequirements": {
+      "$ref": "#/definitions/attackRequirementsType"
+    },
+    "attackVector": {
+      "$ref": "#/definitions/attackVectorType"
+    },
+    "availabilityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "confidentialityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "exploitMaturity": {
+      "$ref": "#/definitions/exploitMaturityType"
+    },
+    "integrityRequirement": {
+      "$ref": "#/definitions/ciaRequirementType"
+    },
+    "modifiedAttackComplexity": {
+      "$ref": "#/definitions/modifiedAttackComplexityType"
+    },
+    "modifiedAttackRequirements": {
+      "$ref": "#/definitions/modifiedAttackRequirementsType"
+    },
+    "modifiedAttackVector": {
+      "$ref": "#/definitions/modifiedAttackVectorType"
+    },
+    "modifiedPrivilegesRequired": {
+      "$ref": "#/definitions/modifiedPrivilegesRequiredType"
+    },
+    "modifiedSubAvailabilityImpact": {
+      "$ref": "#/definitions/modifiedSubIaType"
+    },
+    "modifiedSubConfidentialityImpact": {
+      "$ref": "#/definitions/modifiedSubCType"
+    },
+    "modifiedSubIntegrityImpact": {
+      "$ref": "#/definitions/modifiedSubIaType"
+    },
+    "modifiedUserInteraction": {
+      "$ref": "#/definitions/modifiedUserInteractionType"
+    },
+    "modifiedVulnAvailabilityImpact": {
+      "$ref": "#/definitions/modifiedVulnCiaType"
+    },
+    "modifiedVulnConfidentialityImpact": {
+      "$ref": "#/definitions/modifiedVulnCiaType"
+    },
+    "modifiedVulnIntegrityImpact": {
+      "$ref": "#/definitions/modifiedVulnCiaType"
+    },
+    "privilegesRequired": {
+      "$ref": "#/definitions/privilegesRequiredType"
+    },
+    "providerUrgency": {
+      "$ref": "#/definitions/providerUrgencyType"
+    },
+    "subAvailabilityImpact": {
+      "$ref": "#/definitions/subCiaType"
+    },
+    "subConfidentialityImpact": {
+      "$ref": "#/definitions/subCiaType"
+    },
+    "subIntegrityImpact": {
+      "$ref": "#/definitions/subCiaType"
+    },
+    "userInteraction": {
+      "$ref": "#/definitions/userInteractionType"
+    },
+    "valueDensity": {
+      "$ref": "#/definitions/valueDensityType"
+    },
+    "vectorString": {
+      "pattern": "^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/E:[XAPU])?(/CR:[XHML])?(/IR:[XHML])?(/AR:[XHML])?(/MAV:[XNALP])?(/MAC:[XLH])?(/MAT:[XNP])?(/MPR:[XNLH])?(/MUI:[XNPA])?(/MVC:[XNLH])?(/MVI:[XNLH])?(/MVA:[XNLH])?(/MSC:[XNLH])?(/MSI:[XNLHS])?(/MSA:[XNLHS])?(/S:[XNP])?(/AU:[XNY])?(/R:[XAUI])?(/V:[XDC])?(/RE:[XLMH])?(/U:(X|Clear|Green|Amber|Red))?$",
+      "type": "string"
+    },
+    "version": {
+      "description": "CVSS Version",
+      "enum": [
+        "4.0"
+      ],
+      "type": "string"
+    },
+    "vulnAvailabilityImpact": {
+      "$ref": "#/definitions/vulnCiaType"
+    },
+    "vulnConfidentialityImpact": {
+      "$ref": "#/definitions/vulnCiaType"
+    },
+    "vulnIntegrityImpact": {
+      "$ref": "#/definitions/vulnCiaType"
+    },
+    "vulnerabilityResponseEffort": {
+      "$ref": "#/definitions/vulnerabilityResponseEffortType"
+    }
+  },
+  "required": [
+    "version",
+    "vectorString",
+    "baseScore",
+    "baseSeverity"
+  ],
+  "title": "JSON Schema for Common Vulnerability Scoring System version 4.0",
+  "type": "object"
+}

--- a/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
+++ b/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://www.first.org/cvss/cvss-v4.0.json?20231011",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
+  "unevaluatedProperties": false,
   "allOf": [
     {
       "anyOf": [

--- a/csaf_2.1/test/aggregator_schema/run_tests.sh
+++ b/csaf_2.1/test/aggregator_schema/run_tests.sh
@@ -7,6 +7,7 @@ CSAF_STRICT_SCHEMA=${STRICT_BUILD}/csaf_strict_schema.json
 CVSS_20_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v2.0_strict.json
 CVSS_30_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.0_strict.json
 CVSS_31_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.1_strict.json
+CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 PROVIDER_STRICT_SCHEMA=${STRICT_BUILD}/provider_strict_schema.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
@@ -19,7 +20,7 @@ cd `dirname $0`/../../..
 
 validate() {
   printf "%s" "Testing file $1 against schema ${SCHEMA} ... "
-  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CSAF_STRICT_SCHEMA} ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA} ${PROVIDER_STRICT_SCHEMA}; then
+  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CSAF_STRICT_SCHEMA} ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA} ${CVSS_40_STRICT_SCHEMA} ${PROVIDER_STRICT_SCHEMA}; then
     printf "%s\n" SUCCESS
   else
     printf "%s\n" FAILED

--- a/csaf_2.1/test/csaf_schema/run_tests.sh
+++ b/csaf_2.1/test/csaf_schema/run_tests.sh
@@ -6,6 +6,7 @@ CSAF_STRICT_SCHEMA=${STRICT_BUILD}/csaf_strict_schema.json
 CVSS_20_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v2.0_strict.json
 CVSS_30_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.0_strict.json
 CVSS_31_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.1_strict.json
+CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/examples/csaf/$1/*.json
@@ -17,7 +18,7 @@ cd `dirname $0`/../../..
 
 validate() {
   printf "%s" "Testing file $1 against schema ${SCHEMA} ... "
-  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA}; then
+  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA} ${CVSS_40_STRICT_SCHEMA}; then
     printf "%s\n" SUCCESS
   else
     printf "%s\n" FAILED

--- a/csaf_2.1/test/provider_schema/run_tests.sh
+++ b/csaf_2.1/test/provider_schema/run_tests.sh
@@ -6,6 +6,7 @@ CSAF_STRICT_SCHEMA=${STRICT_BUILD}/csaf_strict_schema.json
 CVSS_20_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v2.0_strict.json
 CVSS_30_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.0_strict.json
 CVSS_31_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.1_strict.json
+CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 PROVIDER_STRICT_SCHEMA=${STRICT_BUILD}/provider_strict_schema.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
@@ -18,7 +19,7 @@ cd `dirname $0`/../../..
 
 validate() {
   printf "%s" "Testing file $1 against schema ${SCHEMA} ... "
-  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CSAF_STRICT_SCHEMA} ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA}; then
+  if python3 ${VALIDATOR} ${SCHEMA} $1 ${CSAF_STRICT_SCHEMA} ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA} ${CVSS_40_STRICT_SCHEMA}; then
     printf "%s\n" SUCCESS
   else
     printf "%s\n" FAILED

--- a/csaf_2.1/test/validator.py
+++ b/csaf_2.1/test/validator.py
@@ -1,3 +1,4 @@
+import decimal
 import jsonschema
 from jsonschema.validators import Draft202012Validator
 from referencing import Registry, Resource
@@ -15,20 +16,20 @@ json_referenced_schemas = sys.argv[3:]
 
 with open(json_schema, 'r') as f:
     schema_data = f.read()
-    schema = json.loads(schema_data)
+    schema = json.loads(schema_data, parse_float=decimal.Decimal)
 
 resource = Resource.from_contents(schema)
 registry = Registry().with_resource(resource.id(), resource)
 
 with open(json_input, 'r') as f:
     input_data = f.read()
-    input_obj = json.loads(input_data)
+    input_obj = json.loads(input_data, parse_float=decimal.Decimal)
 
 if len(json_referenced_schemas) > 0:
     for i in json_referenced_schemas:
         with open(i, 'r') as f:
             current_ref_schema_data = f.read()
-            current_ref_schema = json.loads(current_ref_schema_data)
+            current_ref_schema = json.loads(current_ref_schema_data, parse_float=decimal.Decimal)
             current_resource = Resource.from_contents(current_ref_schema)
             registry = registry.combine(Registry().with_resource(current_resource.id().split('?')[0], current_resource))
 

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-03.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-03.json
@@ -1,0 +1,104 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Use of CVSS v2 as the only Scoring System (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:L/AC:L/Au:S/C:C/I:N/A:N",
+            "baseScore": 4.6
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+            "baseScore": 5.7,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+            "baseScore": 4.3
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-13.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-13.json
@@ -1,0 +1,122 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Use of CVSS v2 as the only Scoring System (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:N/SC:H/SI:H/SA:N",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:L/AC:L/Au:S/C:C/I:N/A:N",
+            "baseScore": 4.6
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+            "baseScore": 5.7,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+            "baseScore": 4.3
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "baseScore": 3.1,
+            "baseSeverity": "LOW"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:L/VI:N/VA:N/SC:L/SI:N/SA:N",
+            "baseScore": 2.1,
+            "baseSeverity": "LOW"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (failing example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-03.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-03.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
@@ -1,0 +1,102 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Informative test: Missing CVSS v4.0 (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+            "baseScore": 4.3
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "baseScore": 3.1,
+            "baseSeverity": "LOW"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
@@ -10,7 +10,7 @@
     "title": "Informative test: Informative test: Missing CVSS v4.0 (failing example 4)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-04",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-04",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-11.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-12.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-13.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-13.json
@@ -1,0 +1,56 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
@@ -10,7 +10,7 @@
     "title": "Informative test: Informative test: Missing CVSS v4.0 (valid example 4)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-14",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-14",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
@@ -1,0 +1,114 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Informative test: Missing CVSS v4.0 (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-01-14",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:H/SI:L/SA:N",
+            "baseScore": 6.3,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+            "baseScore": 4.3
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+            "baseScore": 3.1,
+            "baseSeverity": "LOW"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:L/VI:N/VA:N/SC:L/SI:N/SA:N",
+            "baseScore": 2.1,
+            "baseSeverity": "LOW"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative test: Missing CVSS v4.0 (valid example 5)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-15",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        },
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-03.json
@@ -1,0 +1,60 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          }
+        },
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
@@ -51,8 +51,8 @@
           ],
           "cvss_v4": {
             "version": "4.0",
-            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
-            "baseScore": 5.4,
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:N/SC:H/SI:N/SA:N",
+            "baseScore": 4.9,
             "baseSeverity": "MEDIUM"
           }
         }

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        },
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-13.json
@@ -1,0 +1,66 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-14.json
@@ -1,0 +1,64 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-14",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-15.json
@@ -1,0 +1,66 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (valid example 5)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-15",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    },
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (valid example 6)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-16",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          },
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
@@ -51,8 +51,8 @@
           },
           "cvss_v4": {
             "version": "4.0",
-            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
-            "baseScore": 5.3,
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:N/SC:H/SI:N/SA:N",
+            "baseScore": 4.9,
             "baseSeverity": "MEDIUM"
           }
         }

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-17.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-17.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Multiple Scores with same Version per Product (valid example 7)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-07-17",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:S/C:P/I:P/A:N",
+            "baseScore": 5.5
+          },
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N",
+            "baseScore": 6.4,
+            "baseSeverity": "MEDIUM"
+          },
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 6.5
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json
@@ -1,0 +1,49 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "vectorString": "AV:L/AC:L/Au:M/C:C/I:C/A:C",
+            "baseScore": 6.5
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:L/SI:L/SA:L",
+            "baseScore": 5.4
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-11.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-12.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 6.5,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-13.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:L/AC:L/Au:M/C:C/I:C/A:C",
+            "baseScore": 6.5
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-14.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-08-14",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:A/VC:H/VI:H/VA:H/SC:L/SI:L/SA:L",
+            "baseScore": 5.4,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-03.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 6.5
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-04.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 9.3,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json
@@ -1,0 +1,53 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (failing example 5)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-05",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/E:P",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "threatScore": 9.9,
+            "threatSeverity": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-11.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-12.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:L/AC:L/PR:H/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-13.json
@@ -1,0 +1,50 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10.0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-14.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-14",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json
@@ -1,0 +1,53 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 5)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-15",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/E:P",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "threatScore": 9.3,
+            "threatSeverity": "CRITICAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json
@@ -1,0 +1,51 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Invalid CVSS computation (valid example 6)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-09-16",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+            "baseScore": 5.3,
+            "baseSeverity": "MEDIUM"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json
@@ -1,0 +1,59 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "attackVector": "NETWORK",
+            "attackComplexity": "HIGH",
+            "privilegesRequired": "HIGH",
+            "userInteraction": "REQUIRED",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-03.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:POC",
+            "baseScore": 9.0,
+            "accessVector": "NETWORK",
+            "accessComplexity": "HIGH",
+            "authentication": "MULTIPLE",
+            "confidentialityImpact": "PARTIAL",
+            "integrityImpact": "NONE",
+            "availabilityImpact": "COMPLETE",
+            "exploitability": "FUNCTIONAL"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-04.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "attackVector": "LOCAL",
+            "attackComplexity": "HIGH",
+            "attackRequirements": "PRESENT",
+            "privilegesRequired": "NONE",
+            "userInteraction": "PASSIVE",
+            "vulnConfidentialityImpact": "LOW",
+            "vulnIntegrityImpact": "NONE",
+            "vulnAvailabilityImpact": "HIGH",
+            "subConfidentialityImpact": "LOW",
+            "subIntegrityImpact": "HIGH",
+            "subAvailabilityImpact": "NONE"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-11.json
@@ -1,0 +1,59 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-12.json
@@ -1,0 +1,59 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v3": {
+            "version": "3.0",
+            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-13.json
@@ -1,0 +1,57 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v2": {
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C/E:POC",
+            "baseScore": 9.0,
+            "accessVector": "NETWORK",
+            "accessComplexity": "LOW",
+            "authentication": "NONE",
+            "confidentialityImpact": "COMPLETE",
+            "integrityImpact": "COMPLETE",
+            "availabilityImpact": "COMPLETE",
+            "exploitability": "PROOF_OF_CONCEPT"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory test: Inconsistent CVSS (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-10-14",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "scores": [
+        {
+          "products": [
+            "CSAFPID-9080700"
+          ],
+          "cvss_v4": {
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "baseScore": 10.0,
+            "baseSeverity": "CRITICAL",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "attackRequirements": "NONE",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "vulnConfidentialityImpact": "HIGH",
+            "vulnIntegrityImpact": "HIGH",
+            "vulnAvailabilityImpact": "HIGH",
+            "subConfidentialityImpact": "HIGH",
+            "subIntegrityImpact": "HIGH",
+            "subAvailabilityImpact": "HIGH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-07.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-07.json
@@ -1,0 +1,56 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: CVSS for Fixed Products (failing example 7)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-19-07",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "product_status": {
+        "first_fixed": [
+          "CSAFPID-9080700"
+        ]
+      },
+      "scores": [
+        {
+          "cvss_v4": {
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:P/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "version": "4.0"
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-08.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-08.json
@@ -1,0 +1,61 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: CVSS for Fixed Products (failing example 8)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-19-08",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "product_status": {
+        "first_fixed": [
+          "CSAFPID-9080700"
+        ]
+      },
+      "scores": [
+        {
+          "cvss_v4": {
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "modifiedVulnConfidentialityImpact": "NONE",
+            "modifiedVulnIntegrityImpact": "NONE",
+            "modifiedVulnAvailabilityImpact": "NONE",
+            "modifiedSubConfidentialityImpact": "NONE",
+            "modifiedSubIntegrityImpact": "NONE",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:P/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "version": "4.0"
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-18.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-18.json
@@ -1,0 +1,56 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: CVSS for Fixed Products (valid example 8)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-19-18",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "product_status": {
+        "first_fixed": [
+          "CSAFPID-9080700"
+        ]
+      },
+      "scores": [
+        {
+          "cvss_v4": {
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:P/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:N/MVI:N/MVA:N/MSC:N/MSI:N/MSA:N",
+            "version": "4.0"
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json
@@ -1,0 +1,62 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: CVSS for Fixed Products (valid example 9)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-19-19",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "product_status": {
+        "first_fixed": [
+          "CSAFPID-9080700"
+        ]
+      },
+      "scores": [
+        {
+          "cvss_v4": {
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "modifiedVulnConfidentialityImpact": "NONE",
+            "modifiedVulnIntegrityImpact": "NONE",
+            "modifiedVulnAvailabilityImpact": "NONE",
+            "modifiedSubConfidentialityImpact": "NONE",
+            "modifiedSubIntegrityImpact": "NONE",
+            "modifiedSubAvailabilityImpact": "NONE",
+            "vectorString": "CVSS:4.0/AV:L/AC:L/AT:P/PR:H/UI:P/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+            "version": "4.0"
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -107,6 +107,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-01.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json",
+          "valid": false
         }
       ],
       "valid": [
@@ -116,6 +120,14 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-15.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1215,6 +1215,14 @@
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-06.json",
           "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-07.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-08.json",
+          "valid": true
         }
       ],
       "valid": [
@@ -1244,6 +1252,14 @@
         },
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-17.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-18.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -247,6 +247,36 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-01.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-03.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-04.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-11.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-13.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -109,6 +109,14 @@
           "valid": false
         },
         {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-03.json",
+          "valid": false
+        },
+        {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json",
           "valid": false
         }
@@ -120,6 +128,14 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-13.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-14.json",
           "valid": true
         },
         {

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1523,6 +1523,50 @@
           "valid": true
         }
       ]
+    },
+    {
+      "id": "6.3.12",
+      "group": "informative",
+      "failures": [
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-03.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-11.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-12.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-13.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json",
+          "valid": true
+        }
+      ]
     }
   ]
 }

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1285,6 +1285,10 @@
         {
           "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-02.json",
           "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-03.json",
+          "valid": true
         }
       ],
       "valid": [
@@ -1294,6 +1298,10 @@
         },
         {
           "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-12.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-13.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -237,6 +237,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json",
           "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -159,6 +159,36 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-11.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-13.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-14.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -145,6 +145,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json",
           "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-17.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -199,6 +199,44 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-01.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-03.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-04.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-11.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-13.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-14.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -10,7 +10,7 @@ CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE=oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json'
 EXCLUDE_STRICT=oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
 
 FAIL=0
@@ -30,14 +30,14 @@ validate() {
 }
 
 test_all() {
-  for i in $(ls -1 ${TESTPATH} | grep -v $EXCLUDE)
+  for i in $(ls -1 ${TESTPATH} | grep -Ev "${EXCLUDE}")
   do
     validate $i
   done
 }
 
 test_all_strict() {
-  for i in $(ls -1 ${TESTPATH} | grep -v $EXCLUDE | grep -v ${EXCLUDE_STRICT})
+  for i in $(ls -1 ${TESTPATH} | grep -Ev "${EXCLUDE}" | grep -v ${EXCLUDE_STRICT})
   do
     validate $i
   done

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -6,6 +6,7 @@ CSAF_STRICT_SCHEMA=${STRICT_BUILD}/csaf_strict_schema.json
 CVSS_20_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v2.0_strict.json
 CVSS_30_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.0_strict.json
 CVSS_31_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v3.1_strict.json
+CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
@@ -19,7 +20,7 @@ cd `dirname $0`/../../..
 
 validate() {
   printf "%s" "Testing file $1 against schema ${SCHEMA} ... "
-  if python3 $VALIDATOR $SCHEMA $1 ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA}; then
+  if python3 $VALIDATOR $SCHEMA $1 ${CVSS_20_STRICT_SCHEMA} ${CVSS_30_STRICT_SCHEMA} ${CVSS_31_STRICT_SCHEMA} ${CVSS_40_STRICT_SCHEMA}; then
     printf "%s\n" SUCCESS
   else
     printf "%s\n" FAILED

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -10,7 +10,7 @@ CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json'
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json'
 EXCLUDE_STRICT=oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
 
 FAIL=0

--- a/csaf_2.1/test/validator/testcases_json_schema.json
+++ b/csaf_2.1/test/validator/testcases_json_schema.json
@@ -62,7 +62,7 @@
           "title": "Number of the test",
           "description": "Contains the section number of the test in the specification.",
           "type": "string",
-          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[01])|([12]\\.20)|(1\\.2[1-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-3]))$"
+          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.20)|(1\\.2[1-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-3]))$"
         },
         "valid": {
           "title": "List of valid examples",


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/652
- add CVSS v4 to JSON schema
- add CVSS v4.0 to referenced schemas
- add strict version of schema
- adopt test scripts to include CVSS 4.0
- add CVSS 4.0 to informative references
- add CVSS 4.0 to construction principles
- add CVSS 4.0 to `/vulnerabilities[]/scores[]`
- add CVSS 4.0 to tests 6.1.7, 6.1.8, 6.1.9, 6.1.10, 6.3.1
- add new test 6.3.12 to recommend CVSS 4.0
- add test files for  6.1.7, 6.1.8, 6.1.9, 6.1.10, 6.2.19, 6.3.1, 6.3.12
- add CVSS 4.0 to Appendix C regarding size
- add CVRF-CSAF-conversion rule
- add valid example for 6.1.9 to trigger `multipleOf` issue