### PR TITLE
Clarify initial release date

### DIFF
--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -855,7 +855,7 @@
             },
             "initial_release_date": {
               "title": "Initial release date",
-              "description": "The date when this document was first released to the intended target group.",
+              "description": "The date when this document was first released to the specified target group.",
               "type": "string",
               "format": "date-time"
             },

--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -855,7 +855,7 @@
             },
             "initial_release_date": {
               "title": "Initial release date",
-              "description": "The date when this document was first published.",
+              "description": "The date when this document was first released to the intended target group.",
               "type": "string",
               "format": "date-time"
             },

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -256,6 +256,8 @@ A CSAF content management system satisfies the "CSAF content management system" 
     the configuration (default: 3 weeks)
   * suggest to publish a new version of the CSAF document with the document status `final` if the document status was
     `interim` and no new release has be done during the given threshold in the configuration (default: 6 weeks)
+    > Note that the terms "publish", "publication" and their derived forms are used in this conformance profile independent of
+      whether the intended target group is the public or a closed group.
   * support the following workflows:
 
     * "New Advisory": create a new advisory, request a review, provide review comments or approve it, resolve review comments;
@@ -372,6 +374,8 @@ The resulting translated document:
   It SHOULD NOT use the original `/document/tracking/id` as a suffix.
   If an issuer uses a CSAF translator to publish his advisories in multiple languages they MAY use the combination of
   the original `/document/tracking/id` and translated `/document/lang` as a `/document/tracking/id` for the translated document.
+  > Note that the term "publish" is used in this conformance profile independent of whether the intended target group is the public
+    or a closed group.
 * provides the `/document/lang` property with a value matching the language of the translation.
 * provides the `/document/source_lang` to contain the language of the original document (and SHOULD only be set by CSAF translators).
 * has the value `translator` set in `/document/publisher/category`

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -257,7 +257,7 @@ A CSAF content management system satisfies the "CSAF content management system" 
   * suggest to publish a new version of the CSAF document with the document status `final` if the document status was
     `interim` and no new release has be done during the given threshold in the configuration (default: 6 weeks)
     > Note that the terms "publish", "publication" and their derived forms are used in this conformance profile independent of
-      whether the intended target group is the public or a closed group.
+      whether the specified target group is the public or a closed group.
   * support the following workflows:
 
     * "New Advisory": create a new advisory, request a review, provide review comments or approve it, resolve review comments;
@@ -374,7 +374,7 @@ The resulting translated document:
   It SHOULD NOT use the original `/document/tracking/id` as a suffix.
   If an issuer uses a CSAF translator to publish his advisories in multiple languages they MAY use the combination of
   the original `/document/tracking/id` and translated `/document/lang` as a `/document/tracking/id` for the translated document.
-  > Note that the term "publish" is used in this conformance profile independent of whether the intended target group is the public
+  > Note that the term "publish" is used in this conformance profile independent of whether the specified target group is the public
     or a closed group.
 * provides the `/document/lang` property with a value matching the language of the translation.
 * provides the `/document/source_lang` to contain the language of the original document (and SHOULD only be set by CSAF translators).

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-11-version.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-11-version.md
@@ -39,7 +39,7 @@ The following rules apply:
    Any modifications MUST be released as a new version.
 2. Version zero (0) is for initial development before the `initial_release_date`.
    The document status MUST be `draft`. Anything MAY change at any time. The document SHOULD NOT be considered stable.
-3. Version 1 defines the initial release to the intended target group.
+3. Version 1 defines the initial release to the specified target group.
    Each new version where `/document/tracking/status` is `final` has a version number incremented by one.
 4. Pre-release versions (document status `draft`) MUST carry the new version number.
    Sole exception is before the initial release (see rule 2).
@@ -70,7 +70,7 @@ This results in the following rules:
    tracked in this stage with (0.y.z) by incrementing the minor version y instead.
    Changes that would increment the minor or patch version according to rule 6 or 5 are both tracked in this stage with
    (0.y.z) by incrementing the patch version z instead.
-4. Version 1.0.0 defines the initial release to the intended target group.
+4. Version 1.0.0 defines the initial release to the specified target group.
    The way in which the version number is incremented after this release is dependent on the content and structure of
    the document and how it changes.
 5. Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards compatible bug fixes are introduced.

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-11-version.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-11-version.md
@@ -39,7 +39,7 @@ The following rules apply:
    Any modifications MUST be released as a new version.
 2. Version zero (0) is for initial development before the `initial_release_date`.
    The document status MUST be `draft`. Anything MAY change at any time. The document SHOULD NOT be considered stable.
-3. Version 1 defines the initial public release.
+3. Version 1 defines the initial release to the intended target group.
    Each new version where `/document/tracking/status` is `final` has a version number incremented by one.
 4. Pre-release versions (document status `draft`) MUST carry the new version number.
    Sole exception is before the initial release (see rule 2).
@@ -70,7 +70,7 @@ This results in the following rules:
    tracked in this stage with (0.y.z) by incrementing the minor version y instead.
    Changes that would increment the minor or patch version according to rule 6 or 5 are both tracked in this stage with
    (0.y.z) by incrementing the patch version z instead.
-4. Version 1.0.0 defines the initial public release.
+4. Version 1.0.0 defines the initial release to the intended target group.
    The way in which the version number is incremented after this release is dependent on the content and structure of
    the document and how it changes.
 5. Patch version Z (x.y.Z | x > 0) MUST be incremented if only backwards compatible bug fixes are introduced.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -649,6 +649,9 @@ Initial release date (`initial_release_date`) with value type `string` with form
 > For `TLP:GREEN` and higher, this is the timestamp when it was first made available to the specific group.
 > Note that the initial release date does not change after the initial release even if the document is later on released to a broader audience.
 
+If the timestamp of the initial release date was set incorrectly, it MUST be corrected.
+This change MUST be tracked with a new entry in the revision history.
+
 ##### Document Property - Tracking - Revision History
 
 The Revision History (`revision_history`) with value type `array` of 1 or more Revision History Entries holds one revision item for each version of

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -643,7 +643,7 @@ This value is also used to determine the filename for the CSAF document (cf. sec
 
 ##### Document Property - Tracking - Initial Release Date
 
-Initial release date (`initial_release_date`) with value type `string` with format `date-time` holds the date when this document was first released to the intended target group.
+Initial release date (`initial_release_date`) with value type `string` with format `date-time` holds the date when this document was first released to the specified target group.
 
 > For `TLP:CLEAR` documents, this is usually the timestamp when the document was published.
 > For `TLP:GREEN` and higher, this is the timestamp when it was first made available to the specific group.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -643,7 +643,11 @@ This value is also used to determine the filename for the CSAF document (cf. sec
 
 ##### Document Property - Tracking - Initial Release Date
 
-Initial release date (`initial_release_date`) with value type `string` with format `date-time` holds the date when this document was first published.
+Initial release date (`initial_release_date`) with value type `string` with format `date-time` holds the date when this document was first released to the intended target group.
+
+> For `TLP:CLEAR` documents, this is usually the timestamp when the document was published.
+> For `TLP:GREEN` and higher, this is the timestamp when it was first made available to the specific group.
+> Note that the initial release date does not change after the initial release even if the document is later on released to a broader audience.
 
 ##### Document Property - Tracking - Revision History
 


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/791
- rephrase initial release date to avoid confusion with a release to a closed target group
- adapt description in schema
- rephrase integer and semantic versioning to avoid confusion with a release to a closed target group
- clarify how to correct a wrong `initial_release_date`
- add note to conformance targets that use the word "publish" and its derived forms