### PR TITLE
Line Breaks

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -154,7 +154,7 @@ Secondly, the program fulfills the following for all items of:
   Sets the value as given in the configuration of the program or the corresponding argument the program was invoked with.
   If values from both sources are present, the program SHOULD prefer the latter one.
   The program SHALL NOT use hard-coded values.
-* `/document/tracking/id`: If the element `cvrf:ID` contains any line breaks or leading or trailing white space,
+* `/document/tracking/id`: If the element `cvrf:ID` contains any newline sequence or leading or trailing white space,
   the CVRF CSAF converter removes those characters.
   In addition, the converter outputs a warning that the ID was changed.
 * `/product_tree/relationships[]`: If more than one `prod:FullProductName` instance is given,

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -627,8 +627,7 @@ Unique identifier for the document (`id`) of value type `string` with 1 or more 
 ```
 
 Unique identifier for the document holds the Identifier.
-
-> It SHALL NOT start or end with a white space and SHALL NOT contain a line break.
+It SHALL NOT start or end with a white space and SHALL NOT contain a newline sequence.
 
 The ID is a simple label that provides for a wide range of numbering values, types, and schemes.
 Its value SHOULD be assigned and maintained by the original document issuing authority. It MUST be unique for that organization.


### PR DESCRIPTION
- resolves oasis-tcs/csaf#955
- replace "line breaks" with "newline sequence"
- fix format of normative statement