### PR TITLE
purl

### DIFF
--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -65,7 +65,7 @@ OPENSSL
 :    _GTLS/SSL and crypto library_, OpenSSL Software Foundation, https://www.openssl.org/.
 
 PURL
-:    _Package URL (PURL)_, GitHub Project, https://github.com/package-url/purl-spec.
+:    _Package URL (purl)_, GitHub Project, https://github.com/package-url/purl-spec.
 
 RFC3339
 :    Klyne, G. and C. Newman, "Date and Time on the Internet: Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
@@ -118,7 +118,7 @@ SPDX22
 https://spdx.github.io/spdx-spec/.
 
 VERS
-:    _vers: a mostly universal version range specifier_, Part of the PURL GitHub Project,
+:    _vers: a mostly universal version range specifier_, Part of the purl GitHub Project,
 https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst.
 
 VEX

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -238,20 +238,20 @@ Two `*` MUST NOT follow each other.
     IC25T060ATCS05-0
 ```
 
-##### Full Product Name Type - Product Identification Helper - PURL
+##### Full Product Name Type - Product Identification Helper - purl
 
-The package URL (PURL) representation (`purl`) is a `string` of 7 or more characters with `pattern` (regular expression):
+The package URL (purl) representation (`purl`) is a `string` of 7 or more characters with `pattern` (regular expression):
 
 ```
     ^pkg:[A-Za-z\\.\\-\\+][A-Za-z0-9\\.\\-\\+]*/.+
 ```
 
-> The given pattern does not completely evaluate whether a PURL is valid according to the [cite](#PURL) specification.
+> The given pattern does not completely evaluate whether a purl is valid according to the [cite](#PURL) specification.
 > It provides a more generic approach and general guidance to enable forward compatibility.
-> CSAF uses only the canonical form of PURL to conform with section 3.3 of [cite](#RFC3986).
+> CSAF uses only the canonical form of purl to conform with section 3.3 of [cite](#RFC3986).
 > Therefore, URLs starting with `pkg://` are considered invalid.
 
-This package URL (PURL) attribute refers to a method for reliably identifying and locating software packages external to this specification.
+This package URL (purl) attribute refers to a method for reliably identifying and locating software packages external to this specification.
 See [cite](#PURL) for details.
 
 ##### Full Product Name Type - Product Identification Helper - SBOM URLs

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
@@ -1,6 +1,6 @@
-### PURL
+### purl
 
-It MUST be tested that given PURL is valid.
+It MUST be tested that given purl is valid.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
@@ -1,4 +1,4 @@
-### purl
+### PURL
 
 It MUST be tested that given purl is valid.
 


### PR DESCRIPTION
- resolves oasis-tcs/csaf#579
- use purl as lowercase (but not the references)