### PR TITLE
Meeting Minutes for  2025-01-29

### DIFF
--- a/meeting_minutes/2025/2025-01-29.md
+++ b/meeting_minutes/2025/2025-01-29.md
@@ -58,7 +58,9 @@ The meeting achieved quorum and was conducted as a formal session.
 
 ## GitHub Issues
 
-- Issue #851: The date of the information property in the CSAF document helps order the exploitation date.
+- Issue #851: 
+  - The "date of the information property" in the CSAF document helps order the exploitation date.
+  - A motion to include the changes as stated in issue #851 was presented and passed without discussions or objections.
 - Issue #672: Enforce use of affected in `csaf_security_advisory`.
   - There was extensive discussion about this issue.
   - The `csaf_security_advisory` profile requires the existence of `/vulnerabilities[]/product_status` but does not mandate the inclusion of `/vulnerabilities[]/product_status/affected`.

--- a/meeting_minutes/2025/2025-01-29.md
+++ b/meeting_minutes/2025/2025-01-29.md
@@ -24,7 +24,7 @@ Inability to register attendees due to OASIS system challenges.
 | Feng       | Cao         | Oracle                                                      | Voting Member |
 | Martin     | Prpic       | Red Hat                                                     | Voting Member |
 | Michael   | Reader   | Dell                                                             | Member              |
-| Thomas     | Schaffer    | Cisco Systems                                               | Voting Member |
+| Thomas     | Schaffer    | Cisco Systems                                               | Member        |
 | Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
 | Stefan     | Hagen       | Individual                                                  | Voting Member |
 | Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member |

--- a/meeting_minutes/2025/2025-01-29.md
+++ b/meeting_minutes/2025/2025-01-29.md
@@ -23,6 +23,7 @@ Inability to register attendees due to OASIS system challenges.
 | Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
 | Feng       | Cao         | Oracle                                                      | Voting Member |
 | Martin     | Prpic       | Red Hat                                                     | Voting Member |
+| Michael   | Reader   | Dell                                                             | Member              |
 | Thomas     | Schaffer    | Cisco Systems                                               | Voting Member |
 | Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
 | Stefan     | Hagen       | Individual                                                  | Voting Member |

--- a/meeting_minutes/2025/2025-01-29.md
+++ b/meeting_minutes/2025/2025-01-29.md
@@ -22,7 +22,6 @@ Inability to register attendees due to OASIS system challenges.
 | Denny      | Page        | Individual                                                  | Voting Member |
 | Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
 | Feng       | Cao         | Oracle                                                      | Voting Member |
-| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
 | Martin     | Prpic       | Red Hat                                                     | Voting Member |
 | Thomas     | Schaffer    | Cisco Systems                                               | Voting Member |
 | Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |

--- a/meeting_minutes/2025/2025-01-29.md
+++ b/meeting_minutes/2025/2025-01-29.md
@@ -1,0 +1,72 @@
+![image](https://user-images.githubusercontent.com/1690898/139102180-5c1e2583-14f1-4f58-ab2b-9e3807ed529c.png)
+
+# Common Security Advisory Framework (CSAF) Technical Committee Working Meeting
+
+- Meeting Date: January 29, 2025
+- Time: 18:00 UTC (19:00 CET, 13:00 EST, 10:00 PST)
+
+## Call to Order and Welcome
+
+Meeting called to order @ 17:04 UTC
+
+## Roll call
+
+Inability to register attendees due to OASIS system challenges.
+
+## Participants
+
+| Given Name | Family Name | Affiliation                                                 | Role          |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|
+| Christian  | Banse       | Fraunhofer-Gesellschaft e.V. - Fraunhofer AISEC             | Voting Member |
+| Christoph  | Plutte      | Ericsson AB                                                 | Voting Member |
+| Denny      | Page        | Individual                                                  | Voting Member |
+| Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
+| Feng       | Cao         | Oracle                                                      | Voting Member |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
+| Martin     | Prpic       | Red Hat                                                     | Voting Member |
+| Thomas     | Schaffer    | Cisco Systems                                               | Voting Member |
+| Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member |
+| Stefan     | Hagen       | Individual                                                  | Voting Member |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member |
+| Tobi       | Limmer      | Siemens AG                                                  | Voting Member |
+
+
+
+### Observers present
+
+Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
+
+### Quorum
+
+The meeting achieved quorum and was conducted as a formal session.
+
+## Agenda
+
+- Roll Call
+- Updates or news to the TC
+- Review all open GitHub issues and pull requests requiring TC discussion.
+- CSAF 2.1 Committee Specification Draft
+- Next steps
+- Adjourn
+
+## Meeting Notes
+
+### Updates and Presentations
+
+- Thomas provided an update on the work on reinstating the CSAF.IO domain. Omar and Thomas have worked on restoring it and the site/domain will be available very soon.
+- The potential need to switch from the .IO domain to a generic domain in the future was mentioned.
+
+## GitHub Issues
+
+- Issue #851: The date of the information property in the CSAF document helps order the exploitation date.
+- Issue #672: Enforce use of affected in `csaf_security_advisory`.
+  - There was extensive discussion about this issue.
+  - The `csaf_security_advisory` profile requires the existence of `/vulnerabilities[]/product_status` but does not mandate the inclusion of `/vulnerabilities[]/product_status/affected`.
+  - A motion was presented by Thomas to accept the changes stated in issue #672 and seconded by Denny Page. The motion passed without discussions or objections.
+
+
+## Adjourn
+
+- The meeting was adjourned.
+
+**Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).


### PR DESCRIPTION
This pull request includes the meeting minutes for the CSAF Technical Committee Working Meeting held on January 29, 2025. The changes document the meeting's proceedings, including the roll call, agenda, updates, and discussions on GitHub issues.
