### PR TITLE
Meeting Minutes for 2024-10-30

### DIFF
--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -58,7 +58,7 @@ Note: Observers of this committee that are ready to become Members should follow
 - [Pull Request #810](https://github.com/oasis-tcs/csaf/pull/810). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Denny. The motion passed.
 - [Pull Request #805](https://github.com/oasis-tcs/csaf/pull/805).  A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Thomas Schaffer. The motion passed.
 - Motion passed to include support for SSVC in CSAF 2.1 as an optional field, as discussed in [Issue #803](https://github.com/oasis-tcs/csaf/issues/803). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Michael. The motion passed.
-- Motion passed to include support for EPSS in CSAF 2.1 as an optional field, as described in [Issue #622](https://github.com/oasis-tcs/csaf/issues/622). A motion was moved by Thomas to include the changes suggested in this pull request, during the CSAF TC monthly meeting on 2024-10-30. The motion was seconded by Omar. The motion passed.
+- Motion passed to include support for EPSS in CSAF 2.1 as an optional field, as described in [Issue #622](https://github.com/oasis-tcs/csaf/issues/622). A motion was moved by Thomas to include the changes suggested in this issue, during the CSAF TC monthly meeting on 2024-10-30. The motion was seconded by Omar. The motion passed.
 
 ## Adjourn
 

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -57,7 +57,7 @@ Note: Observers of this committee that are ready to become Members should follow
 - Thomas sets the motion to approve pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.
 - [Pull Request #810](https://github.com/oasis-tcs/csaf/pull/810). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Denny. The motion passed.
 - [Pull Request #805](https://github.com/oasis-tcs/csaf/pull/805).  A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Thomas Schaffer. The motion passed.
-- Motion passed to include support for SSVC in CSAF 2.1 as an optional field, as discussed in [Issue #803](https://github.com/oasis-tcs/csaf/issues/803). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Michael. The motion passed.
+- Motion passed to include support for SSVC in CSAF 2.1 as an optional field, as discussed in [Issue #803](https://github.com/oasis-tcs/csaf/issues/803). A motion was moved by Omar to include the changes suggested in this issue. The motion was seconded by Michael. The motion passed.
 - Motion passed to include support for EPSS in CSAF 2.1 as an optional field, as described in [Issue #622](https://github.com/oasis-tcs/csaf/issues/622). A motion was moved by Thomas to include the changes suggested in this issue, during the CSAF TC monthly meeting on 2024-10-30. The motion was seconded by Omar. The motion passed.
 
 ## Adjourn

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -54,7 +54,7 @@ Note: Observers of this committee that are ready to become Members should follow
 - The team is considering using MK Docs or a permutation of it for the documentation website.
 - The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation for the next meeting.
 - The December meeting may be moved to December 18th to accommodate the holidays.
-- Thomas sets the motion to approved pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.
+- Thomas sets the motion to approve pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.
 - [Pull Request #810](https://github.com/oasis-tcs/csaf/pull/810). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Denny. The motion passed.
 - [Pull Request #805](https://github.com/oasis-tcs/csaf/pull/805).  A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Thomas Schaffer. The motion passed.
 - Motion passed to include support for SSVC in CSAF 2.1 as an optional field, as discussed in [Issue #803](https://github.com/oasis-tcs/csaf/issues/803). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Michael. The motion passed.

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -1,0 +1,68 @@
+![image](https://user-images.githubusercontent.com/1690898/139102180-5c1e2583-14f1-4f58-ab2b-9e3807ed529c.png)
+
+# Common Security Advisory Framework (CSAF) Technical Committee Working Meeting
+
+- Meeting Date: October 30, 2024
+- Time: 17:00 UTC (19:00 CEST, 13:00 EDT, 10:00 PDT)
+
+## Call to Order and Welcome
+
+Meeting called to order @ 17:03 UTC
+
+## Roll call
+
+Inability to register attendees due to OASIS system challenges.
+
+## Participants
+
+| Given Name | Family Name | Affiliation                                                 | Role          |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|
+| Christoph  | Plutte      | Ericsson                                                    | Voting Member |
+| Denny      | Page        | Individual                                                  | Voting Member |
+| Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
+| Feng       | Cao         | Oracle                                                      | Voting Member |
+| JD         | Stefaniak   | Dell                                                        | Member        |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
+| Michael    | Reeder      | Dell                                                        | Voting Member |
+| Omar       | Santos      | Cisco                                                       | Chair         |
+| Rhonda     | Levy        | Cisco                                                       | Voting Member |
+| Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
+| Stefan     | Hagen       | Individual                                                  | Voting Member |
+| Thomas     | Schaffer    | Cisco                                                       | Voting Member |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member |
+| Vivek      |  Nair       | Microsoft                                                   | Voting Member |
+| Vijay | Sarvepalli | CERT cc Software Engineering Institute, Carnegie Mellon University | Member | 
+| Christian | Banse | Fraunhofer-Gesellschaft | Member |
+
+### Observers present
+
+Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
+
+## Agenda
+
+- Roll call
+- Secretary nomination
+- Review GitHub Issues for TC Discussion:  https://github.com/oasis-tcs/csaf/issues
+- Discuss next steps.
+- Adjourn
+
+**Quorum was reached.**
+
+## Meeting Notes
+- Christophe led a discussion about false positives and best practices for describing them in CSAF.
+- There was a discussion about using relationships and nested relationships in product descriptions.
+- The team is considering using MK Docs or a permutation of it for the documentation website.
+- The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation for the next meeting.
+- The December meeting may be moved to December 18th to accommodate the holidays.
+- Thomas sets the motion to approved pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.
+- [Pull Request #810](https://github.com/oasis-tcs/csaf/pull/810). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Denny. The motion passed.
+- [Pull Request #805](https://github.com/oasis-tcs/csaf/pull/805).  A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Thomas Schaffer. The motion passed.
+- Motion passed to include support for SSVC in CSAF 2.1 as an optional field, as discussed in [Issue #803](https://github.com/oasis-tcs/csaf/issues/803). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Michael. The motion passed.
+- Motion passed to include support for EPSS in CSAF 2.1 as an optional field, as described in [Issue #622](https://github.com/oasis-tcs/csaf/issues/622). A motion was moved by Thomas to include the changes suggested in this pull request, during the CSAF TC monthly meeting on 2024-10-30. The motion was seconded by Omar. The motion passed.
+
+## Adjourn
+
+- The meeting was adjourned @ 18:00 UTC
+
+**Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).
+The next meeting will be held on November 27, 2024.  

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -50,7 +50,7 @@ Note: Observers of this committee that are ready to become Members should follow
 - Christoph led a discussion about false positives and best practices for describing them in CSAF.
 - There was a discussion about using relationships and nested relationships in product descriptions.
 - The team is considering using MK Docs or a derivate / similar product of it for the documentation website.
-- The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation for the next meeting.
+- The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation of the Committee Specification Draft 01 for the next meeting.
 - The December meeting may be moved to December 18th to accommodate the holidays.
 - Thomas sets the motion to approve pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.
 - [Pull Request #810](https://github.com/oasis-tcs/csaf/pull/810). A motion was moved by Omar to include the changes suggested in this pull request. The motion was seconded by Denny. The motion passed.

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -24,7 +24,6 @@ Inability to register attendees due to OASIS system challenges.
 | Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
 | Michael    | Reeder      | Dell                                                        | Voting Member |
 | Omar       | Santos      | Cisco                                                       | Chair         |
-| Rhonda     | Levy        | Cisco                                                       | Voting Member |
 | Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
 | Stefan     | Hagen       | Individual                                                  | Voting Member |
 | Thomas     | Schaffer    | Cisco                                                       | Voting Member |

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -49,7 +49,7 @@ Note: Observers of this committee that are ready to become Members should follow
 ## Meeting Notes
 - Christoph led a discussion about false positives and best practices for describing them in CSAF.
 - There was a discussion about using relationships and nested relationships in product descriptions.
-- The team is considering using MK Docs or a permutation of it for the documentation website.
+- The team is considering using MK Docs or a derivate / similar product of it for the documentation website.
 - The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation for the next meeting.
 - The December meeting may be moved to December 18th to accommodate the holidays.
 - Thomas sets the motion to approve pull request #814 https://github.com/oasis-tcs/csaf/pull/814. Thomas presented a motion to incorporate the changes outlined in this PR. The motion was seconded by Sonny and, following a unanimous lack of discussion or objections, it was carried.

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -49,7 +49,7 @@ Note: Observers of this committee that are ready to become Members should follow
 **Quorum was reached.**
 
 ## Meeting Notes
-- Christophe led a discussion about false positives and best practices for describing them in CSAF.
+- Christoph led a discussion about false positives and best practices for describing them in CSAF.
 - There was a discussion about using relationships and nested relationships in product descriptions.
 - The team is considering using MK Docs or a permutation of it for the documentation website.
 - The timeline plan includes a feature close, November editor revision, merging of open motions, and - preparation for the next meeting.

--- a/meeting_minutes/2024/2024-10-30.md
+++ b/meeting_minutes/2024/2024-10-30.md
@@ -20,7 +20,6 @@ Inability to register attendees due to OASIS system challenges.
 | Christoph  | Plutte      | Ericsson                                                    | Voting Member |
 | Denny      | Page        | Individual                                                  | Voting Member |
 | Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
-| Feng       | Cao         | Oracle                                                      | Voting Member |
 | JD         | Stefaniak   | Dell                                                        | Member        |
 | Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
 | Michael    | Reeder      | Dell                                                        | Voting Member |


### PR DESCRIPTION
This pull request includes the meeting minutes for the CSAF Technical Committee Working Meeting held on October 30, 2024. The minutes document the participants, agenda, discussions, and motions passed during the meeting.

Key changes include:

* Addition of the meeting agenda and participants list, including roles and affiliations.
* Documentation of discussions on false positives, product description relationships, and the use of MK Docs for the documentation website.
* Recording of motions passed to approve various pull requests and include support for SSVC and EPSS in CSAF 2.1.
* Note on the next meeting date and the regular schedule for monthly meetings.