### PR TITLE
Revert 788 "Code block syntax"

### DIFF
--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -51,29 +51,28 @@ and `x_generic_uris`, one is mandatory.
         "cpe": {
           // ...
         },
-        "hashes": [
+        "hashes": {
           // ...
-        ],
-        "model_numbers": [
+        },
+        "model_numbers": {
           // ...
-        ],
+        },
         "purl": {
           // ...
         },
-        "sbom_urls": [
+        "sbom_urls": {
           // ...
-        ],
-        "serial_numbers": [
+        },
+        "serial_numbers": {
           // ...
-        ],
-        "skus": [
+        },
+        "skus": {
           // ...
-        ],
-        "x_generic_uris": [
+        },
+        "x_generic_uris": {
           // ...
-        ]
+        }
       }
-    }
 ```
 
 ##### Full Product Name Type - Product Identification Helper - CPE


### PR DESCRIPTION
- addresses parts of #787 
- reverts #788 as that incorrectly changed '{` (used in the JSON schema) to `[` (used in the JSON document)

The code blocks show excerpts of the [***schema***](https://github.com/oasis-tcs/csaf/blob/master/csaf_2.1/json_schema/csaf_json_schema.json), not a single document.