### PR TITLE
Same timestamps

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-14-sorted-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-14-sorted-revision-history.md
@@ -1,6 +1,7 @@
 ### Sorted Revision History
 
-It MUST be tested that the value of `number` of items of the revision history are sorted ascending when the items are sorted ascending by `date`.
+It MUST be tested that the value of `number` of items of the revision history are sorted ascending when the items are sorted
+ascending by `date` and as a second level criteria `number`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-16-latest-document-version.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-16-latest-document-version.md
@@ -1,7 +1,8 @@
 ### Latest Document Version
 
-It MUST be tested that document version has the same value as the `number` in the last item of Revision History when
-it is sorted ascending by `date`. Build metadata is ignored in the comparison.
+It MUST be tested that document version has the same value as the `number` in the last item of the revision history when
+it is sorted ascending by `date` and as a second level criteria `number`.
+Build metadata is ignored in the comparison.
 Any pre-release part is also ignored if the document status is `draft`.
 
 The relevant path for this test is:


### PR DESCRIPTION
- resolves https://github.com/oasis-tcs/csaf/issues/628
- add `number` as second level sorting field in 6.1.16
- unify phrasing to match 6.1.14
- resolves https://github.com/oasis-tcs/csaf/issues/647
- add `number` as second level sorting field in 6.1.14