### PR TITLE
CPE tests

### DIFF
--- a/csaf_2.0/test/cpe/run_tests.sh
+++ b/csaf_2.0/test/cpe/run_tests.sh
@@ -20,7 +20,7 @@ get_dictionary() {
 prepare_23_dictionary() {
   # Get CPE 2.3 fields
   # Correctly decode special characters
-  grep '<cpe-23:cpe23-item name=' "$CPE".xml | sed -e 's/^.*<cpe-23:cpe23-item name="//' -e 's/"\/>$//' \
+  grep '<cpe-23:cpe23-item name=' "$CPE".xml | sed -e 's/^.*<cpe-23:cpe23-item name="//' -e 's/"\/\?>$//' \
     | sed -e 's/\\&amp;/\\\&/g' \
     | sed -e 's/\\&quot;/\\"/g' \
     > "$CPE".txt


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#710
- backport of 61e78c8
- correct parsing of CPE 2.3 Dictionary (to also capture endings `">` instead of just `"/>`)