### PR TITLE
Meeting Minutes for 2024-11-27

### DIFF
--- a/meeting_minutes/2024/2024-11-27.md
+++ b/meeting_minutes/2024/2024-11-27.md
@@ -1,0 +1,110 @@
+![image](https://user-images.githubusercontent.com/1690898/139102180-5c1e2583-14f1-4f58-ab2b-9e3807ed529c.png)
+
+# Common Security Advisory Framework (CSAF) Technical Committee Working Meeting
+
+- Meeting Date: November 25, 2024
+- Time: 17:00 UTC (19:00 CEST, 13:00 EDT, 10:00 PDT)
+
+## Call to Order and Welcome
+
+Meeting called to order @ 17:03 UTC
+
+## Roll call
+
+Inability to register attendees due to OASIS system challenges.
+
+## Participants
+
+| Given Name | Family Name | Affiliation                                                 | Role          |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|
+| Martin  | Prpic      | RedHat                                                    | Voting Member |
+| Denny      | Page        | Individual                                                  | Voting Member |
+| Feng       | Cao         | Oracle                                                      | Voting Member |
+| Christian  | Banse       | Fraunhofer-Gesellschaft                                     | Member        |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
+| Omar       | Santos      | Cisco                                                       | Chair         |
+| Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
+| Stefan     | Hagen       | Individual                                                  | Voting Member |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member |
+| Tobi       |  Limmer     | Siemens AG                                                   | Voting Member |
+
+### Observers present
+
+Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
+
+### Quorum
+The meeting achieved quorum and was conducted as a formal session.
+
+## Agenda
+
+- Roll Call
+- Updates or news to the TC
+  - Sonny’s update: CSAF and the OpenEuler CSAF capabilities at the OpenEuler Summit 2024 in Beijing, China.
+  - Thomas to provide an update on the CSAF workshop and community days. Details at: https://workshop.csaf.io
+  - Pending motions and PRs. 
+  - Co-Chairs and Discussion with OASIS staff
+- Review all open GitHub issues and pull requests requiring TC discussion.
+- CSAF 2.1 Committee Specification Draft
+- Next steps
+- Adjourn
+
+## Meeting Notes
+
+
+# CSAF Technical Committee Meeting Minutes
+
+## Meeting Notes
+
+### Updates and Presentations
+- Sonny presented on CSAF at OpenEuler Summit
+  - Introduced CSAF as an open standard
+  - Discussed its capabilities
+
+- Thomas provided updates on CSAF workshops and Community Days
+  - Shared information about dates and agenda
+  - Details at the [CSAF Workshops Website](https://oasis-open.github.io/csaf-documentation/workshop/) and the [CSAF Community Days Website](https://oasis-open.github.io/csaf-documentation/communitydays/).
+  - CSAF Community Days virtual participation is available via Webex webinars
+
+### Administrative Updates
+- Omar discussed with OASIS staff regarding co-chairs and clarified there is no restriction on the number of co-chairs
+- Nominations were opened
+- Justin Murphy, Omar Santos, and Stefan Haggen nominated themselves as co-chairs
+- No nominations received for secretary position
+- Omar sets the motion for the TC to allow the chair to start the nomination and ballot process with the OASIS staff. Stefan seconds the motion. The motion passed without objections or further discussions.
+
+### GitHub Issues and Pull Requests
+
+- Issue [#832](https://github.com/oasis-tcs/csaf/issues/832)
+  - Discussed need for generic examples rather than specific company names to avoid omitting other companies
+  - TC agreed to work on wording and provide links to examples in GitHub repository
+  - [An email was sent to the TC](https://groups.oasis-open.org/discussion/call-to-action-for-832) to provide additional examples.
+
+- Issue [#817](https://github.com/oasis-tcs/csaf/issues/817)
+  - Discussed need for clear separation between hardware and software in product identification helpers
+  - Motion passed to add section addressing this separation
+  - Motion set by Thomas Schmidt and seconded by Stefan.
+
+- Issue [#812](https://github.com/oasis-tcs/csaf/issues/812)
+  - Feng provided the update of the CVE efforts around CPE assignments and the reference to: https://csrc.nist.gov/schema/nvd/feed/1.1/nvd_cve_feed_json_1.1.schema
+  - Thomas Schmidt moves to adopt the implementation of a mandatory test within the CSAF validation process to identify and flag discrepancies between the product_identification_helper and the product details specified in the branches section of CSAF documents. This test will focus on low-hanging issues, such as missing version numbers in Common Platform Enumeration (CPE) identifiers or Package URLs (purls).
+  - The motion was seconded by Sonny. The motion passed.
+
+- Issue [#790](https://github.com/oasis-tcs/csaf/issues/790)
+  - Stefan moves to adopt the changes presented this issue.
+  - The motion was seconded by Denny. The motion passed. 
+
+- Issue [#782](https://github.com/oasis-tcs/csaf/issues/782)
+  - There was a discussion about this issue (to Differentiate Between `disclosure_date` and `first_known_exploitation_date` in CSAF Documents)
+  - A few folks suggested not to include these fields. However, for the purpose of documentation and awareness. The suggestion is not to include these as mandatory fields, but OPTIONAL fields.
+  - Feng and Sonny presented some concerns about including this from a vendor standpoint.
+  - Omar suggested that it will be good to introduce a differentiation in the `/vulnerabilities[]` section of CSAF documents by defining two distinct fields: `disclosure_date` and `first_known_exploitation_date`.
+  - An OPTIONAL field, that clarifies the distinction between when a vulnerability is disclosed and when it is observed to be actively exploited.  
+  - Omar[ sent an email to the broader TC](https://groups.oasis-open.org/discussion/issue-782-differentiate-betweendisclosure-dateandfirst-known-exploitation-datein-csaf-documents) to discuss this issue.
+ 
+
+## Adjourn
+
+- The meeting was adjourned @ 18:04 UTC
+
+**Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).
+[An email was sent to the TC](https://groups.oasis-open.org/discussion/tc-meeting-in-december-2024) to discuss the date for the meeting in December 2024.  


### PR DESCRIPTION
This pull request includes the meeting minutes for the CSAF Technical Committee Working Meeting held on November 25, 2024. The document details the meeting's roll call, agenda, discussions, and resolutions.

Key changes and additions include:

Meeting Details and Participants:
* Added meeting date, time, and participant list including their affiliations and roles.

Agenda and Discussions:
* Detailed the agenda items, including updates on CSAF, discussions on GitHub issues, and administrative updates.
* Provided specific updates and presentations from committee members.

Resolutions and Motions:
* Documented various motions and their outcomes, including the adoption of changes to product identification helpers and the differentiation between `disclosure_date` and `first_known_exploitation_date` in CSAF documents.

Administrative Notes:
* Included notes on administrative updates such as nominations for co-chair positions and discussions with OASIS staff.

Meeting Adjournment:
* Noted the adjournment time and provided information about the next meeting date.