### PR TITLE
Meeting Minutes for 2025-02-26

### DIFF
--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -78,7 +78,7 @@ The meeting achieved quorum and was conducted as a formal session.
 - Issue: https://github.com/oasis-tcs/csaf/issues/877
   - Moving the test for additional items in CSAF documents to the schema for better code generation and clarity.
   - No objections. No discussion, no objections, motion passed.
-  - Thomas makes motion to accept the pull request to accept the changes suggested in Issue [#877](https://github.com/oasis-tcs/csaf/issues/877) and included in CSAF v2.1.
+  - Thomas makes motion to accept the changes suggested in Issue [#877](https://github.com/oasis-tcs/csaf/issues/877) and included in CSAF v2.1.
   - Christoph seconded. Motion passed.
 - Issue: https://github.com/oasis-tcs/csaf/issues/876
   - Thomas suggest that we should add a sentence to prohibit the use of client-side scripts to generate the listing as the data is static and this is a problem for text-based browsers and such entities that filter JavaScript at their firewall.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -91,6 +91,26 @@ The meeting achieved quorum and was conducted as a formal session.
   - Thomas and Omar echo support for inclusion in CSAF v2.1
   - Omar moves to approve the proposal for all notes as stated in Issue [#863](https://github.com/oasis-tcs/csaf/issues/863) and editors work on the specific wording.
   - Stefan seconded. No discussion, no objections, motion passed.
+- Issue: https://github.com/oasis-tcs/csaf/issues/813
+  - Thomas suggests enforcing format validation in CSAF documents to ensure consistency.
+  - Thomas sets the motion to enforce the format validation as stated in Issue [#813](https://github.com/oasis-tcs/csaf/issues/813)
+  - Omar seconded. No discussion, no objections, motion passed.
+- Issue: https://github.com/oasis-tcs/csaf/issues/636
+  - Thomas suggests adding a test or a series of test enforcing the product version range rules.
+  - Omar asks to clarify what specific validation would be enforcing?
+  - Thomas talks describes how the standard uses vers and vls.
+  - Feng mentions that it would be nice as a vendor to not have too many formats for versioning. Suggests using something similar to CVE JSON 5.
+  - Thomas clarifies the rules are not new and already present in CSAF v2.0 (before CVE JSON 5). The CVE JSON 5 has some ambiguity in its definition, but it can be converted to a valid product version range in CSAF.
+  - Thomas mentions the possibility of adding a tool to perform the conversion. 
+    - Mentions complexities of CVE JSON 5 allowing git hashes as a version, and not being able to be automatically evaluatable.
+  - Stefan suggests to steer toward strong automation.
+  - Feng will put the CPE workaround schema for the issues TC members to reference.
+  - Thomas suggests the editors prepare a PR and discuss the validation rules for enforcing product version ranges for review.
+- Issue: https://github.com/oasis-tcs/csaf/issues/653
+  - Thomas suggests including the access control allow origin header as a distribution requirement in CSAF v2.1.
+  - No questions or discussion.
+  - Thomas sets a motion to include the access control allow origin header as a distribution requirement in CSAF v2.1 and as state in Issue [#653](https://github.com/oasis-tcs/csaf/issues/653).
+  - Stefan seconded. No discussion, no objections, motion passed.
 
 ## Adjourn
 

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -91,7 +91,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Thomas and Omar echo support for inclusion in CSAF v2.1
   - Omar moves to approve the proposal for all notes as stated in Issue [#863](https://github.com/oasis-tcs/csaf/issues/863) and editors work on the specific wording.
   - Stefan seconded. No discussion, no objections, motion passed.
-- Issue: https://github.com/oasis-tcs/csaf/issues/813
+- Issue [#813](https://github.com/oasis-tcs/csaf/issues/813)
   - Thomas suggests enforcing format validation in CSAF documents to ensure consistency.
   - Thomas sets the motion to enforce the format validation as stated in Issue [#813](https://github.com/oasis-tcs/csaf/issues/813)
   - Omar seconded. No discussion, no objections, motion passed.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -73,7 +73,24 @@ The meeting achieved quorum and was conducted as a formal session.
   - Location and dates to be provided soon. 
 - Omar and Justin to also present at VulnCon on the updates for CSAF v2.1.
 
-## GitHub Issues
+## GitHub Issues & Pull Requests
+
+- Issue: https://github.com/oasis-tcs/csaf/issues/877
+  - Moving the test for additional items in CSAF documents to the schema for better code generation and clarity.
+  - No objections. No discussion, no objections, motion passed.
+  - Thomas makes motion to accept the pull request to accept the changes suggested in Issue [#877](https://github.com/oasis-tcs/csaf/issues/877) and included in CSAF v2.1.
+  - Christoph seconded. Motion passed.
+- Issue: https://github.com/oasis-tcs/csaf/issues/876
+  - Thomas suggest that we should add a sentence to prohibit the use of client-side scripts to generate the listing as the data is static and this is a problem for text-based browsers and such entities that filter JavaScript at their firewall.
+  - Omar clarifies this is not a change in the schema, but in the documentation.
+  - Stefan suggest phrasing it without negation.
+  - Thomas sets the motion to state that directory listings should be presented in HTML that is server generated as state in Issue [#876](https://github.com/oasis-tcs/csaf/issues/876), notwithstanding any editorial changes that do not undermine the original intent.
+  - Omar seconded. No discussion, no objections, motion passed.
+- Issue: https://github.com/oasis-tcs/csaf/issues/863
+  - Christoph presents the issue to support product specific notes in vulnerabilities by adding product_ids and group_ids to note objects under vulnerability.
+  - Thomas and Omar echo support for inclusion in CSAF v2.1
+  - Omar moves to approve the proposal for all notes as stated in Issue [#863](https://github.com/oasis-tcs/csaf/issues/863) and editors work on the specific wording.
+  - Stefan seconded. No discussion, no objections, motion passed.
 
 ## Adjourn
 

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -11,6 +11,21 @@
 
 ## Participants
 
+| Given Name | Family Name | Affiliation                                                 | Role          |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|
+| Christoph  | Plutte      | Ericsson AB                                                 | Voting Member |
+| Denny      | Page        | Individual                                                  | Voting Member |
+| Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
+| Feng       | Cao         | Oracle                                                      | Voting Member |
+| Michael    | Reeder      | Dell                                                        | Voting Member |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
+| Omar       | Santos      | Cisco Systems                                               | Chair         |
+| Stefan     | Hagen       | Individual                                                  | Voting Member |
+| Thomas     | Schaffer    | Cisco Systems                                               | Member        |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member |
+| Tobi       | Limmer      | Siemens AG                                                  | Voting Member |
+| Vivek      | Nair        | Microsoft Corporation                                       | Voting Member |
+
 ### Observers present
 
 Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
@@ -19,6 +34,13 @@ Note: Observers of this committee that are ready to become Members should follow
 
 ## Agenda
 
+- Roll Call
+- Updates or news to the TC
+- Review all open GitHub issues and pull requests requiring TC discussion.
+- CSAF 2.1 Committee Specification Draft
+- Next steps
+- Adjourn
+
 ## Meeting Notes
 
 ### Updates and Presentations
@@ -26,5 +48,7 @@ Note: Observers of this committee that are ready to become Members should follow
 ## GitHub Issues
 
 ## Adjourn
+
+- The meeting was adjourned.
 
 **Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -75,7 +75,7 @@ The meeting achieved quorum and was conducted as a formal session.
 
 ## GitHub Issues & Pull Requests
 
-- Issue: https://github.com/oasis-tcs/csaf/issues/877
+- Issue [#877](https://github.com/oasis-tcs/csaf/issues/877)
   - Moving the test for additional items in CSAF documents to the schema for better code generation and clarity.
   - No objections. No discussion, no objections, motion passed.
   - Thomas makes motion to accept the changes suggested in Issue [#877](https://github.com/oasis-tcs/csaf/issues/877) and included in CSAF v2.1.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -21,7 +21,7 @@ Inability to register attendees due to OASIS system challenges.
 | Denny      | Page        | Individual                                                  | Voting Member |
 | Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
 | Feng       | Cao         | Oracle                                                      | Voting Member |
-| Michael    | Reeder      | Dell                                                                       | Member         |
+| Michael    | Reeder      | Dell                                                        | Member        |
 | Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
 | Omar       | Santos      | Cisco Systems                                               | Chair         |
 | Stefan     | Hagen       | Individual                                                  | Voting Member |

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -95,7 +95,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Thomas suggests enforcing format validation in CSAF documents to ensure consistency.
   - Thomas sets the motion to enforce the format validation as stated in Issue [#813](https://github.com/oasis-tcs/csaf/issues/813)
   - Omar seconded. No discussion, no objections, motion passed.
-- Issue: https://github.com/oasis-tcs/csaf/issues/636
+- Issue [#636](https://github.com/oasis-tcs/csaf/issues/636)
   - Thomas suggests adding a test or a series of test enforcing the product version range rules.
   - Omar asks to clarify what specific validation would be enforcing?
   - Thomas talks describes how the standard uses vers and vls.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -87,7 +87,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Thomas sets the motion to state that directory listings should be presented in HTML that is server generated as state in Issue [#876](https://github.com/oasis-tcs/csaf/issues/876), notwithstanding any editorial changes that do not undermine the original intent.
   - Omar seconded. No discussion, no objections, motion passed.
 - Issue [#863](https://github.com/oasis-tcs/csaf/issues/863)
-  - Christoph presents the issue to support product specific notes in vulnerabilities by adding product_ids and group_ids to note objects under vulnerability.
+  - Christoph presents the issue to support product specific notes in vulnerabilities by adding `product_ids` and `group_ids` to note objects under vulnerability.
   - Thomas and Omar echo support for inclusion in CSAF v2.1
   - Omar moves to approve the proposal for all notes as stated in Issue [#863](https://github.com/oasis-tcs/csaf/issues/863) and editors work on the specific wording.
   - Stefan seconded. No discussion, no objections, motion passed.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -21,7 +21,7 @@ Inability to register attendees due to OASIS system challenges.
 | Denny      | Page        | Individual                                                  | Voting Member |
 | Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member |
 | Feng       | Cao         | Oracle                                                      | Voting Member |
-| Michael    | Reeder      | Dell                                                        | Voting Member |
+| Michael    | Reeder      | Dell                                                                       | Member         |
 | Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Voting Member |
 | Omar       | Santos      | Cisco Systems                                               | Chair         |
 | Stefan     | Hagen       | Individual                                                  | Voting Member |

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -80,7 +80,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - No objections. No discussion, no objections, motion passed.
   - Thomas makes motion to accept the changes suggested in Issue [#877](https://github.com/oasis-tcs/csaf/issues/877) and included in CSAF v2.1.
   - Christoph seconded. Motion passed.
-- Issue: https://github.com/oasis-tcs/csaf/issues/876
+- Issue [#876](https://github.com/oasis-tcs/csaf/issues/876)
   - Thomas suggest that we should add a sentence to prohibit the use of client-side scripts to generate the listing as the data is static and this is a problem for text-based browsers and such entities that filter JavaScript at their firewall.
   - Omar clarifies this is not a change in the schema, but in the documentation.
   - Stefan suggest phrasing it without negation.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -49,7 +49,7 @@ The meeting achieved quorum and was conducted as a formal session.
 
 ## Meeting Notes
 
-- Omar provided update that OASIS board/staff has setup a technology subcommittee (solutions team) has been formed to evaluate the challenges faced with Higher Logic tool.
+- Omar provided update that OASIS board/staff has setup a technology subcommittee (solutions team) to evaluate the challenges faced with Higher Logic tool.
   - Subcommittee made up of a group of some of the most active OASIS members.
     - Stefan is part of the subcommittee.
   - Seems to be consensus on looking at tools that are not dependent on a specific vendor.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -86,7 +86,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Stefan suggest phrasing it without negation.
   - Thomas sets the motion to state that directory listings should be presented in HTML that is server generated as state in Issue [#876](https://github.com/oasis-tcs/csaf/issues/876), notwithstanding any editorial changes that do not undermine the original intent.
   - Omar seconded. No discussion, no objections, motion passed.
-- Issue: https://github.com/oasis-tcs/csaf/issues/863
+- Issue [#863](https://github.com/oasis-tcs/csaf/issues/863)
   - Christoph presents the issue to support product specific notes in vulnerabilities by adding product_ids and group_ids to note objects under vulnerability.
   - Thomas and Omar echo support for inclusion in CSAF v2.1
   - Omar moves to approve the proposal for all notes as stated in Issue [#863](https://github.com/oasis-tcs/csaf/issues/863) and editors work on the specific wording.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -65,7 +65,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Thomas will take the action to discuss with OASIS staff about the utlization of the tool.
 - Stefan supports the idea of using BSI open source tool for calculating quorum.
 - Stefan emphasizes the importance of these tools for TC processes to function properly (quorum, membership/participation, etc.).
-- Omar moves to accept the Dember meeting minutes. Stefan seconds.
+- Omar moves to accept the December meeting minutes. Stefan seconds.
   - December meeting minutes accepted. PR: https://github.com/oasis-tcs/csaf/pull/869
   - Motion will be sent over email for January meeting minutes.
 - Thomas announces upcoming CSAF workshop led by Thomas (BSI) and Justin (CISA) at the 2025 VulnCon conference in April in Raleigh, NC.

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -49,13 +49,29 @@ The meeting achieved quorum and was conducted as a formal session.
 
 ## Meeting Notes
 
-- Omar provided update that a technology subcommittee (solutions team) has been formed to evaluate and select tools that are not vendor-dependent.
+- Omar provided update that OASIS board/staff has setup a technology subcommittee (solutions team) has been formed to evaluate the challenges faced with Higher Logic tool.
+  - Subcommittee made up of a group of some of the most active OASIS members.
+    - Stefan is part of the subcommittee.
+  - Seems to be consensus on looking at tools that are not dependent on a specific vendor.
+    - Not only for tools for the TCs, but all tools across OASIS for members support, budgeting, etc.
   - GitHub and Google Calendar are being considered as potential tools for TCs, with further exploration of other tools.
-- Omar asked TC to review meeting minutes for December and January:
+    - Aim is to be less disruptive to TC activities, and to embrace the tools that are already being utilized and working well for the TCs. 
+- Omar asked TC to review meeting minutes for December (12/18) and January (1/29):
   - PR: https://github.com/oasis-tcs/csaf/pull/869
-  - December meeting minutes accepted
   - PR: https://github.com/oasis-tcs/csaf/pull/878
   - January meeting minutes to be updated via GitHub and motion will be done on Higher Logic platform to accept January meeting minutes.
+- Thomas accounced that BSI is working on an open source tool to track quorum.
+  - Currently under development.
+  - Thomas will take the action to discuss with OASIS staff about the utlization of the tool.
+- Stefan supports the idea of using BSI open source tool for calculating quorum.
+- Stefan emphasizes the importance of these tools for TC processes to function properly (quorum, membership/participation, etc.).
+- Omar moves to accept the Dember meeting minutes. Stefan seconds.
+  - December meeting minutes accepted. PR: https://github.com/oasis-tcs/csaf/pull/869
+  - Motion will be sent over email for January meeting minutes.
+- Thomas announces upcoming CSAF workshop led by Thomas (BSI) and Justin (CISA) at the 2025 VulnCon conference in April in Raleigh, NC.
+- Thomas announces unconfirmed/tentative CSAF workshop to possibly take place the week after the RSA Conference.
+  - Location and dates to be provided soon. 
+- Omar and Justin to also present at VulnCon on the updates for CSAF v2.1.
 
 ## GitHub Issues
 

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -7,7 +7,11 @@
 
 ## Call to Order and Welcome
 
+Meeting called to order.
+
 ## Roll call
+
+Inability to register attendees due to OASIS system challenges.
 
 ## Participants
 
@@ -32,6 +36,8 @@ Note: Observers of this committee that are ready to become Members should follow
 
 ### Quorum
 
+The meeting achieved quorum and was conducted as a formal session.
+
 ## Agenda
 
 - Roll Call
@@ -43,7 +49,13 @@ Note: Observers of this committee that are ready to become Members should follow
 
 ## Meeting Notes
 
-### Updates and Presentations
+- Omar provided update that a technology subcommittee (solutions team) has been formed to evaluate and select tools that are not vendor-dependent.
+  - GitHub and Google Calendar are being considered as potential tools for TCs, with further exploration of other tools.
+- Omar asked TC to review meeting minutes for December and January:
+  - PR: https://github.com/oasis-tcs/csaf/pull/869
+  - December meeting minutes accepted
+  - PR: https://github.com/oasis-tcs/csaf/pull/878
+  - January meeting minutes to be updated via GitHub and motion will be done on Higher Logic platform to accept January meeting minutes.
 
 ## GitHub Issues
 

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -98,7 +98,7 @@ The meeting achieved quorum and was conducted as a formal session.
 - Issue [#636](https://github.com/oasis-tcs/csaf/issues/636)
   - Thomas suggests adding a test or a series of test enforcing the product version range rules.
   - Omar asks to clarify what specific validation would be enforcing?
-  - Thomas talks describes how the standard uses vers and vls.
+  - Thomas describes how the standard uses `vers` and `vls`.
   - Feng mentions that it would be nice as a vendor to not have too many formats for versioning. Suggests using something similar to CVE JSON 5.
   - Thomas clarifies the rules are not new and already present in CSAF v2.0 (before CVE JSON 5). The CVE JSON 5 has some ambiguity in its definition, but it can be converted to a valid product version range in CSAF.
   - Thomas mentions the possibility of adding a tool to perform the conversion. 

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -106,7 +106,7 @@ The meeting achieved quorum and was conducted as a formal session.
   - Stefan suggests to steer toward strong automation.
   - Feng will put the CPE workaround schema for the issues TC members to reference.
   - Thomas suggests the editors prepare a PR and discuss the validation rules for enforcing product version ranges for review.
-- Issue: https://github.com/oasis-tcs/csaf/issues/653
+- Issue [#653](https://github.com/oasis-tcs/csaf/issues/653)
   - Thomas suggests including the access control allow origin header as a distribution requirement in CSAF v2.1.
   - No questions or discussion.
   - Thomas sets a motion to include the access control allow origin header as a distribution requirement in CSAF v2.1 and as state in Issue [#653](https://github.com/oasis-tcs/csaf/issues/653).

--- a/meeting_minutes/2025/2025-02-26.md
+++ b/meeting_minutes/2025/2025-02-26.md
@@ -1,0 +1,30 @@
+![image](https://user-images.githubusercontent.com/1690898/139102180-5c1e2583-14f1-4f58-ab2b-9e3807ed529c.png)
+
+# Common Security Advisory Framework (CSAF) Technical Committee Working Meeting
+
+- Meeting Date: February 26, 2025
+- Time: 18:00 UTC (19:00 CET, 13:00 EST, 10:00 PST)
+
+## Call to Order and Welcome
+
+## Roll call
+
+## Participants
+
+### Observers present
+
+Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
+
+### Quorum
+
+## Agenda
+
+## Meeting Notes
+
+### Updates and Presentations
+
+## GitHub Issues
+
+## Adjourn
+
+**Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).


### PR DESCRIPTION
This pull request includes the meeting minutes for the CSAF Technical Committee meeting held on February 26, 2025. 

The changes document the meeting's proceedings, including the roll call, agenda, updates, and discussions on GitHub issues.

This PR is ready for review.