### PR TITLE
Code block syntax

### DIFF
--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -51,28 +51,29 @@ and `x_generic_uris`, one is mandatory.
         "cpe": {
           // ...
         },
-        "hashes": {
+        "hashes": [
           // ...
-        },
-        "model_numbers": {
+        ],
+        "model_numbers": [
           // ...
-        },
+        ],
         "purl": {
           // ...
         },
-        "sbom_urls": {
+        "sbom_urls": [
           // ...
-        },
-        "serial_numbers": {
+        ],
+        "serial_numbers": [
           // ...
-        },
-        "skus": {
+        ],
+        "skus": [
           // ...
-        },
-        "x_generic_uris": {
+        ],
+        "x_generic_uris": [
           // ...
-        }
+        ]
       }
+    }
 ```
 
 ##### Full Product Name Type - Product Identification Helper - CPE


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#787
- correct syntax for `product_identification_helper`
- extracted from #781 => thanks to @mprpic 