### PR TITLE
Tests - 6.1.37 and 6.1.48

### DIFF
--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Mandatory test: Date and Time (valid example 3)",
+    "title": "Mandatory test: Date and Time (failing example 6)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-37-13",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-37-06",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {
@@ -31,8 +31,8 @@
   },
   "vulnerabilities": [
     {
-      "disclosure_date": "2016-12-31T00:00:60-23:59",
-      "discovery_date": "2015-07-01T06:59:60+07:00"
+      "disclosure_date": "2016-12-31T00:00:60+23:59",
+      "discovery_date": "2015-07-01T06:59:60-07:00"
     }
   ]
 }

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-02.json
@@ -55,7 +55,7 @@
                     "Critical",
                     "Catastrophic"
                   ],
-                  "version": "1.0.0"
+                  "version": "2.0.0"
                 }
               ],
               "timestamp": "2024-01-24T10:00:00.000Z"

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-03.json
@@ -56,7 +56,7 @@
                     "Marginal",
                     "Negligible"
                   ],
-                  "version": "1.0.0"
+                  "version": "2.0.0"
                 }
               ],
               "timestamp": "2024-01-24T10:00:00.000Z"

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-12.json
@@ -55,7 +55,7 @@
                     "Critical",
                     "Catastrophic"
                   ],
-                  "version": "1.0.0"
+                  "version": "2.0.0"
                 }
               ],
               "timestamp": "2024-01-24T10:00:00.000Z"

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-13.json
@@ -56,7 +56,7 @@
                     "Critical",
                     "Catastrophic"
                   ],
-                  "version": "1.0.0"
+                  "version": "2.0.0"
                 }
               ],
               "timestamp": "2024-01-24T10:00:00.000Z"

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1145,6 +1145,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json",
+          "valid": false
         }
       ],
       "valid": [

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -12,7 +12,7 @@ SSVC_101_DPVS_SCHEMA=csaf_2.1/referenced_schema/certcc/Decision_Point_Value_Sele
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json'
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json'
 EXCLUDE_LEAP='oasis_csaf_tc-csaf_2_1-2024-6-1-37-12.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-13.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-14.json'
 EXCLUDE_STRICT=oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
 


### PR DESCRIPTION
- resolves oasis-tcs/csaf#944
- correct sign mistake in timezone in valid example of 6.1.37
- add additional invalid example for 6.1.37
- resolves https://github.com/oasis-tcs/csaf/issues/945
- correct version of SSVC decision point