### PR TITLE
Editorial nits for 2025-03-26

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
@@ -11,6 +11,7 @@ The relevant paths for this test are:
   /product_tree/product_groups[]/product_ids[]
   /product_tree/relationships[]/product_reference
   /product_tree/relationships[]/relates_to_product_reference
+  /vulnerabilities[]/flags[]/product_ids[]
   /vulnerabilities[]/metrics[]/products[]
   /vulnerabilities[]/notes[]/product_ids[]
   /vulnerabilities[]/product_status/first_affected[]

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -8,6 +8,7 @@ The relevant paths for this test are:
 
 ```
   /document/notes[]/group_ids[]
+  /vulnerabilities[]/flags[]/group_ids[]
   /vulnerabilities[]/notes[]/group_ids[]
   /vulnerabilities[]/remediations[]/group_ids[]
   /vulnerabilities[]/threats[]/group_ids[]

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
@@ -1,6 +1,6 @@
 ### CWE{#mandatory-tests--cwe}
 
-For each CWE it MUST be tested that the given CWE exists and is valid in the version provided.
+For each CWE it MUST be tested that the given CWE exists and is valid in the `version` provided.
 Any `id` that refers to a CWE Category or View MUST fail the test.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-02-optional.md
+++ b/csaf_2.1/prose/edit/src/tests-02-optional.md
@@ -1305,11 +1305,13 @@ The relevant path for this test is:
 *Example 1 (which fails the test):*
 
 ```
-      "flags": [
-        {
-          "label": "component_not_present"
-        }
-      ]
+    "notes": [
+      {
+        "category": "description",
+        "text": "Product A is a local time tracking tool. It is mainly used by software developers and can be connected with most modern time-tracking systems.",
+        "title": "Product Description"
+      }
+    ],
 ```
 
-> The given flag does not specify to which products it should be applied.
+> The given note item does not specify to which products it applies to.

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -125,7 +125,7 @@ It MUST be tested that at least one CWE is given.
 The relevant path for this test is:
 
 ```
-  /vulnerabilities[]/cwe
+  /vulnerabilities[]/cwes
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -1,4 +1,4 @@
-## Informative Test
+## Informative Tests
 
 Informative tests provide insights in common mistakes and bad practices.
 They MAY fail at a valid CSAF document.


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/864
- add missing "s" in path of informative test "Missing CWE"
- make version code syntax
- add missing "s" to align
- correct example in prose for test 6.2.38
- addresses parts of https://github.com/oasis-tcs/csaf/issues/909
- add missing path to test 6.1.1 and 6.1.4
