### PR TITLE
Tests - 6.2.6

### DIFF
--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-03.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-03.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Older Current Release Date than Revision History (failing example 2)",
+    "title": "Optional test: Older Current Release Date than Revision History (failing example 3)",
     "tracking": {
-      "current_release_date": "2024-01-21T11:00:00.000+11:00",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-06-02",
+      "current_release_date": "2024-01-22T11:00:00.000+11:30",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-06-03",
       "initial_release_date": "2023-09-06T10:00:00.000Z",
       "revision_history": [
         {
@@ -25,7 +25,7 @@
           "summary": "Initial version."
         },
         {
-          "date": "2024-01-21T11:00:00.000+10:00",
+          "date": "2024-01-21T13:00:00.000-11:30",
           "number": "2",
           "summary": "Second version."
         }

--- a/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-13.json
+++ b/csaf_2.1/test/validator/data/optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-13.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Optional test: Older Current Release Date than Revision History (failing example 2)",
+    "title": "Optional test: Older Current Release Date than Revision History (valid example 3)",
     "tracking": {
-      "current_release_date": "2024-01-21T11:00:00.000+11:00",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-06-02",
+      "current_release_date": "2024-01-22T11:00:00.000+11:30",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-06-13",
       "initial_release_date": "2023-09-06T10:00:00.000Z",
       "revision_history": [
         {
@@ -25,7 +25,7 @@
           "summary": "Initial version."
         },
         {
-          "date": "2024-01-21T11:00:00.000+10:00",
+          "date": "2024-01-21T12:00:00.000-11:30",
           "number": "2",
           "summary": "Second version."
         }

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1660,6 +1660,10 @@
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-02.json",
           "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-03.json",
+          "valid": true
         }
       ],
       "valid": [
@@ -1669,6 +1673,10 @@
         },
         {
           "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-12.json",
+          "valid": true
+        },
+        {
+          "name": "optional/oasis_csaf_tc-csaf_2_1-2024-6-2-06-13.json",
           "valid": true
         }
       ]


### PR DESCRIPTION
- resolves oasis-tcs/csaf#910
- correct mistake in `current_release_time`
- add invalid example
- add valid example