### PR TITLE
Editorial for Editor revision 2025-01-29

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -536,8 +536,10 @@ Firstly, the program:
 
 Secondly, the program fulfills the following for all items of:
 
-* type `/$defs/full_product_name_t/cpe`: If a CPE is invalid, the CSAF 2.0 to CSAF 2.1 converter SHOULD removed the invalid value and output a
-  warning that an invalid CPE was detected and removed. Such a warning MUST include the invalid CPE.
+* type `/$defs/full_product_name_t/product_identification_helper/cpe`: If a CPE is invalid, the CSAF 2.0 to CSAF 2.1 converter SHOULD removed the
+  invalid value and output a warning that an invalid CPE was detected and removed. Such a warning MUST include the invalid CPE.
+* type `/$defs/full_product_name_t/product_identification_helper/purls`: If a `/$defs/full_product_name_t/product_identification_helper/purl` is given,
+  the CSAF 2.0 to CSAF 2.1 converter MUST convert it into the first item of the corresponding `purls` array.
 * `/$schema`: The CSAF 2.0 to CSAF 2.1 converter MUST set property with the value prescribed by the schema.
 * `/document/csaf_version`: The CSAF 2.0 to CSAF 2.1 converter MUST update the value to `2.1`.
 * `/document/distribution/tlp/label`: If a TLP label is given, the CSAF 2.0 to CSAF 2.1 converter MUST convert it according to the table below:

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -383,9 +383,9 @@ The resulting translated document:
 
 A processor satisfies the "CSAF consumer" conformance profile if the processor:
 
