### PR TITLE
Fix SSVC ID for test 6.1.47-15

### DIFF
--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-15.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-15.json
@@ -43,7 +43,7 @@
         {
           "content": {
             "ssvc_v1": {
-              "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-43-15",
+              "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-15",
               "schemaVersion": "1-0-1",
               "selections": [
                 {


### PR DESCRIPTION
Fixed the `id` field in the mandatory positive test 15 JSON to ensure consistency with the document id.