### PR TITLE
TLP 2.0 in PMD

### DIFF
--- a/csaf_2.1/json_schema/provider_json_schema.json
+++ b/csaf_2.1/json_schema/provider_json_schema.json
@@ -53,10 +53,26 @@
         "type": "object",
         "minProperties": 1,
         "properties": {
-          "directory_url": {
-            "title": "Directory URL",
-            "description": "Contains the base url for the directory distribution.",
-            "$ref": "#/$defs/url_t"
+          "directory": {
+            "title": "Directory",
+            "description": "Contains all information for directory-based distribution.",
+            "type": "object",
+            "required": [
+              "tlp_label",
+              "url"
+            ],
+            "properties": {
+              "tlp_label": {
+                "title": "TLP label",
+                "description": "Provides the TLP label for the directory.",
+                "$ref": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json#/properties/document/properties/distribution/properties/tlp/properties/label"
+              },
+              "url": {
+                "title": "Directory URL",
+                "description": "Contains the base url for the directory-based distribution.",
+                "$ref": "#/$defs/url_t"
+              }
+            }
           },
           "rolie": {
             "title": "ROLIE",

--- a/csaf_2.1/json_schema/provider_json_schema.json
+++ b/csaf_2.1/json_schema/provider_json_schema.json
@@ -104,15 +104,7 @@
                     "tlp_label": {
                       "title": "TLP label",
                       "description": "Provides the TLP label for the feed.",
-                      "type": "string",
-                      "enum": [
-                        "UNLABELED",
-                        "CLEAR",
-                        "GREEN",
-                        "AMBER",
-                        "AMBER+STRICT",
-                        "RED"
-                      ]
+                      "$ref": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json#/properties/document/properties/distribution/properties/tlp/properties/label"
                     },
                     "url": {
                       "title": "URL of the feed",


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/633
- adapt provider-metadata.json to use only TLP 2.0
- add TLP also to directory-based distribution