### PR TITLE
Add `Access-Control-Allow-Origin` requirement

### DIFF
--- a/csaf_2.1/prose/edit/src/distributing.md
+++ b/csaf_2.1/prose/edit/src/distributing.md
@@ -597,6 +597,17 @@ The temporary blocking SHOULD be removed as soon as possible, at latest two week
 
 > Also confer to the TC's guidance on content delivery networks and caching.
 
+### Requirement 25: Access-Control-Allow-Origin
+
+For any CSAF documents and related metadata, the web server SHOULD set the HTTP header `Access-Control-Allow-Origin: *`.
+
+> The HTTP header enables users to access the CSAF data with web browser based clients.
+
+The HTTP header MAY be altered to allow just specified domains.
+In such case, the response SHOULD also include the `Vary` header.
+
+> Such restriction may allow the allow-listed domains to send credentials.
+
 ## Roles
 
 This subsection groups the requirements from the previous subsection into named sets which target the roles with the same name.
@@ -634,7 +645,7 @@ A CSAF publisher satisfies the "CSAF provider" role if the party fulfills the fo
 Firstly, the party:
 
 * satisfies the "CSAF publisher" role profile.
-* additionally satisfies the requirements 5 to 7 and 24 in section [sec](#requirements).
+* additionally satisfies the requirements 5 to 7, 24 and 25 in section [sec](#requirements).
 
 Secondly, the party:
 
@@ -658,7 +669,7 @@ A CSAF provider satisfies the "CSAF trusted provider" role if the party:
 
 A distributing party satisfies the "CSAF lister" role if the party:
 
-* satisfies the requirements 6, 21, 22 and 24 in section [sec](#requirements).
+* satisfies the requirements 6, 21, 22, 24 and 25 in section [sec](#requirements).
 * uses the value `lister` for `/aggregator/category`.
 * does not list any mirror pointing to a domain under its own control.
 
@@ -669,7 +680,7 @@ A distributing party satisfies the "CSAF lister" role if the party:
 
 A distributing party satisfies the "CSAF aggregator" role if the party:
 
-* satisfies the requirements 1 to 6 and 21 to 24 in section [sec](#requirements).
+* satisfies the requirements 1 to 6 and 21 to 25 in section [sec](#requirements).
 * uses the value `aggregator` for `/aggregator/category`.
 * lists a mirror for at least two disjoint issuing parties pointing to a domain under its own control.
 * links the public part of the OpenPGP key used to sign CSAF documents for each mirrored issuing party in

--- a/csaf_2.1/prose/edit/src/distributing.md
+++ b/csaf_2.1/prose/edit/src/distributing.md
@@ -604,7 +604,7 @@ For any CSAF documents and related metadata, the web server SHOULD set the HTTP 
 > The HTTP header enables users to access the CSAF data with web browser based clients.
 
 The value of the HTTP header MAY be altered to allow just specified domains.
-In such case, the response SHOULD follow the recommendation of [cite](#FETCH) including but not limited to about the `Vary` header.
+In such case, the response SHOULD follow the recommendations of [cite](#FETCH) including but not limited to those about the `Vary` header.
 
 > Such restriction may allow the allow-listed domains to send credentials.
 

--- a/csaf_2.1/prose/edit/src/distributing.md
+++ b/csaf_2.1/prose/edit/src/distributing.md
@@ -603,8 +603,8 @@ For any CSAF documents and related metadata, the web server SHOULD set the HTTP 
 
 > The HTTP header enables users to access the CSAF data with web browser based clients.
 
-The HTTP header MAY be altered to allow just specified domains.
-In such case, the response SHOULD follow the recommendation of [cite](#FETCH) including but not limited to the `Vary` header.
+The value of the HTTP header MAY be altered to allow just specified domains.
+In such case, the response SHOULD follow the recommendation of [cite](#FETCH) including but not limited to about the `Vary` header.
 
 > Such restriction may allow the allow-listed domains to send credentials.
 

--- a/csaf_2.1/prose/edit/src/distributing.md
+++ b/csaf_2.1/prose/edit/src/distributing.md
@@ -604,7 +604,7 @@ For any CSAF documents and related metadata, the web server SHOULD set the HTTP 
 > The HTTP header enables users to access the CSAF data with web browser based clients.
 
 The HTTP header MAY be altered to allow just specified domains.
-In such case, the response SHOULD also include the `Vary` header.
+In such case, the response SHOULD follow the recommendation of [cite](#FETCH) including but not limited to the `Vary` header.
 
 > Such restriction may allow the allow-listed domains to send credentials.
 

--- a/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-04-informative-references.md
@@ -45,6 +45,9 @@ CWE
 CYCLONEDX161
 :    _CycloneDX Software Bill-of-Material Specification JSON schema version 1.6.1_, cyclonedx.org, November 7, 2024, https://github.com/CycloneDX/specification/blob/1.6.1/schema/bom-1.6.schema.json.
 
+FETCH
+:    _Fetch: Living Standard_, https://fetch.spec.whatwg.org.
+
 GFMCMARK
 :    _GitHub's fork of cmark, a CommonMark parsing and rendering library and program in C_, https://github.com/github/cmark.
 

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -35,7 +35,7 @@ The distribution requirements of CSAF data allow to specify domains as the value
 While a wildcard (`*`) as header value usually prevents implementing browsers from sending credentials during the CORS request,
 the restriction to specified domains often enables sending credentials.
 Allowing several specified domains results in using dynamics on the server, which can widen the attack surface slightly by more code and configuration.
-Furthermore, this might leak information about internal structures or tools used.
+Furthermore, this might reveal information about internal structures, e.g. which domains are allowed to send credentials, or which tools are used.
 Given that credentials from a browser are a potent tool in the event of an attack, restricting the origins seems to imply a higher risk and
 therefore less secure than allowing all domains without credentials.
 

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -39,4 +39,8 @@ Furthermore, this might leak information about internal structures or tools used
 Given that credentials from a browser are a potent tool in the event of an attack, restricting the origins seems to imply a higher risk and
 therefore less secure than allowing all domains without credentials.
 
+As setting the `Access-Control-Allow-Origin` header potentially allows for cross site request forgery,
+it SHOULD only be served on files and directories containing CSAF data.
+For any restricted feeds, standard authentication methods SHOULD be used that are not send by web browsers if the wildcard is used as header value.
+
 -------

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -34,7 +34,7 @@ Moreover, it SHALL be treated as unsafe (user) input.
 The distribution requirements of CSAF data allow to specify domains as the value of the HTTP header `Access-Control-Allow-Origin`.
 While a wildcard (`*`) as header value usually prevents implementing browsers from sending credentials during the CORS request,
 the restriction to specified domains often enables sending credentials.
-As such configuration is more complex, there is a higher risk of misconfiguration.
+Allowing several specified domains results in using dynamics on the server, which can widen the attack surface slightly by more code and configuration.
 Furthermore, this might leak information about internal structures or tools used.
 Given that credentials from a browser are a potent tool in the event of an attack, restricting the origins seems to imply a higher risk and
 therefore less secure than allowing all domains without credentials.

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -31,4 +31,12 @@ Moreover, it SHALL be treated as unsafe (user) input.
   > Additional, supporting mitigation measures like retrieving only CSAF documents from trusted sources and check their integrity and
   > signature before parsing the document SHOULD be in place to reduce the risk further.
 
+The distribution requirements of CSAF data allow to specify domains as the value of the HTTP header `Access-Control-Allow-Origin`.
+While a wildcard (`*`) as header value usually prevents implementing browsers from sending credentials during the CORS request,
+the restriction to specified domains often enables sending credentials.
+As such configuration is more complex, there is a higher risk of misconfiguration.
+Furthermore, this might leak information about internal structures or tools used.
+Given that credentials from a browser are a potent tool in the event of an attack, restricting the origins seems to imply a higher risk and
+therefore less secure than allowing all domains without credentials.
+
 -------

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -34,7 +34,7 @@ Moreover, it SHALL be treated as unsafe (user) input.
 The distribution requirements of CSAF data allow to specify domains as the value of the HTTP header `Access-Control-Allow-Origin`.
 While a wildcard (`*`) as header value usually prevents implementing browsers from sending credentials during the CORS request,
 the restriction to specified domains often enables sending credentials.
-Allowing several specified domains results in using dynamics on the server, which can widen the attack surface slightly by more code and configuration.
+Allowing several specified domains results in using dynamics on the server, which can widen the attack surface by using more code and configuration.
 Furthermore, this might reveal information about internal structures, e.g. which domains are allowed to send credentials, or which tools are used.
 Given that credentials from a browser are a potent tool in the event of an attack, restricting the origins seems to imply a higher risk and
 therefore less secure than allowing all domains without credentials.


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/653
- add requirement 25 as SHOULD
- include it for CSAF provider
- include it for CSAF aggregators
- add security considerations