### PR TITLE
Editor revision 2024 03 27

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -473,7 +473,7 @@ A CSAF SBOM matching system satisfies the "CSAF SBOM matching system" conformanc
   A switch to mark all SBOM component at once MAY be implemented.
 * does not bring up a newer revision of a CSAF document as a new match if the remediation for the matched SBOM or SBOM component has not changed.
 * detects the usage semantic version (as described in section [sec](#version-type-semantic-versioning)).
-* is able to trigger a run of the asset matching module:
+* is able to trigger a run of the SBOM matching module:
   * manually:
     * per CSAF document
     * per list of CSAF documents

--- a/csaf_2.1/prose/edit/src/frontmatter.md
+++ b/csaf_2.1/prose/edit/src/frontmatter.md
@@ -55,7 +55,7 @@ This specification replaces or supersedes:
 
 
 #### Abstract:
-The Common Security Advisory Framework (CSAF) Version 2.0 is the definitive reference for the language which supports creation, update, and interoperable exchange of security advisories as structured information on products, vulnerabilities and the status of impact and remediation among interested parties.
+The Common Security Advisory Framework (CSAF) Version 2.1 is the definitive reference for the language which supports creation, update, and interoperable exchange of security advisories as structured information on products, vulnerabilities and the status of impact and remediation among interested parties.
 
 #### Status:
 This document was last revised or approved by the membership of OASIS on the above date. The level of approval is also listed above. Check the "Latest stage" location noted above for possible later revisions of this document. Any other numbered Versions and other technical work produced by the Technical Committee (TC) are listed at https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=csaf#technical.

--- a/csaf_2.1/prose/edit/src/frontmatter.md
+++ b/csaf_2.1/prose/edit/src/frontmatter.md
@@ -7,7 +7,7 @@
 
 ## Committee Specification Draft 01
 
-## 28 February 2024
+## 27 March 2024
 
 #### This stage:
 https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.md (Authoritative) \
@@ -71,7 +71,7 @@ When referencing this specification the following citation format should be used
 
 **[csaf-v2.1]**
 
-_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 28 February 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
+_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 27 March 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
 
 
 -------

--- a/csaf_2.1/prose/edit/src/revision-history.md
+++ b/csaf_2.1/prose/edit/src/revision-history.md
@@ -12,4 +12,5 @@ toc:
 |:-------------------------|:-----------|:--------------------------------|:--------------------------------------------------------------------------------------|
 | csaf-v2.0-wd20240124-dev | 2024-01-24 | Stefan Hagen and Thomas Schmidt | Preparing initial Editor Revision |
 | csaf-v2.0-wd20240228-dev | 2024-02-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
+| csaf-v2.0-wd20240327-dev | 2024-03-27 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 -------


### PR DESCRIPTION
- update dates
- insert new revision for tracking
- update overlooked CSAF 2.0 to 2.1
- resolves https://github.com/oasis-tcs/csaf/issues/708
- correct copy-paste mistake "asset" => "SBOM"