### PR TITLE
Mandatory TLP 2.0

### DIFF
--- a/csaf_2.1/examples/ROLIE/example-01-category.json
+++ b/csaf_2.1/examples/ROLIE/example-01-category.json
@@ -2,10 +2,10 @@
   "categories": {
     "category": [
       {
-          "term": "Example Company Product A"
+        "term": "Example Company Product A"
       },
       {
-          "term": "Example Company Product B"
+        "term": "Example Company Product B"
       }
     ]
   }

--- a/csaf_2.1/examples/ROLIE/example-01-feed-tlp-white.json
+++ b/csaf_2.1/examples/ROLIE/example-01-feed-tlp-white.json
@@ -1,11 +1,11 @@
 {
   "feed": {
-    "id": "example-csaf-feed-tlp-white",
-    "title": "Example CSAF feed (TLP:WHITE)",
+    "id": "example-csaf-feed-tlp-clear",
+    "title": "Example CSAF feed (TLP:CLEAR)",
     "link": [
       {
         "rel": "self",
-        "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-white.json"
+        "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-clear.json"
       }
     ],
     "category": [

--- a/csaf_2.1/examples/ROLIE/example-01-service.json
+++ b/csaf_2.1/examples/ROLIE/example-01-service.json
@@ -5,8 +5,8 @@
         "title": "Public CSAF feed",
         "collection": [
           {
-            "title": "Example CSAF feed (TLP:WHITE)",
-            "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-white.json",
+            "title": "Example CSAF feed (TLP:CLEAR)",
+            "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-clear.json",
             "categories": {
               "category": [
                 {

--- a/csaf_2.1/examples/ROLIE/example-02-service.json
+++ b/csaf_2.1/examples/ROLIE/example-02-service.json
@@ -5,8 +5,8 @@
         "title": "Public CSAF feed",
         "collection": [
           {
-            "title": "Example CSAF feed (TLP:WHITE)",
-            "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-white.json",
+            "title": "Example CSAF feed (TLP:CLEAR)",
+            "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-clear.json",
             "categories": {
               "category": [
                 {

--- a/csaf_2.1/examples/csaf/bsi-2022-0001.json
+++ b/csaf_2.1/examples/csaf/bsi-2022-0001.json
@@ -7,7 +7,7 @@
     "csaf_version": "2.1",
     "distribution": {
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/csaf/cisco-sa-20180328-smi2.json
+++ b/csaf_2.1/examples/csaf/cisco-sa-20180328-smi2.json
@@ -3,6 +3,13 @@
     "title": "Cisco IOS and IOS XE Software Smart Install Remote Code Execution Vulnerability",
     "category": "Cisco Security Advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "distribution": {
+        "tlp": {
+          "label": "CLEAR"
+        }
+      }
+    },
     "publisher": {
       "category": "vendor",
       "contact_details": "Emergency Support:\n+1 877 228 7302 (toll-free within North America)\n+1 408 525 6532 (International direct-dial)\nNon-emergency Support:\nEmail: psirt@cisco.com\nSupport requests that are received via e-mail are typically acknowledged within 48 hours.",

--- a/csaf_2.1/examples/csaf/cisco-sa-20180328-smi2.json
+++ b/csaf_2.1/examples/csaf/cisco-sa-20180328-smi2.json
@@ -4,10 +4,8 @@
     "category": "Cisco Security Advisory",
     "csaf_version": "2.1",
     "distribution": {
-      "distribution": {
-        "tlp": {
-          "label": "CLEAR"
-        }
+      "tlp": {
+        "label": "CLEAR"
       }
     },
     "publisher": {

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-a-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-a-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-f-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-f-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-na-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-na-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-ui-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-01-ui-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-02-na-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-02-na-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-03-ms-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-03-ms-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-04-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-04-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-05-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-05-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-06-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-06-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-07-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-07-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-08-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-08-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-09-001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/2022-evd-uc-09-001.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/examples/csaf/csaf_vex/sec-vex-2022-0001.json
+++ b/csaf_2.1/examples/csaf/csaf_vex/sec-vex-2022-0001.json
@@ -4,7 +4,7 @@
     "csaf_version": "2.1",
     "distribution": {
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/csaf/rhsa-2019_1862.json
+++ b/csaf_2.1/examples/csaf/rhsa-2019_1862.json
@@ -9,7 +9,7 @@
     "distribution": {
       "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/csaf/rhsa-2021_5186.json
+++ b/csaf_2.1/examples/csaf/rhsa-2021_5186.json
@@ -9,7 +9,7 @@
     "distribution": {
       "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/csaf/rhsa-2021_5217.json
+++ b/csaf_2.1/examples/csaf/rhsa-2021_5217.json
@@ -9,7 +9,7 @@
     "distribution": {
       "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/csaf/rhsa-2022_0011.json
+++ b/csaf_2.1/examples/csaf/rhsa-2022_0011.json
@@ -9,7 +9,7 @@
     "distribution": {
       "text": "Copyright \u00a9 2022 Red Hat, Inc. All rights reserved.",
       "tlp": {
-        "label": "WHITE",
+        "label": "CLEAR",
         "url": "https://www.first.org/tlp/"
       }
     },

--- a/csaf_2.1/examples/provider-metadata/example-01-provider-metadata.json
+++ b/csaf_2.1/examples/provider-metadata/example-01-provider-metadata.json
@@ -5,9 +5,9 @@
       "rolie": {
         "feeds": [
           {
-            "summary": "All TLP:WHITE advisories of Example Company.",
-            "tlp_label": "WHITE",
-            "url": "https://www.example.com/.well-known/csaf/feed-tlp-white.json"
+            "summary": "All TLP:CLEAR advisories of Example Company.",
+            "tlp_label": "CLEAR",
+            "url": "https://www.example.com/.well-known/csaf/feed-tlp-clear.json"
           }
         ]
       }

--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -503,6 +503,7 @@
       "required": [
         "category",
         "csaf_version",
+        "distribution",
         "publisher",
         "title",
         "tracking"
@@ -565,7 +566,9 @@
           "title": "Rules for sharing document",
           "description": "Describe any constraints on how this document might be shared.",
           "type": "object",
-          "minProperties": 1,
+          "required": [
+            "tlp"
+          ],
           "properties": {
             "text": {
               "title": "Textual description",

--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -592,9 +592,10 @@
                   "type": "string",
                   "enum": [
                     "AMBER",
+                    "AMBER+STRICT",
+                    "CLEAR",
                     "GREEN",
-                    "RED",
-                    "WHITE"
+                    "RED"
                   ]
                 },
                 "url": {

--- a/csaf_2.1/json_schema/provider_json_schema.json
+++ b/csaf_2.1/json_schema/provider_json_schema.json
@@ -98,7 +98,7 @@
                       "description": "Contains a summary of the feed.",
                       "type": "string",
                       "examples": [
-                        "All TLP:WHITE advisories of Example Company."
+                        "All TLP:CLEAR advisories of Example Company."
                       ]
                     },
                     "tlp_label": {
@@ -107,9 +107,10 @@
                       "type": "string",
                       "enum": [
                         "UNLABELED",
-                        "WHITE",
+                        "CLEAR",
                         "GREEN",
                         "AMBER",
+                        "AMBER+STRICT",
                         "RED"
                       ]
                     },

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -519,6 +519,8 @@ Secondly, the program fulfills the following for all items of:
   both values: the converted one based on the table and the one from the distribution text.
   > This is a common case for CSAF 2.0 documents labeled as TLP:RED but actually intended to be TLP:AMBER+STRICT.
 
+  If no TLP label was given, the CSAF 2.0 to CSAF 2.1 converter SHOULD assign `TLP:CLEAR` and output a warning that the default TLP has been set.
+
 > A tool MAY implement options to convert other Markdown formats to GitHub-flavoured Markdown.
 
 > A tool MAY implement an additional, non-default option to output an invalid document that can be fixed afterwards. Solely in this case, any

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -504,6 +504,20 @@ Secondly, the program fulfills the following for all items of:
 
 * type `/$defs/full_product_name_t/cpe`: If a CPE is invalid, the CSAF 2.0 to CSAF 2.1 converter SHOULD removed the invalid value and output a
   warning that an invalid CPE was detected and removed. Such a warning MUST include the invalid CPE.
+* `/document/distribution/tlp/label`: If a TLP label is given, the CSAF 2.0 to CSAF 2.1 converter MUST convert it according to the table below:
+  
+  | CSAF 2.0 (using TLP v1.0) | CSAF 2.1 (using TLP v2.0) |
+  |---------------------------|---------------------------|
+  | `TLP:WHITE`               | `TLP:CLEAR`               |
+  | `TLP:GREEN`               | `TLP:GREEN`               |
+  | `TLP:AMBER`               | `TLP:AMBER`               |
+  | `TLP:RED`                 | `TLP:RED`                 |
+
+  If `/document/distribution/text` contains the string `TLP v2.0: TLP:<ValidTLPLabel>`, the CSAF 2.0 to CSAF 2.1 converter SHOULD provide an
+  option to use this label instead. If the TLP label changes through such conversion in a way that is not reflected in the table above, the
+  the CSAF 2.0 to CSAF 2.1 converter MUST output a warning that the TLP label was taken from the distribution text. Such a warning MUST include
+  both values: the converted one based on the table and the one from the distribution text.
+  > This is a common case for CSAF 2.0 documents labeled as TLP:RED but actually intended to be TLP:AMBER+STRICT.
 
 > A tool MAY implement options to convert other Markdown formats to GitHub-flavoured Markdown.
 

--- a/csaf_2.1/prose/edit/src/distributing.md
+++ b/csaf_2.1/prose/edit/src/distributing.md
@@ -25,9 +25,9 @@ The CSAF document is per default retrievable from a website which uses TLS for e
 The CSAF document MUST NOT be downloadable from a location which does not encrypt the transport when crossing organizational
 boundaries to maintain the chain of custody.
 
-### Requirement 4: TLP:WHITE
+### Requirement 4: TLP:CLEAR
 
-If the CSAF document is labeled TLP:WHITE, it MUST be freely accessible.
+If the CSAF document is labeled TLP:CLEAR, it MUST be freely accessible.
 
 This does not exclude that such a document is also available in an access protected customer portal.
 However, there MUST be one copy of the document available for people without access to the portal.
@@ -35,10 +35,10 @@ However, there MUST be one copy of the document available for people without acc
 > Reasoning: If an advisory is already in the media, an end user should not be forced to collect the pieces of information from a
 > press release but be able to retrieve the CSAF document.
 
-### Requirement 5: TLP:AMBER and TLP:RED
+### Requirement 5: TLP:AMBER, TLP:AMBER+STRICT and TLP:RED
 
-CSAF documents labeled TLP:AMBER or TLP:RED MUST be access protected.
-If they are provided via a web server this SHALL be done under a different path than for TLP:WHITE,
+CSAF documents labeled TLP:AMBER, TLP:AMBER+STRICT or TLP:RED MUST be access protected.
+If they are provided via a web server this SHALL be done under a different path than for TLP:CLEAR,
 TLP:GREEN and unlabeled CSAF documents. TLS client authentication, access tokens or any other automatable authentication method SHALL be used.
 
 An issuing party MAY agree with the recipients to use any kind of secured drop at the recipients' side to avoid putting them on their own website.
@@ -80,9 +80,9 @@ CSAF aggregator SHOULD display over any individual `publisher` values in the CSA
         "rolie": {
           "feeds": [
             {
-              "summary": "All TLP:WHITE advisories of Example Company.",
-              "tlp_label": "WHITE",
-              "url": "https://www.example.com/.well-known/csaf/feed-tlp-white.json"
+              "summary": "All TLP:CLEAR advisories of Example Company.",
+              "tlp_label": "CLEAR",
+              "url": "https://www.example.com/.well-known/csaf/feed-tlp-clear.json"
             }
           ]
         }
@@ -215,7 +215,7 @@ ROLIE is built on top of the Atom Publishing Format and Protocol, with specific 
 All CSAF documents with the same TLP level MUST be listed in a single ROLIE feed.
 At least one of the feeds
 
-* TLP:WHITE
+* TLP:CLEAR
 * TLP:GREEN
 * unlabeled
 
@@ -227,12 +227,12 @@ Each ROLIE feed document MUST be a JSON file that conforms with [cite](#RFC8322)
 ```
   {
     "feed": {
-      "id": "example-csaf-feed-tlp-white",
-      "title": "Example CSAF feed (TLP:WHITE)",
+      "id": "example-csaf-feed-tlp-clear",
+      "title": "Example CSAF feed (TLP:CLEAR)",
       "link": [
         {
           "rel": "self",
-          "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-white.json"
+          "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-clear.json"
         }
       ],
       "category": [
@@ -299,8 +299,8 @@ If it is used, each ROLIE service document MUST be a JSON file that conforms wit
           "title": "Public CSAF feed",
           "collection": [
             {
-              "title": "Example CSAF feed (TLP:WHITE)",
-              "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-white.json",
+              "title": "Example CSAF feed (TLP:CLEAR)",
+              "href": "https://psirt.domain.tld/advisories/csaf/feed-tlp-clear.json",
               "categories": {
                 "category": [
                   {

--- a/csaf_2.1/prose/edit/src/frontmatter.md
+++ b/csaf_2.1/prose/edit/src/frontmatter.md
@@ -7,7 +7,7 @@
 
 ## Committee Specification Draft 01
 
-## 27 March 2024
+## 24 April 2024
 
 #### This stage:
 https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.md (Authoritative) \
@@ -71,7 +71,7 @@ When referencing this specification the following citation format should be used
 
 **[csaf-v2.1]**
 
-_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 27 March 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
+_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 24 April 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
 
 
 -------

--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -283,7 +283,7 @@ A string which is an enum has a fixed maximum length given by its longest value.
 It seems to be safe to assume that the length of each value is not greater than 50. This applies to:
 
 * `/document/csaf_version` (3)
-* `/document/distribution/tlp/label` (5)
+* `/document/distribution/tlp/label` (12)
 * `/document/notes[]/category` (16)
 * `/document/publisher/category` (11)
 * `/document/references[]/category` (8)

--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -29,6 +29,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 * The following elements MUST exist and be valid:
   * `/document/category`
   * `/document/csaf_version`
+  * `/document/distribution/tlp/label`
   * `/document/publisher/category`
   * `/document/publisher/name`
   * `/document/publisher/namespace`

--- a/csaf_2.1/prose/edit/src/revision-history.md
+++ b/csaf_2.1/prose/edit/src/revision-history.md
@@ -13,4 +13,5 @@ toc:
 | csaf-v2.0-wd20240124-dev | 2024-01-24 | Stefan Hagen and Thomas Schmidt | Preparing initial Editor Revision |
 | csaf-v2.0-wd20240228-dev | 2024-02-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 | csaf-v2.0-wd20240327-dev | 2024-03-27 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
+| csaf-v2.0-wd20240424-dev | 2024-04-24 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 -------

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
@@ -190,10 +190,15 @@ Valid values of the `enum` are:
 
 ```
     AMBER
+    AMBER+STRICT
+    CLEAR
     GREEN
     RED
-    WHITE
 ```
+
+> Note: In the TLP specification there are only 4 labels. The part `+STRICT` is an extension to `TLP:AMBER`.
+> To simplify the JSON structure, avoid additional business level tests and aid in parsing, consumption and
+> processing, it is provided as a label to be selected instead of having a separate field.
 
 The URL of TLP version (`url`) with value type `string` with format `uri` provides a URL where to find
 the textual description of the TLP version which is used in this document.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
@@ -1,11 +1,11 @@
 ### Document Property
 
-Document level meta-data (`document`) of value type `object` with the 5 mandatory properties Category (`category`),
-CSAF Version (`csaf_version`), Publisher (`publisher`), Title (`title`),
+Document level meta-data (`document`) of value type `object` with the 6 mandatory properties Category (`category`),
+CSAF Version (`csaf_version`), Distribution (`distribution`), Publisher (`publisher`), Title (`title`),
 and  Tracking (`tracking`) captures the meta-data about this document describing a particular set of security advisories.
-In addition, the `document` object MAY provide the 7 optional properties Acknowledgments (`acknowledgments`),
-Aggregate Severity (`aggregate_severity`), Distribution (`distribution`), Language (`lang`), Notes (`notes`),
-References (`references`), and Source Language (`source_lang`).
+In addition, the `document` object MAY provide the 6 optional properties Acknowledgments (`acknowledgments`),
+Aggregate Severity (`aggregate_severity`), Language (`lang`), Notes (`notes`), References (`references`),
+and Source Language (`source_lang`).
 
 ```
     "document": {
@@ -135,8 +135,8 @@ The single valid value for this `enum` is:
 
 #### Document Property - Distribution
 
-Rules for sharing document (`distribution`) of value type `object` with at least 1 of the 2 properties Text (`text`) and
-Traffic Light Protocol (TLP) (`tlp`) describes any constraints on how this document might be shared.
+Rules for sharing document (`distribution`) of value type `object` with the mandatory property Traffic Light Protocol (TLP) (`tlp`) and the
+optional property Text (`text`) describes any constraints on how this document might be shared.
 
 ```
     "distribution": {
@@ -161,7 +161,7 @@ The Textual description (`text`) of value type `string` with 1 or more character
 *Examples 1:*
 
 ```
-    Copyright 2021, Example Company, All Rights Reserved.
+    Copyright 2024, Example Company, All Rights Reserved.
     Distribute freely.
     Share only on a need-to-know-basis only.
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -399,6 +399,11 @@ The relevant path for this test is:
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       // ...
     },

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -320,7 +320,7 @@ The relevant paths for this test are:
 
 > The hash algorithm `sha1` is used in one item of hashes without being accompanied by a second hash algorithm.
 
-### Missing TLP label
+### Missing TLP label (deprecated)
 
 It MUST be tested that `/document/distribution/tlp/label` is present and valid.
 

--- a/csaf_2.1/test/filenames/data/invalid/OASIS_CSAF_TC-CSAF_2.1-2024-5-1-01.json
+++ b/csaf_2.1/test/filenames/data/invalid/OASIS_CSAF_TC-CSAF_2.1-2024-5-1-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/filenames/data/invalid/oasis-open_csaf_tc-csaf_21-2024-5-1-02.json
+++ b/csaf_2.1/test/filenames/data/invalid/oasis-open_csaf_tc-csaf_21-2024-5-1-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/filenames/data/invalid/oasis____csaf_tc-csaf_2_1-2024-5-1-03.json
+++ b/csaf_2.1/test/filenames/data/invalid/oasis____csaf_tc-csaf_2_1-2024-5-1-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-11.json
+++ b/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-12.json
+++ b/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-13.json
+++ b/csaf_2.1/test/filenames/data/valid/oasis_csaf_tc-csaf_2_1-2024-5-1-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-03.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-13.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-02.json
@@ -10,6 +10,11 @@
     ],
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en",
     "notes": [
       {

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en",
     "notes": [
       {

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-03.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-04.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-05.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-06.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-13.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-14.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-15.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-03.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-13.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-02-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-02-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-05-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-05-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-17.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-17.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-12-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-12-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "EZ",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-06.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-07.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-07.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-08.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-08.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-17.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-17.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-18.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-18.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-19.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-19.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "translator",
       "name": "OASIS CSAF TC Translator",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "translator",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "translator",
       "name": "OASIS CSAF TC Translator",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "translator",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-06.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-07.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-07.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-08.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-08.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-17.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-17.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-18.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-18.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-19.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-19.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-31.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-31.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-17-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-17-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-18-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-18-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-20-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-20-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-22-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-22-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-23-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-23-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "Security_Incident_Response",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-01-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-01-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_security_incident_response",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "legal_disclaimer",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-02-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-02-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_informational_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_informational_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_security_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_security_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_security_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-07-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-07-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-06.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-16.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-10-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-10-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_vex",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-11-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-11-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_security_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-05.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-06.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-07.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-07.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-08.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-08.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-09.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-09.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/oasis_csaf_tc-csaf_2_1-2024-TEMPLATE.json
+++ b/csaf_2.1/test/validator/data/oasis_csaf_tc-csaf_2_1-2024-TEMPLATE.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-01-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-01-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-01-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-01-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_informational_advisory",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "notes": [
       {
         "category": "summary",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-02-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-02-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-03-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-03-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-05-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-05-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-07-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-07-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-08-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-08-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-08-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-08-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-09-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-09-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-09-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-09-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-11-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-11-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-11-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-11-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-13-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-13-01.json
@@ -2,6 +2,11 @@
   "document": {
     "csaf_version": "2.1",
     "category": "csaf_base",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "qtx",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "qdq",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-QM",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-05.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-XP",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-06.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-Qabc",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-07.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-07.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-AA",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-08.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-08.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "fr-ZZ",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-14-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en-US",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "i-default",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-15-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "lang": "en",
     "publisher": {
       "category": "other",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-16-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-17-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-17-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-17-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-17-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-18-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-18-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-18-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-18-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-01.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-02.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-03.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-04.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-05.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-05.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-06.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-06.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-07.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-07.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-08.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-08.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-11.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-12.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-13.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-14.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-14.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-15.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-15.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-16.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-16.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-17.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-17.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-18.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-18.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json
@@ -2,6 +2,11 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
@@ -3,6 +3,11 @@
     "category": "csaf_base",
     "csaf_version": "2.1",
     "custom_property": "any",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
     "publisher": {
       "category": "other",
       "name": "OASIS CSAF TC",

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -10,7 +10,7 @@ CVSS_40_STRICT_SCHEMA=csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json'
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json'
 EXCLUDE_STRICT=oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
 
 FAIL=0


### PR DESCRIPTION
### Addresses parts of https://github.com/oasis-tcs/csaf/issues/591
- change schema to use TLP 2.0
- adapt prose to reflect schema
- add TLP:AMBER+STRICT in appropriate places
- add conversion rule
- update PMD schema
- update example files
### Addresses parts of https://github.com/oasis-tcs/csaf/issues/633
- adapt prose to reflect schema
- add `/document/distribution/tlp/label` in CSAF base profile
- mark test 6.2.10 as deprecated
- add conversion rule
- correct examples
- add TLP label
- add `/document/distribution/tlp` to validator test data
- add `/document/distribution/tlp` to filename test data
- adapt prose to reflect current test files
- exclude deprecated test 6.2.10