### PR TITLE
CVSS 4.0

### DIFF
--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-03-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-03-vulnerabilities.md
@@ -750,7 +750,8 @@ Valid values are:
 The value `exploit_status` indicates that the `details` field contains a description of the degree to which an exploit for the vulnerability is known.
 This knowledge can range from information privately held among a very small group to an issue that has been described to the public at
 a major conference or is being widely exploited globally.
-For consistency and simplicity, this section can be a mirror image of the CVSS "Exploitability" metric.
+For consistency and simplicity, this section can be a mirror image of the CVSS `exploitMaturity` (v4.0),
+respectively `exploitCodeMaturity` (v3.1 and v3.0) or `exploitability` (v2.0) metric.
 However, it can also contain a more contextual status, such as "Weaponized" or "Functioning Code".
 
 The value `impact` indicates that the `details` field contains an assessment of the impact on the user or the target set if

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -412,8 +412,6 @@ The relevant paths for this test are:
 
 > The product version starts with a `v`.
 
--------
-
 ### Missing CVSS v4.0
 
 For each item in the list of scores it MUST be tested that a `cvss_v4` object is present.
@@ -455,3 +453,5 @@ The relevant path for this test is:
 ```
 
 > There is no CVSS v4.0 score given for `CSAFPID-9080700`.
+
+-------


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/652
- explicitly mention names of Exploitability throughout the different CVSS versions
- addresses parts of https://github.com/oasis-tcs/csaf/pull/699
- correct location of section separator