-* reads CSAF documents and interprets them according to the semantics defined in section [sec](#schema-elements).
-* satisfies those normative requirements in section [sec](#schema-elements) and [sec](#safety-security-and-data-protection-considerations) that
-  are designated as applying to CSAF consumers.
+* reads CSAF documents and interprets them according to the semantics defined in section [sec](#schema-elements) and [sec](#additional-conventions).
+* satisfies those normative requirements in section [sec](#schema-elements), [sec](#additional-conventions) and
+  [sec](#safety-security-and-data-protection-considerations) that are designated as applying to CSAF consumers.
 
 ### Conformance Clause 11: CSAF viewer
 

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -8,7 +8,7 @@ Informative Comments:
 > The order in which targets, and their corresponding clauses appear is somewhat arbitrary as there is
 > no natural order on such diverse roles participating in the document exchanging ecosystem.
 >
-> Except for the target **CSAF document**, all other 16 targets span a taxonomy of the complex CSAF ecosystems existing
+> Except for the target **CSAF document**, all other 22 targets span a taxonomy of the complex CSAF ecosystems existing
 > in and between diverse security advisory generating, sharing, and consuming communities.
 >
 > In any case, there are no capabilities organized in increasing quality levels for targets because

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -61,9 +61,10 @@ The entities ("conformance targets") for which this document defines requirement
 
 A text file or data stream satisfies the "CSAF document" conformance profile if it:
 
-* conforms to the syntax and semantics defined in section [sec](#date-and-time)
+* conforms to the syntax and semantics defined in section [sec](#date-and-time).
 * conforms to the syntax and semantics defined in section [sec](#schema-elements).
 * satisfies at least one profile defined in section [sec](#profiles).
+* conforms to the syntax and semantics defined in section [sec](#additional-conventions).
 * does not fail any mandatory test defined in section [sec](#mandatory-tests).
 
 ### Conformance Clause 2: CSAF producer

--- a/csaf_2.1/prose/edit/src/design-considerations-02-date-time.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-02-date-time.md
@@ -1,7 +1,7 @@
 ## Date and Time
 
 This standard uses the `date-time` format as defined in JSON Schema Draft 2020-12 Section 7.3.1.
-In accordance with [cite]{#RFC3339} and [cite]{#ISO8601}, the following rules apply:
+In accordance with [cite](#RFC3339) and [cite](#ISO8601), the following rules apply:
 
 * The letter `T` separating the date and time SHALL be upper case.
 * The separator between date and time MUST be the letter `T`.

--- a/csaf_2.1/prose/edit/src/design-considerations-02-date-time.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-02-date-time.md
@@ -1,7 +1,7 @@
 ## Date and Time
 
 This standard uses the `date-time` format as defined in JSON Schema Draft 2020-12 Section 7.3.1.
-In accordance with [cite](#RFC3339) and [cite](#ISO8601), the following rules apply:
+In accordance with [cite](#RFC3339) and [cite](#ISO8601-1), the following rules apply:
 
 * The letter `T` separating the date and time SHALL be upper case.
 * The separator between date and time MUST be the letter `T`.

--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -55,16 +55,16 @@ An array SHOULD NOT have more than:
   * `/document/acknowledgments[]/names`
   * `/document/acknowledgments[]/urls`
   * `/document/tracking/aliases`
-  * `/product_tree/branches[]/product/product_identification_helper/hashes`
-  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes`
-  * `/product_tree/branches[]/product/product_identification_helper/purls`
-  * `/product_tree/branches[]/product/product_identification_helper/sbom_urls`
-  * `/product_tree/branches[]/product/product_identification_helper/x_generic_uris`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/hashes`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/hashes[]/file_hashes`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/purls`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/sbom_urls`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/x_generic_uris`
+  * `/product_tree/branches[]/product/product_identification_helper/hashes`
+  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes`
+  * `/product_tree/branches[]/product/product_identification_helper/purls`
+  * `/product_tree/branches[]/product/product_identification_helper/sbom_urls`
+  * `/product_tree/branches[]/product/product_identification_helper/x_generic_uris`
   * `/product_tree/full_product_names[]/product_identification_helper/hashes`
   * `/product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes`
   * `/product_tree/full_product_names[]/product_identification_helper/purls`
@@ -72,7 +72,7 @@ An array SHOULD NOT have more than:
   * `/product_tree/full_product_names[]/product_identification_helper/x_generic_uris`
   * `/product_tree/relationships[]/full_product_name/product_identification_helper/hashes`
   * `/product_tree/relationships[]/full_product_name/product_identification_helper/hashes[]/file_hashes`
-  * `/product_tree/relationships[]/full_product_name/product_identification_helper/purls[]`
+  * `/product_tree/relationships[]/full_product_name/product_identification_helper/purls`
   * `/product_tree/relationships[]/full_product_name/product_identification_helper/sbom_urls`
   * `/product_tree/relationships[]/full_product_name/product_identification_helper/x_generic_uris`
   * `/vulnerabilities[]/acknowledgments`
@@ -93,12 +93,12 @@ An array SHOULD NOT have more than:
   * `/document/tracking/revision_history`
   * `/product_tree/branches`
   * `/product_tree(/branches[])*/branches`
-  * `/product_tree/branches[]/product/product_identification_helper/model_numbers`
-  * `/product_tree/branches[]/product/product_identification_helper/serial_numbers`
-  * `/product_tree/branches[]/product/product_identification_helper/skus`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/model_numbers`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/serial_numbers`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/skus`
+  * `/product_tree/branches[]/product/product_identification_helper/model_numbers`
+  * `/product_tree/branches[]/product/product_identification_helper/serial_numbers`
+  * `/product_tree/branches[]/product/product_identification_helper/skus`
   * `/product_tree/full_product_names`
   * `/product_tree/full_product_names[]/product_identification_helper/model_numbers`
   * `/product_tree/full_product_names[]/product_identification_helper/serial_numbers`
@@ -110,14 +110,16 @@ An array SHOULD NOT have more than:
   * `/vulnerabilities`
 
 * 10 000 000 for
-  * `/product_tree/relationships`
   * `/product_tree/product_groups`
+  * `/product_tree/relationships`
   * `/vulnerabilities[]/remediations[]/group_ids`
 
 * 100 000 000 for
   * `/vulnerabilities[]/flags`
   * `/vulnerabilities[]/flags[]/group_ids`
   * `/vulnerabilities[]/flags[]/product_ids`
+  * `/vulnerabilities[]/metrics`
+  * `/vulnerabilities[]/metrics[]/products`
   * `/vulnerabilities[]/product_status/first_affected`
   * `/vulnerabilities[]/product_status/first_fixed`
   * `/vulnerabilities[]/product_status/fixed`
@@ -128,8 +130,6 @@ An array SHOULD NOT have more than:
   * `/vulnerabilities[]/product_status/under_investigation`
   * `/vulnerabilities[]/remediations`
   * `/vulnerabilities[]/remediations[]/product_ids`
-  * `/vulnerabilities[]/metrics`
-  * `/vulnerabilities[]/metrics[]/products`
   * `/vulnerabilities[]/threats`
   * `/vulnerabilities[]/threats[]/group_ids`
   * `/vulnerabilities[]/threats[]/product_ids`
@@ -157,15 +157,6 @@ A string SHOULD NOT have a length greater than:
   * `/document/tracking/revision_history[]/legacy_version`
   * `/document/tracking/revision_history[]/number`
   * `/document/tracking/version`
-  * `/product_tree/branches[]/name`
-  * `/product_tree/branches[]/product/name`
-  * `/product_tree/branches[]/product/product_id`
-  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes[]/algorithm`
-  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes[]/value`
-  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/filename`
-  * `/product_tree/branches[]/product/product_identification_helper/model_numbers[]`
-  * `/product_tree/branches[]/product/product_identification_helper/serial_numbers[]`
-  * `/product_tree/branches[]/product/product_identification_helper/skus[]`
   * `/product_tree/branches[](/branches[])*/name`
   * `/product_tree/branches[](/branches[])*/product/name`
   * `/product_tree/branches[](/branches[])*/product/product_id`
@@ -175,6 +166,15 @@ A string SHOULD NOT have a length greater than:
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/model_numbers[]`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/serial_numbers[]`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/skus[]`
+  * `/product_tree/branches[]/name`
+  * `/product_tree/branches[]/product/name`
+  * `/product_tree/branches[]/product/product_id`
+  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes[]/algorithm`
+  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/file_hashes[]/value`
+  * `/product_tree/branches[]/product/product_identification_helper/hashes[]/filename`
+  * `/product_tree/branches[]/product/product_identification_helper/model_numbers[]`
+  * `/product_tree/branches[]/product/product_identification_helper/serial_numbers[]`
+  * `/product_tree/branches[]/product/product_identification_helper/skus[]`
   * `/product_tree/full_product_names[]/name`
   * `/product_tree/full_product_names[]/product_id`
   * `/product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes[]/algorithm`
@@ -205,6 +205,10 @@ A string SHOULD NOT have a length greater than:
   * `/vulnerabilities[]/flags[]/product_ids[]`
   * `/vulnerabilities[]/ids[]/system_name`
   * `/vulnerabilities[]/ids[]/text`
+  * `/vulnerabilities[]/metrics[]/content/cvss_v2/vectorString`
+  * `/vulnerabilities[]/metrics[]/content/cvss_v3/vectorString`
+  * `/vulnerabilities[]/metrics[]/content/cvss_v4/vectorString`
+  * `/vulnerabilities[]/metrics[]/products[]`
   * `/vulnerabilities[]/notes[]/audience`
   * `/vulnerabilities[]/notes[]/title`
   * `/vulnerabilities[]/product_status/first_affected[]`
@@ -217,10 +221,6 @@ A string SHOULD NOT have a length greater than:
   * `/vulnerabilities[]/product_status/under_investigation[]`
   * `/vulnerabilities[]/remediations[]/group_ids[]`
   * `/vulnerabilities[]/remediations[]/product_ids[]`
-  * `/vulnerabilities[]/metrics[]/content/cvss_v2/vectorString`
-  * `/vulnerabilities[]/metrics[]/content/cvss_v3/vectorString`
-  * `/vulnerabilities[]/metrics[]/content/cvss_v4/vectorString`
-  * `/vulnerabilities[]/scores[]/products[]`
   * `/vulnerabilities[]/threats[]/group_ids[]`
   * `/vulnerabilities[]/threats[]/product_ids[]`
   * `/vulnerabilities[]/title`
@@ -232,10 +232,10 @@ A string SHOULD NOT have a length greater than:
   * `/document/publisher/issuing_authority`
   * `/document/references[]/summary`
   * `/document/tracking/revision_history[]/summary`
-  * `/product_tree/branches[]/product/product_identification_helper/cpe`
-  * `/product_tree/branches[]/product/product_identification_helper/purls[]`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/cpe`
   * `/product_tree/branches[](/branches[])*/product/product_identification_helper/purls[]`
+  * `/product_tree/branches[]/product/product_identification_helper/cpe`
+  * `/product_tree/branches[]/product/product_identification_helper/purls[]`
   * `/product_tree/full_product_names[]/product_identification_helper/cpe`
   * `/product_tree/full_product_names[]/product_identification_helper/purls[]`
   * `/product_tree/product_groups[]/summary`
@@ -265,8 +265,8 @@ The maximum length of strings representing a temporal value is given by the form
 * `/document/tracking/revision_history[]/date`
 * `/vulnerabilities[]/discovery_date`
 * `/vulnerabilities[]/flags[]/date`
-* `/vulnerabilities[]/release_date`
 * `/vulnerabilities[]/involvements[]/date`
+* `/vulnerabilities[]/release_date`
 * `/vulnerabilities[]/remediations[]/date`
 * `/vulnerabilities[]/threats[]/date`
 
@@ -284,100 +284,99 @@ It seems to be safe to assume that the length of this value is not greater than 
 
 For all other values, it seems to be safe to assume that the length of each value is not greater than 50.
 This applies to:
-
 * `/document/csaf_version` (3)
 * `/document/distribution/tlp/label` (12)
 * `/document/notes[]/category` (16)
 * `/document/publisher/category` (11)
 * `/document/references[]/category` (8)
 * `/document/tracking/status` (7)
-* `/product_tree/branches[]/category` (15)
 * `/product_tree/branches[](/branches[])*/category` (15)
+* `/product_tree/branches[]/category` (15)
 * `/product_tree/relationships[]/category` (21)
 * `/vulnerabilities[]/flags[]/label` (49)
 * `/vulnerabilities[]/involvements[]/party` (11)
 * `/vulnerabilities[]/involvements[]/status` (17)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/accessComplexity` (6)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/accessVector` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/authentication` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/availabilityImpact` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/availabilityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/collateralDamagePotential` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/confidentialityImpact` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/confidentialityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/exploitability` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/integrityImpact` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/integrityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/remediationLevel` (13)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/reportConfidence` (14)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/targetDistribution` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v2/version` (3)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/attackComplexity` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/attackVector` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/availabilityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/availabilityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/baseSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/confidentialityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/confidentialityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/environmentalSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/exploitCodeMaturity` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/integrityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/integrityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAttackComplexity` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAttackVector` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAvailabilityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedConfidentialityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedIntegrityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedPrivilegesRequired` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedScope` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedUserInteraction` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/privilegesRequired` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/remediationLevel` (13)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/reportConfidence` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/scope` (9)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/temporalSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/userInteraction` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v3/version` (3)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackComplexity` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackRequirements` (7)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackVector` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/Automatable` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/availabilityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/baseSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/confidentialityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/environmentalSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/exploitMaturity` (16)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/integrityRequirement` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackComplexity` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackRequirements` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackVector` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedPrivilegesRequired` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubAvailabilityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubConfidentialityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubIntegrityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedUserInteraction` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnAvailabilityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnConfidentialityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnIntegrityImpact` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/privilegesRequired` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/providerUrgency` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/Recovery` (13)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/Safety` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/subAvailabilityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/subConfidentialityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/subIntegrityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/threatSeverity` (8)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/userInteraction` (7)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/valueDensity` (12)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/version` (3)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnAvailabilityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnConfidentialityImpact` (4)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnerabilityResponseEffort` (11)
+* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnIntegrityImpact` (4)
 * `/vulnerabilities[]/notes[]/category` (16)
 * `/vulnerabilities[]/references[]/category` (8)
 * `/vulnerabilities[]/remediations[]/category` (14)
 * `/vulnerabilities[]/remediations[]/restart_required/category` (20)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/version` (3)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/accessVector` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/accessComplexity` (6)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/authentication` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/confidentialityImpact` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/integrityImpact` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/availabilityImpact` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/exploitability` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/remediationLevel` (13)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/reportConfidence` (14)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/collateralDamagePotential` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/targetDistribution` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/confidentialityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/integrityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v2/availabilityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/version` (3)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/attackVector` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/attackComplexity` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/privilegesRequired` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/userInteraction` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/scope` (9)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/confidentialityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/integrityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/availabilityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/baseSeverity` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/exploitCodeMaturity` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/remediationLevel` (13)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/reportConfidence` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/temporalSeverity` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/confidentialityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/integrityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/availabilityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAttackVector` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAttackComplexity` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedPrivilegesRequired` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedUserInteraction` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedScope` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedConfidentialityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedIntegrityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/modifiedAvailabilityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v3/environmentalSeverity` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/version` (3)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackVector` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackComplexity` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/attackRequirements` (7)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/privilegesRequired` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/userInteraction` (7)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnConfidentialityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnIntegrityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnAvailabilityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/subConfidentialityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/subIntegrityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/subAvailabilityImpact` (4)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/exploitMaturity` (16)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/confidentialityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/integrityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/availabilityRequirement` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackVector` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackComplexity` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedAttackRequirements` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedPrivilegesRequired` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedUserInteraction` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnConfidentialityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnIntegrityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedVulnAvailabilityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubConfidentialityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubIntegrityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/modifiedSubAvailabilityImpact` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/Safety` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/Automatable` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/Recovery` (13)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/valueDensity` (12)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/vulnerabilityResponseEffort` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/providerUrgency` (11)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/baseSeverity` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/threatSeverity` (8)
-* `/vulnerabilities[]/metrics[]/content/cvss_v4/environmentalSeverity` (8)
 * `/vulnerabilities[]/threats[]/category` (14)
 
 ## URI Length
@@ -387,14 +386,14 @@ A string with format `uri` SHOULD NOT have a length greater than 20000. This app
 * `/document/acknowledgments[]/urls[]`
 * `/document/aggregate_severity/namespace`
 * `/document/distribution/tlp/url`
-* `/document/references[]/url`
 * `/document/publisher/namespace`
-* `/product_tree/branches[]/product/product_identification_helper/sbom_urls[]`
-* `/product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/namespace`
-* `/product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/uri`
+* `/document/references[]/url`
 * `/product_tree/branches[](/branches[])*/product/product_identification_helper/sbom_urls[]`
 * `/product_tree/branches[](/branches[])*/product/product_identification_helper/x_generic_uris[]/namespace`
 * `/product_tree/branches[](/branches[])*/product/product_identification_helper/x_generic_uris[]/uri`
+* `/product_tree/branches[]/product/product_identification_helper/sbom_urls[]`
+* `/product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/namespace`
+* `/product_tree/branches[]/product/product_identification_helper/x_generic_uris[]/uri`
 * `/product_tree/full_product_names[]/product_identification_helper/sbom_urls[]`
 * `/product_tree/full_product_names[]/product_identification_helper/x_generic_uris[]/namespace`
 * `/product_tree/full_product_names[]/product_identification_helper/x_generic_uris[]/uri`

--- a/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
@@ -1,7 +1,7 @@
 ## Normative References
 
-ISO8601
-:    _Data elements and interchange formats — Information interchange — Representation of dates and times_, International Standard, ISO 8601:2004(E), December 1, 2004, https://www.iso.org/standard/40874.html.
+ISO8601-1
+:    _Date and time — Representations for information interchangePart 1: Basic rules_, International Standard, ISO 8601-1:2019(E), February 2019, https://www.iso.org/standard/70907.html.
 
 JSON-Schema-Core
 :    _JSON Schema: A Media Type for Describing JSON Documents_, draft-bhutton-json-schema-00, December 2020, <https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00>.

--- a/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
@@ -1,7 +1,7 @@
 ## Normative References
 
 ISO8601-1
-:    _Date and time — Representations for information interchangePart 1: Basic rules_, International Standard, ISO 8601-1:2019(E), February 2019, https://www.iso.org/standard/70907.html.
+:    _Date and time — Representations for information interchangePart 1: Basic rules_, International Standard, ISO 8601-1:2019(E), February 25, 2019, https://www.iso.org/standard/70907.html.
 
 JSON-Schema-Core
 :    _JSON Schema: A Media Type for Describing JSON Documents_, draft-bhutton-json-schema-00, December 2020, <https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00>.

--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -103,7 +103,7 @@ SPDX22
 :    _The Software Package Data Exchange (SPDX®) Specification Version 2.2_, Linux Foundation and its Contributors, 2020, <https://spdx.github.io/spdx-spec/>.
 
 VERS
-:    _vers: a mostly universal version range specifier_, Part of the purl GitHub Project, <https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst>.
+:    _vers: a mostly universal version range specifier_, Part of the purl GitHub Project, <https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst>.
 
 VEX
 :    _Vulnerability-Exploitability eXchange (VEX) - An Overview_, VEX sub-group of the Framing Working Group in the NTIA SBOM initiative, 27 September 2021, <https://ntia.gov/files/ntia/publications/vex_one-page_summary.pdf>.

--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -16,7 +16,7 @@ CSAF-v2.0
 :    _Common Security Advisory Framework Version 2.0_. Edited by Langley Rock, Stefan Hagen, and Thomas Schmidt. 18 November 2022. OASIS Standard. https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html.
 
 CVE
-:    _Common Vulnerability and Exposures (CVE) – The Standard for Information Security Vulnerability Names_, MITRE, 1999, https://cve.mitre.org/about/.
+:    _Common Vulnerability and Exposures (CVE) – The Standard for Information Security Vulnerability Names_, MITRE, 1999, https://www.cve.org/About/Overview.
 
 CVE-NF
 :    _Common Vulnerability and Exposures (CVE) – The Standard for Information Security Vulnerability Names - CVE ID Syntax Change_, MITRE, January 01, 2014, https://cve.mitre.org/cve/identifiers/syntaxchange.html.
@@ -37,10 +37,10 @@ CVSS31
 :    _Common Vulnerability Scoring System v3.1: Specification Document_, FIRST.Org, Inc., June 2019, https://www.first.org/cvss/v3-1/cvss-v31-specification_r1.pdf.
 
 CVSS40
-:    _Common Vulnerability Scoring System v4.0: Specification Document_, FIRST.Org, Inc., 09 November 2023, https://www.first.org/cvss/v4-0/cvss-v40-specification.pdf.
+:    _Common Vulnerability Scoring System v4.0: Specification Document_, FIRST.Org, Inc., November 9, 2023, https://www.first.org/cvss/v4-0/cvss-v40-specification.pdf.
 
 CWE
-:    _Common Weakness Enumeration (CWE) – A Community-Developed List of Software Weakness Types_, MITRE, 2005, http://cwe.mitre.org/about/.
+:    _Common Weakness Enumeration (CWE) – A Community-Developed List of Software Weakness Types_, MITRE, 2006, http://cwe.mitre.org/about/.
 
 CYCLONEDX161
 :    _CycloneDX Software Bill-of-Material Specification JSON schema version 1.6.1_, cyclonedx.org, November 7, 2024, https://github.com/CycloneDX/specification/blob/1.6.1/schema/bom-1.6.schema.json.
@@ -55,7 +55,7 @@ ISO19770-2
 :    _Information technology — IT asset management — Part 2: Software identification tag_, International Standard, ISO 19770-2:2015, September 30, 2015, <https://www.iso.org/standard/65666.html>.
 
 ISO29147
-:    _Information technology — Security techniques — Vulnerability disclosure_, International Standard, ISO/IEC 29147:2018, October, 2018, <https://www.iso.org/standard/72311.html>.
+:    _Information technology — Security techniques — Vulnerability disclosure_, International Standard, ISO/IEC 29147:2018, October 23, 2018, <https://www.iso.org/standard/72311.html>.
 
 OPENSSL
 :    _GTLS/SSL and crypto library_, OpenSSL Software Foundation, https://www.openssl.org/.

--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -42,8 +42,8 @@ CVSS40
 CWE
 :    _Common Weakness Enumeration (CWE) – A Community-Developed List of Software Weakness Types_, MITRE, 2005, http://cwe.mitre.org/about/.
 
-CYCLONEDX13
-:    _CycloneDX Software Bill-of-Material Specification JSON schema version 1.3_, cyclonedx.org, May 2021, https://github.com/CycloneDX/specification/blob/1.3/schema/bom-1.3.schema.json.
+CYCLONEDX161
+:    _CycloneDX Software Bill-of-Material Specification JSON schema version 1.6.1_, cyclonedx.org, November 7, 2024, https://github.com/CycloneDX/specification/blob/1.6.1/schema/bom-1.6.schema.json.
 
 GFMCMARK
 :    _GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C_, https://github.com/github/cmark.
@@ -99,8 +99,8 @@ SECURITY-TXT
 SemVer
 :    _Semantic Versioning 2.0.0_, T. Preston-Werner, June 2013, <https://semver.org/>.
 
-SPDX22
-:    _The Software Package Data Exchange (SPDX®) Specification Version 2.2_, Linux Foundation and its Contributors, 2020, <https://spdx.github.io/spdx-spec/>.
+SPDX301
+:    _The System Package Data Exchange® (SPDX®) Specification Version 3.0.1_, Linux Foundation and its Contributors, 2024, <https://spdx.github.io/spdx-spec/>.
 
 VERS
 :    _vers: a mostly universal version range specifier_, Part of the purl GitHub Project, <https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst>.

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-02-branches.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-02-branches.md
@@ -159,7 +159,7 @@ The value of MUST obey to exactly one of the following options:
     *Examples 1 (for `name` when using `product_version_range` with vers):*
 
     ```
-        vers:gem/>=2.2.0|!= 2.2.1|<2.3.0
+        vers:gem/>=2.2.0|!=2.2.1|<2.3.0
         vers:npm/1.2.3|>=2.0.0|<5.0.0
         vers:pypi/0.0.0|0.0.1|0.0.2|0.0.3|1.0|2.0pre1
         vers:tomee/>=8.0.0-M1|<=8.0.1

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -164,19 +164,19 @@ The default value for `algorithm` is `sha256`.
 
 These values are derived from the currently supported digests OpenSSL [cite](#OPENSSL). Leading dashes were removed.
 
-> The command `openssl dgst -list` (Version 1.1.1f from 2020-03-31) outputs the following:
+> The command `openssl dgst -list` (Version 3.4.0 from 2024-10-22) outputs the following:
 >
 >```
 >  Supported digests:
 >  -blake2b512                -blake2s256                -md4                      
->  -md5                       -md5-sha1                  -ripemd                   
->  -ripemd160                 -rmd160                    -sha1                     
->  -sha224                    -sha256                    -sha3-224                 
->  -sha3-256                  -sha3-384                  -sha3-512                 
->  -sha384                    -sha512                    -sha512-224               
->  -sha512-256                -shake128                  -shake256                 
->  -sm3                       -ssl3-md5                  -ssl3-sha1                
->  -whirlpool
+>  -md5                       -md5-sha1                  -mdc2
+>  -ripemd                    -ripemd160                 -rmd160
+>  -sha1                      -sha224                    -sha256
+>  -sha3-224                  -sha3-256                  -sha3-384
+>  -sha3-512                  -sha384                    -sha512
+>  -sha512-224                -sha512-256                -shake128
+>  -shake256                  -sm3                       -ssl3-md5
+>  -ssl3-sha1                 -whirlpool
 >```
 
 The Value of the cryptographic hash representation (`value`) of value type `string` of 32 or more characters with `pattern` (regular expression):

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
@@ -1,6 +1,6 @@
 ### CWE
 
-It MUST be tested that given CWE exists and is valid in the version provided.
+For each CWE it MUST be tested that the given CWE exists and is valid in the version provided.
 Any `id` that refers to a CWE Category or View MUST fail the test.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -120,7 +120,7 @@ If no CVE exists for that vulnerability, it is recommended to get one assigned.
 
 ### Missing CWE
 
-It MUST be tested that the CWE is given.
+It MUST be tested that at least one CWE is given.
 
 The relevant path for this test is:
 
@@ -139,7 +139,7 @@ The relevant path for this test is:
   ]
 ```
 
-> The CWE number is not given.
+> No CWE number is given.
 
 ### Use of Short Hash
 


### PR DESCRIPTION
- fixes #841 
- correct vers example by removing invalid space
- update link to vers
- update count of conformance targets
-  fix refs in date and time (wrong brackets)
- fix format mistake
- add section 5 to be of relevance for conformance
- sort guidance on size
- remove obsolete scores from guidance on size
- update OpenSSL digest list
- update reference to ISO 8601
- update SBOM format references
- rephrase test 6.1.11 and 6.3.4 to clarify the test according to the change to multiple CWEs
- add conversion rule
- correct JSON path by adding missing `product_identification_helper` part 