### PR TITLE
Language

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -299,7 +299,7 @@ A CSAF content management system satisfies the "CSAF content management system" 
 
   * `/$schema` with the value prescribed by the schema
   * `/document/csaf_version` with the value prescribed by the schema
-  * `/document/language`
+  * `/document/lang`
   * `/document/notes`
     * `legal_disclaimer` (Terms of use from the configuration)
     * `general` (General Security recommendations from the configuration)
@@ -322,7 +322,7 @@ A CSAF content management system satisfies the "CSAF content management system" 
   * updates the following fields with the values given below or based on the templates from configuration:
     * `/$schema` with the value prescribed by the schema
     * `/document/csaf_version` with the value prescribed by the schema
-    * `/document/language`
+    * `/document/lang`
     * `/document/notes`
       * `legal_disclaimer` (Terms of use from the configuration)
       * `general` (General Security recommendations from the configuration)

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-12-language.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-12-language.md
@@ -1,6 +1,6 @@
 ### Language
 
-For each element of type `/$defs/language_t` it MUST be tested that the language code is valid and exists.
+For each element of type `/$defs/lang_t` it MUST be tested that the language code is valid and exists.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -424,7 +424,7 @@ The relevant path for this test is:
 
 ### Use of Private Language
 
-For each element of type `/$defs/language_t` it MUST be tested that the language code does not contain subtags reserved for private use.
+For each element of type `/$defs/lang_t` it MUST be tested that the language code does not contain subtags reserved for private use.
 
 The relevant paths for this test are:
 
@@ -445,7 +445,7 @@ The relevant paths for this test are:
 
 ### Use of Default Language
 
-For each element of type `/$defs/language_t` it MUST be tested that the language code is not `i-default`.
+For each element of type `/$defs/lang_t` it MUST be tested that the language code is not `i-default`.
 
 The relevant paths for this test are:
 


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#897
- correct mistake where `language` was used instead of `lang`

spotted by @bernhardreiter 