### PR TITLE
Clarify markdown

### DIFF
--- a/csaf_2.1/prose/edit/src/additional-conventions.md
+++ b/csaf_2.1/prose/edit/src/additional-conventions.md
@@ -47,4 +47,28 @@ they MUST be separated by the Record Separator in accordance with [cite](#RFC746
 
 The keys within a CSAF document SHOULD be sorted alphabetically.
 
+## Usage of Markdown
+
+The use of GitHub-flavoured Markdown is permitted in the following fields:
+
+```
+  /document/acknowledgments[]/summary
+  /document/distribution/text
+  /document/notes[]/text
+  /document/publisher/issuing_authority
+  /document/references[]/summary
+  /document/tracking/revision_history[]/summary
+  /product_tree/product_groups[]/summary
+  /vulnerabilities[]/acknowledgments[]/summary
+  /vulnerabilities[]/involvements[]/summary
+  /vulnerabilities[]/notes[]/text
+  /vulnerabilities[]/references[]/summary
+  /vulnerabilities[]/remediations[]/details
+  /vulnerabilities[]/remediations[]/entitlements[]
+  /vulnerabilities[]/remediations[]/restart_required/details
+  /vulnerabilities[]/threats[]/details
+```
+
+Other fields MUST NOT contain Markdown.
+
 -------

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -12,7 +12,7 @@ CSAF documents are based on JSON, thus the security considerations of [cite](#RF
 In addition, CSAF documents may be rendered by consumers in various human-readable formats like HTML or PDF.
 Thus, for security reasons, CSAF producers and consumers SHALL adhere to the following:
 
-* CSAF producers SHOULD NOT emit messages that contain HTML, even though GitHub-flavoured Markdown is permit.
+* CSAF producers SHOULD NOT emit messages that contain HTML, even though GitHub-flavoured Markdown is permitted.
   To include HTML, source code, or any other content that may be interpreted or executed by a CSAF consumer,
   e.g. to provide a proof-of-concept, the issuing party SHALL use Markdown's fenced code blocks or inline code option.
 * Deeply nested markup can cause a stack overflow in the Markdown processor [cite](#GFMENG).

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -12,7 +12,7 @@ CSAF documents are based on JSON, thus the security considerations of [cite](#RF
 In addition, CSAF documents may be rendered by consumers in various human-readable formats like HTML or PDF.
 Thus, for security reasons, CSAF producers and consumers SHALL adhere to the following:
 
-* CSAF producers SHOULD NOT emit messages that contain HTML, even though all variants of Markdown permit it.
+* CSAF producers SHOULD NOT emit messages that contain HTML, even though GitHub-flavoured Markdown is permit.
   To include HTML, source code, or any other content that may be interpreted or executed by a CSAF consumer,
   e.g. to provide a proof-of-concept, the issuing party SHALL use Markdown's fenced code blocks or inline code option.
 * Deeply nested markup can cause a stack overflow in the Markdown processor [cite](#GFMENG).


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/629
- clearly state that GitHub-flavoured Markdown is allowed
- explicitly mention fields that may contain Markdown