### PR TITLE
CWE: Optional tests

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -795,7 +795,7 @@ The relevant path for this test is:
       ]
 ```
 
-> The usage of CWE-20 is discouraged as "is commonly misused in low-information vulnerability reports when lower-level CWEs could be used instead, or when more details about the vulnerability are available". [cite](https://cwe.mitre.org/data/definitions/20.html)
+> The usage of CWE-20 is discouraged as "is commonly misused in low-information vulnerability reports when lower-level CWEs could be used instead, or when more details about the vulnerability are available". [cite](https://cwe.mitre.org/data/definitions/20.html#Vulnerability_Mapping_Notes_20)
 
 ### Usage of CWE Allowed with Review for Vulnerability Mapping
 
@@ -822,4 +822,4 @@ The relevant path for this test is:
       ]
 ```
 
-> The usage of CWE-1023 is allowed with review as the "CWE entry is a Class and might have Base-level children that would be more appropriate". [cite](https://cwe.mitre.org/data/definitions/1023.html)
+> The usage of CWE-1023 is allowed with review as the "CWE entry is a Class and might have Base-level children that would be more appropriate". [cite](https://cwe.mitre.org/data/definitions/1023.html#Vulnerability_Mapping_Notes_1023)

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -708,7 +708,7 @@ The relevant path for this test is:
 
 ### Usage of deprecated CWE
 
-For each item CWE array it MUST be tested that the CWE is not deprecated in the given version.
+For each item in the CWE array it MUST be tested that the CWE is not deprecated in the given version.
 
 The relevant path for this test is:
 
@@ -730,4 +730,4 @@ The relevant path for this test is:
 
 > The `CWE-596` is deprecated in version 4.13.
 
-> A tool MAY suggest to replace the deprecated CWE with its replacement or closes equivalent.
+> A tool MAY suggest to replace the deprecated CWE with its replacement or closest equivalent.

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -706,7 +706,7 @@ The relevant path for this test is:
 > A tool MAY remove the document tracking id from the document title.
 > It SHOULD also remove any separating characters including whitespace, colon, dash and brackets.
 
-### Usage of deprecated CWE
+### Usage of Deprecated CWE
 
 For each item in the CWE array it MUST be tested that the CWE is not deprecated in the given version.
 
@@ -732,7 +732,7 @@ The relevant path for this test is:
 
 > A tool MAY suggest to replace the deprecated CWE with its replacement or closest equivalent.
 
-### Usage of non-latest CWE Version
+### Usage of Non-Latest CWE Version
 
 For each item in the CWE array it MUST be tested that the latest CWE version available at the time of the last revision was used.
 The test SHALL fail if a later CWE version was used.
@@ -771,7 +771,7 @@ The relevant path for this test is:
 > A tool MAY suggest to use the latest version available at the time of the `current_release_date`.
 > This is most likely also the overall latest CWE version as modifications to a CSAF document lead to a new `current_release_date`.
 
-### Usage of CWE not allowed for Vulnerability Mapping
+### Usage of CWE Not Allowed for Vulnerability Mapping
 
 For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed.
 
@@ -797,7 +797,7 @@ The relevant path for this test is:
 
 > The usage of CWE-20 is discouraged as "is commonly misused in low-information vulnerability reports when lower-level CWEs could be used instead, or when more details about the vulnerability are available". [cite](https://cwe.mitre.org/data/definitions/20.html)
 
-### Usage of CWE allowed with Review for Vulnerability Mapping
+### Usage of CWE Allowed with Review for Vulnerability Mapping
 
 For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed without review.
 

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -770,3 +770,29 @@ The relevant path for this test is:
 
 > A tool MAY suggest to use the latest version available at the time of the `current_release_date`.
 > This is most likely also the overall latest CWE version as modifications to a CSAF document lead to a new `current_release_date`.
+
+### Usage of CWE not allowed for Vulnerability Mapping
+
+For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed.
+
+> Currently, this includes the two usage state `Allowed` and `Allowed-with-Review`.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cwes[]
+```
+
+*Example 1 (which fails the test):*
+
+```
+      "cwes": [
+        {
+          "id": "CWE-20",
+          "name": "Improper Input Validation",
+          "version": "4.13"
+        }
+      ]
+```
+
+> The usage of CWE-20 is discouraged as "is commonly misused in low-information vulnerability reports when lower-level CWEs could be used instead, or when more details about the vulnerability are available". [cite](https://cwe.mitre.org/data/definitions/20.html)

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -705,3 +705,29 @@ The relevant path for this test is:
 
 > A tool MAY remove the document tracking id from the document title.
 > It SHOULD also remove any separating characters including whitespace, colon, dash and brackets.
+
+### Usage of deprecated CWE
+
+For each item CWE array it MUST be tested that the CWE is not deprecated in the given version.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cwes[]
+```
+
+*Example 1 (which fails the test):*
+
+```
+     "cwes": [
+        {
+          "id": "CWE-596",
+          "name": "DEPRECATED: Incorrect Semantic Object Comparison",
+          "version": "4.13"
+        }
+      ]
+```
+
+> The `CWE-596` is deprecated in version 4.13.
+
+> A tool MAY suggest to replace the deprecated CWE with its replacement or closes equivalent.

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -796,3 +796,30 @@ The relevant path for this test is:
 ```
 
 > The usage of CWE-20 is discouraged as "is commonly misused in low-information vulnerability reports when lower-level CWEs could be used instead, or when more details about the vulnerability are available". [cite](https://cwe.mitre.org/data/definitions/20.html)
+
+### Usage of CWE allowed with Review for Vulnerability Mapping
+
+For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed without review.
+
+> Reasoning: CWEs marked with a vulnerability mapping state of `Allowed-with-Review` should only be used if a thorough review was done.
+> This test helps to flag such mappings which can be used to trigger processes that ensure the extra review, e.g. by a senior analyst.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cwes[]
+```
+
+*Example 1 (which fails the test):*
+
+```
+      "cwes": [
+        {
+          "id": "CWE-1023",
+          "name": "Incomplete Comparison with Missing Factors",
+          "version": "4.13"
+        }
+      ]
+```
+
+> The usage of CWE-1023 is allowed with review as the "CWE entry is a Class and might have Base-level children that would be more appropriate". [cite](https://cwe.mitre.org/data/definitions/1023.html)

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -728,6 +728,45 @@ The relevant path for this test is:
       ]
 ```
 
-> The `CWE-596` is deprecated in version 4.13.
+> The `CWE-596` is deprecated in version `4.13`.
 
 > A tool MAY suggest to replace the deprecated CWE with its replacement or closest equivalent.
+
+### Usage of non-latest CWE Version
+
+For each item in the CWE array it MUST be tested that the latest CWE version available at the time of the last revision was used.
+The test SHALL fail if a later CWE version was used.
+
+The relevant path for this test is:
+
+```
+  /vulnerabilities[]/cwes[]
+```
+
+*Example 1 (which fails the test):*
+
+```
+  "document": {
+    // ...
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      // ...
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-256",
+          "name": "Plaintext Storage of a Password",
+          "version": "4.12"
+        }
+      ]
+    }
+  ]
+```
+
+> The CWE version listed is `4.12`. However, version `4.13` was most recent version when the document was released on `2024-01-21T10:00:00.000Z`.
+
+> A tool MAY suggest to use the latest version available at the time of the `current_release_date`.
+> This is most likely also the overall latest CWE version as modifications to a CSAF document lead to a new `current_release_date`.

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (failing example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-01",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-596",
+          "name": "DEPRECATED: Incorrect Semantic Object Comparison",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (failing example 1)",
+    "title": "Optional test: Usage of Deprecated CWE (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-01",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (failing example 2)",
+    "title": "Optional test: Usage of Deprecated CWE (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-02",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-02",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1324",
+          "name": "DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface",
+          "version": "4.10"
+        },
+        {
+          "id": "CWE-300",
+          "name": "Channel Accessible by Non-Endpoint",
+          "version": "4.10"
+        },
+        {
+          "id": "CWE-923",
+          "name": "Improper Restriction of Communication Channel to Intended Endpoints",
+          "version": "4.10"
+        },
+        {
+          "id": "CWE-284",
+          "name": "Improper Access Control",
+          "version": "4.10"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-03.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-03",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-602",
+          "name": "Client-Side Enforcement of Server-Side Security",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-1004",
+          "name": "Sensitive Cookie Without 'HttpOnly' Flag",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-365",
+          "name": "DEPRECATED: Race Condition in Switch",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-03.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (failing example 3)",
+    "title": "Optional test: Usage of Deprecated CWE (failing example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-03",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-11.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-11",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-596",
+          "name": "Incorrect Semantic Object Comparison",
+          "version": "3.0"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-11.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (valid example 1)",
+    "title": "Optional test: Usage of Deprecated CWE (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-11",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-12.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (valid example 2)",
+    "title": "Optional test: Usage of Deprecated CWE (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-12",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-12.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-12",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-319",
+          "name": "Cleartext Transmission of Sensitive Information",
+          "version": "4.10"
+        },
+        {
+          "id": "CWE-311",
+          "name": "Missing Encryption of Sensitive Data",
+          "version": "4.10"
+        },
+        {
+          "id": "CWE-693",
+          "name": "Protection Mechanism Failure",
+          "version": "4.10"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of deprecated CWE (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-13",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-602",
+          "name": "Client-Side Enforcement of Server-Side Security",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-1004",
+          "name": "Sensitive Cookie Without 'HttpOnly' Flag",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-367",
+          "name": "Time-of-check Time-of-use (TOCTOU) Race Condition",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of deprecated CWE (valid example 3)",
+    "title": "Optional test: Usage of Deprecated CWE (valid example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-23-13",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (failing example 1)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-01",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (failing example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-01",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-256",
+          "name": "Plaintext Storage of a Password",
+          "version": "4.12"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (failing example 2)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-02",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-02",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-143",
+          "name": "Improper Neutralization of Record Delimiters",
+          "version": "4.15"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-03.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-03",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-262",
+          "name": "Not Using Password Aging",
+          "version": "1.8.1"
+        },
+        {
+          "id": "CWE-1390",
+          "name": "Weak Authentication",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-287",
+          "name": "Insufficient Authentication",
+          "version": "1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-03.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (failing example 3)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (failing example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-03",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-04.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (failing example 4)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (failing example 4)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-04",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-04.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-04",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-158",
+          "name": "Failure to Sanitize Null Byte or NUL Character",
+          "version": "1.3"
+        },
+        {
+          "id": "CWE-138",
+          "name": "Improper Neutralization of Special Elements",
+          "version": "2.1"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-318",
+          "name": "Cleartext Storage of Sensitive Information in Executable",
+          "version": "4.14"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-61",
+          "name": "UNIX Symbolic Link (Symlink) Following",
+          "version": "4.15"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-11.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (valid example 1)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-11",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-11.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-11",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-256",
+          "name": "Plaintext Storage of a Password",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-12.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-12",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-143",
+          "name": "Improper Neutralization of Record Delimiters",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-12.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (valid example 2)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-12",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-13.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (valid example 3)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (valid example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-13",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-13.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-13",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-262",
+          "name": "Not Using Password Aging",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-1390",
+          "name": "Weak Authentication",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-287",
+          "name": "Improper Authentication",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of non-latest CWE Version (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-14",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-158",
+          "name": "Improper Neutralization of Null Byte or NUL Character",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-138",
+          "name": "Improper Neutralization of Special Elements",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-318",
+          "name": "Cleartext Storage of Sensitive Information in Executable",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-61",
+          "name": "UNIX Symbolic Link (Symlink) Following",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of non-latest CWE Version (valid example 4)",
+    "title": "Optional test: Usage of Non-Latest CWE Version (valid example 4)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-24-14",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-01",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-20",
+          "name": "Improper Input Validation",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 1)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-01",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-02",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1187",
+          "name": "DEPRECATED: Use of Uninitialized Resource",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 2)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-02",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-03.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 3)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (failing example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-03",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-03.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-03",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1287",
+          "name": "Improper Validation of Specified Type of Input",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-20",
+          "name": "Improper Input Validation",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-04.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 4)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (failing example 4)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-04",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-04.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-04.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (failing example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-04",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1284",
+          "name": "Improper Validation of Specified Quantity in Input",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-1289",
+          "name": "Improper Validation of Unsafe Equivalence in Input",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-94",
+          "name": "Improper Control of Generation of Code ('Code Injection')",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-74",
+          "name": "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-11.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 1)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-11",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-11.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-11",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-112",
+          "name": "Missing XML Validation",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-12.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 2)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-12",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-12.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-12",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-908",
+          "name": "Use of Uninitialized Resource",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-13.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 3)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (valid example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-13",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-13.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-13",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1287",
+          "name": "Improper Validation of Specified Type of Input",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 4)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-14",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1284",
+          "name": "Improper Validation of Specified Quantity in Input",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-1289",
+          "name": "Improper Validation of Unsafe Equivalence in Input",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-94",
+          "name": "Improper Control of Generation of Code ('Code Injection')",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-74",
+          "name": "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE not allowed for Vulnerability Mapping (valid example 4)",
+    "title": "Optional test: Usage of CWE Not Allowed for Vulnerability Mapping (valid example 4)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-25-14",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 1)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-01",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-01",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-1023",
+          "name": "Incomplete Comparison with Missing Factors",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 2)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-02",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-02",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-733",
+          "name": "Compiler Optimization Removal or Modification of Security-critical Code",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-1038",
+          "name": "Insecure Automated Optimizations",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 3)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (failing example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-03",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-03",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-15",
+          "name": "External Control of System or Configuration Setting",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-13",
+          "name": "ASP.NET Misconfiguration: Password in Configuration File",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-11",
+          "name": "ASP.NET Misconfiguration: Creating Debug Binary",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-1039",
+          "name": "Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-11.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 1)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-11",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-11.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-11.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-11",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-184",
+          "name": "Incomplete List of Disallowed Inputs",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-12.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 2)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-12",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-12.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-12.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-12",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-14",
+          "name": "Compiler Removal of Code to Clear Buffers",
+          "version": "4.13"
+        },
+        {
+          "id": "CWE-733",
+          "name": "Compiler Optimization Removal or Modification of Security-critical Code",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json
@@ -13,7 +13,7 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 3)",
+    "title": "Optional test: Usage of CWE Allowed with Review for Vulnerability Mapping (valid example 3)",
     "tracking": {
       "current_release_date": "2024-01-21T10:00:00.000Z",
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-13",

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Optional test: Usage of CWE allowed with Review for Vulnerability Mapping (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-21T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-26-13",
+      "initial_release_date": "2024-01-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "cwes": [
+        {
+          "id": "CWE-15",
+          "name": "External Control of System or Configuration Setting",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-13",
+          "name": "ASP.NET Misconfiguration: Password in Configuration File",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-11",
+          "name": "ASP.NET Misconfiguration: Creating Debug Binary",
+          "version": "4.13"
+        }
+      ]
+    },
+    {
+      "cwes": [
+        {
+          "id": "CWE-843",
+          "name": "Access of Resource Using Incompatible Type ('Type Confusion')",
+          "version": "4.13"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1480,6 +1480,38 @@
       ]
     },
     {
+      "id": "6.2.23",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-03.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-11.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-12.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.1",
       "group": "informative",
       "failures": [

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1512,6 +1512,46 @@
       ]
     },
     {
+      "id": "6.2.24",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-03.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-04.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-11.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-12.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-13.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.1",
       "group": "informative",
       "failures": [

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1592,6 +1592,46 @@
       ]
     },
     {
+      "id": "6.2.26",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-04.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-11.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-12.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-14.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.1",
       "group": "informative",
       "failures": [

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1552,6 +1552,46 @@
       ]
     },
     {
+      "id": "6.2.25",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-03.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-04.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-11.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-12.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-13.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.1",
       "group": "informative",
       "failures": [

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1606,10 +1606,6 @@
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-03.json",
           "valid": true
-        },
-        {
-          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-04.json",
-          "valid": true
         }
       ],
       "valid": [
@@ -1623,10 +1619,6 @@
         },
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json",
-          "valid": true
-        },
-        {
-          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-26-14.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/testcases_json_schema.json
+++ b/csaf_2.1/test/validator/testcases_json_schema.json
@@ -62,7 +62,7 @@
           "title": "Number of the test",
           "description": "Contains the section number of the test in the specification.",
           "type": "string",
-          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-4])|(1\\.2[5-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
+          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-5])|(1\\.2[68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
         },
         "valid": {
           "title": "List of valid examples",

--- a/csaf_2.1/test/validator/testcases_json_schema.json
+++ b/csaf_2.1/test/validator/testcases_json_schema.json
@@ -62,7 +62,7 @@
           "title": "Number of the test",
           "description": "Contains the section number of the test in the specification.",
           "type": "string",
-          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-3])|(1\\.2[4-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
+          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-4])|(1\\.2[5-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
         },
         "valid": {
           "title": "List of valid examples",

--- a/csaf_2.1/test/validator/testcases_json_schema.json
+++ b/csaf_2.1/test/validator/testcases_json_schema.json
@@ -62,7 +62,7 @@
           "title": "Number of the test",
           "description": "Contains the section number of the test in the specification.",
           "type": "string",
-          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-5])|(1\\.2[68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
+          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-6])|(1\\.2[8-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
         },
         "valid": {
           "title": "List of valid examples",

--- a/csaf_2.1/test/validator/testcases_json_schema.json
+++ b/csaf_2.1/test/validator/testcases_json_schema.json
@@ -62,7 +62,7 @@
           "title": "Number of the test",
           "description": "Contains the section number of the test in the specification.",
           "type": "string",
-          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-2])|(1\\.2[3-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
+          "pattern": "^6\\.(([1-3]\\.[1-9])|([12]\\.1[0-9])|(3\\.1[0-2])|([12]\\.2[0-3])|(1\\.2[4-68-9])|(1\\.27\\.([1-9]|10|11))|(1\\.3[0-4]))$"
         },
         "valid": {
           "title": "List of valid examples",


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/660, https://github.com/oasis-tcs/csaf/issues/735
- add test to prevent usage of deprecated CWEs
- addresses parts of https://github.com/oasis-tcs/csaf/issues/660, https://github.com/oasis-tcs/csaf/issues/737
- add optional test to suggest usage of latest corresponding version in CWE
- fix spelling mistake
- addresses parts of https://github.com/oasis-tcs/csaf/issues/660, https://github.com/oasis-tcs/csaf/issues/743
- add optional test to prevent vulnerability mapping to CWE that is not allowed
- addresses parts of https://github.com/oasis-tcs/csaf/issues/660, https://github.com/oasis-tcs/csaf/issues/743
- add optional test to prevent vulnerability mapping to CWE that is not allowed without review
- add invalid examples for 6.2.23-6.2.26
- add valid examples for 6.2.23-6.2.26