### PR TITLE
`TLP:CLEAR` as default

### DIFF
--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -594,6 +594,7 @@
                   "title": "Label of TLP",
                   "description": "Provides the TLP label of the document.",
                   "type": "string",
+                  "default": "CLEAR",
                   "enum": [
                     "AMBER",
                     "AMBER+STRICT",

--- a/csaf_2.1/prose/edit/src/frontmatter.md
+++ b/csaf_2.1/prose/edit/src/frontmatter.md
@@ -7,7 +7,7 @@
 
 ## Committee Specification Draft 01
 
-## 24 April 2024
+## 29 May 2024
 
 #### This stage:
 https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.md (Authoritative) \
@@ -71,7 +71,7 @@ When referencing this specification the following citation format should be used
 
 **[csaf-v2.1]**
 
-_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 24 April 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
+_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen, and Thomas Schmidt. 29 May 2024. OASIS Committee Specification Draft 01. https://docs.oasis-open.org/csaf/csaf/v2.1/csd01/csaf-v2.1-csd01.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
 
 
 -------

--- a/csaf_2.1/prose/edit/src/revision-history.md
+++ b/csaf_2.1/prose/edit/src/revision-history.md
@@ -14,4 +14,5 @@ toc:
 | csaf-v2.0-wd20240228-dev | 2024-02-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 | csaf-v2.0-wd20240327-dev | 2024-03-27 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 | csaf-v2.0-wd20240424-dev | 2024-04-24 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
+| csaf-v2.0-wd20240529-dev | 2024-05-29 | Stefan Hagen and Thomas Schmidt | Next Editor Revision |
 -------

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-01-document.md
@@ -200,6 +200,11 @@ Valid values of the `enum` are:
 > To simplify the JSON structure, avoid additional business level tests and aid in parsing, consumption and
 > processing, it is provided as a label to be selected instead of having a separate field.
 
+The default value for `label` is `CLEAR`.
+
+> Note: This provides the suggested default value for anyone writing CSAF documents as the majority of those
+> are intended to be publicly available.
+
 The URL of TLP version (`url`) with value type `string` with format `uri` provides a URL where to find
 the textual description of the TLP version which is used in this document.
 The default value is the URL to the definition by FIRST:


### PR DESCRIPTION
- resolves https://github.com/oasis-tcs/csaf/issues/721
- set TLP label `CLEAR` as default
- add reasoning