### PR TITLE
`"additionalProperties": false`

### DIFF
--- a/csaf_2.1/json_schema/aggregator_json_schema.json
+++ b/csaf_2.1/json_schema/aggregator_json_schema.json
@@ -44,7 +44,8 @@
           "description": "Contains the URL of the provider-metadata.json for that entry.",
           "$ref": "https://docs.oasis-open.org/csaf/csaf/v2.1/provider_json_schema.json#/properties/canonical_url"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "mirrors_t": {
       "title": "List of mirrors",
@@ -132,7 +133,8 @@
             "https://csaf.io"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "aggregator_version": {
       "title": "CSAF aggregator version",
@@ -171,7 +173,8 @@
             "description": "Contains a list of URLs or mirrors for this CSAF provider.",
             "$ref": "#/$defs/mirrors_t"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "csaf_publishers": {
@@ -213,7 +216,8 @@
               "on notification by CSAF publisher"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "last_updated": {
@@ -222,5 +226,6 @@
       "type": "string",
       "format": "date-time"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/csaf_2.1/json_schema/csaf_json_schema.json
+++ b/csaf_2.1/json_schema/csaf_json_schema.json
@@ -64,7 +64,8 @@
               "format": "uri"
             }
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "branches_t": {
@@ -125,7 +126,8 @@
           "product": {
             "$ref": "#/$defs/full_product_name_t"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "full_product_name_t": {
@@ -217,7 +219,8 @@
                             "9ea4c8200113d49d26505da0e02e2f49055dc078d1ad7a419b32e291c7afebbb84badfbd46dec42883bea0b2a1fa697c"
                           ]
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "filename": {
@@ -231,7 +234,8 @@
                       "sudoers.so"
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "model_numbers": {
@@ -325,12 +329,15 @@
                     "type": "string",
                     "format": "uri"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "lang_t": {
       "title": "Language type",
@@ -409,7 +416,8 @@
               "Impact on safety systems"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "product_group_id_t": {
@@ -489,7 +497,8 @@
             "type": "string",
             "format": "uri"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "version_t": {
@@ -563,7 +572,8 @@
                 "Moderate"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "category": {
           "title": "Document category",
@@ -623,7 +633,8 @@
                     "US Federal Civilian Authorities"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "text": {
               "title": "Textual description",
@@ -668,9 +679,11 @@
                     "https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Kritis/Merkblatt_TLP.pdf"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         },
         "lang": {
           "title": "Document language",
@@ -742,7 +755,8 @@
                 "https://www.example.com"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "references": {
           "title": "Document references",
@@ -843,9 +857,11 @@
                         "2"
                       ]
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "id": {
               "title": "Unique identifier for the document",
@@ -904,7 +920,8 @@
                       "Initial version."
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "status": {
@@ -920,9 +937,11 @@
             "version": {
               "$ref": "#/$defs/version_t"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "product_tree": {
       "title": "Product tree",
@@ -979,7 +998,8 @@
                   "The x64 versions of the operating system."
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "relationships": {
@@ -1023,10 +1043,12 @@
                 "description": "Holds a Product ID that refers to the Full Product Name element, which is referenced as the second element of the relationship.",
                 "$ref": "#/$defs/product_id_t"
               }
-            }
+            },
+            "additionalProperties": false
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "vulnerabilities": {
       "title": "Vulnerabilities",
@@ -1102,7 +1124,8 @@
                     "4.12"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "disclosure_date": {
@@ -1155,7 +1178,8 @@
                 "product_ids": {
                   "$ref": "#/$defs/products_t"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "ids": {
@@ -1193,7 +1217,8 @@
                     "oasis-tcs/csaf#210"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "involvements": {
@@ -1248,7 +1273,8 @@
                   "type": "string",
                   "minLength": 1
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "metrics": {
@@ -1316,12 +1342,14 @@
                           "type": "string",
                           "format": "date-time"
                         }
-                      }
+                      },
+                      "additionalProperties": false
                     },
                     "ssvc_v1": {
                       "$ref": "https://certcc.github.io/SSVC/data/schema/v1/Decision_Point_Value_Selection-1-0-1.schema.json"
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "products": {
                   "$ref": "#/$defs/products_t"
@@ -1332,7 +1360,8 @@
                   "type": "string",
                   "format": "uri"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "notes": {
@@ -1391,7 +1420,8 @@
                 "description": "It is not known whether these versions are or are not affected by the vulnerability. There is also no investigation and therefore the status might never be determined.",
                 "$ref": "#/$defs/products_t"
               }
-            }
+            },
+            "additionalProperties": false
           },
           "references": {
             "title": "Vulnerability references",
@@ -1486,7 +1516,8 @@
                       "type": "string",
                       "minLength": 1
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 },
                 "url": {
                   "title": "URL to the remediation",
@@ -1494,7 +1525,8 @@
                   "type": "string",
                   "format": "uri"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "threats": {
@@ -1539,7 +1571,8 @@
                 "product_ids": {
                   "$ref": "#/$defs/products_t"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "title": {
@@ -1548,8 +1581,10 @@
             "type": "string",
             "minLength": 1
           }
-        }
+        },
+        "additionalProperties": false
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/csaf_2.1/json_schema/provider_json_schema.json
+++ b/csaf_2.1/json_schema/provider_json_schema.json
@@ -82,7 +82,8 @@
                 "description": "Contains the base url for the directory-based distribution.",
                 "$ref": "#/$defs/url_t"
               }
-            }
+            },
+            "additionalProperties": false
           },
           "rolie": {
             "title": "ROLIE",
@@ -144,7 +145,8 @@
                       "description": "Contains the URL of the feed.",
                       "$ref": "#/$defs/json_url_t"
                     }
-                  }
+                  },
+                  "additionalProperties": false
                 }
               },
               "services": {
@@ -159,9 +161,11 @@
                   "$ref": "#/$defs/json_url_t"
                 }
               }
-            }
+            },
+            "additionalProperties": false
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "last_updated": {
@@ -215,7 +219,8 @@
             "description": "Contains the URL where the key can be retrieved.",
             "$ref": "#/$defs/url_t"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "publisher": {
@@ -234,5 +239,6 @@
         "csaf_trusted_provider"
       ]
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -104,6 +104,8 @@ Firstly, the program:
 
 * satisfies the "CSAF producer" conformance profile.
 * takes only CVRF documents as input.
+* outputs a warning that an additional property was detected and not converted if it detects an additional property in the input.
+  The CVRF CSAF converter converter SHALL ignore that additional property during the conversion.
 * additionally satisfies the normative requirements given below.
 
 Secondly, the program fulfills the following for all items of:
@@ -582,6 +584,8 @@ Firstly, the program:
 
 * satisfies the "CSAF producer" conformance profile.
 * takes only CSAF 2.0 documents as input.
+* outputs a warning that an additional property was detected and not converted if it detects an additional property in the input.
+  The CSAF 2.0 to CSAF 2.1 converter SHALL ignore that additional property during the conversion.
 * additionally satisfies the normative requirements given below.
 
 Secondly, the program fulfills the following for all items of:

--- a/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
@@ -57,8 +57,9 @@ Delegation to industry best practices technologies is used in referencing schema
   * Common Vulnerability Scoring System (CVSS) Version 2.0 [cite](#CVSS2)
     * JSON Schema Reference: https://www.first.org/cvss/cvss-v2.0.json
 
-Even though the JSON schema does not prohibit specifically additional properties and custom keywords,
+Even though not all - especially the referenced ones - JSON schemas prohibit specifically additional properties and custom keywords,
 it is strongly recommended not to use them. Suggestions for new fields SHOULD be made through issues in the TC's GitHub.
+The JSON schemas defined in this standard do not allow the use of additional properties and custom keywords.
 
 > The standardized fields allow for scalability across different issuing parties and dramatically reduce the human effort and
 > need for dedicated parsers as well as other tools on the side of the consuming parties.

--- a/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
@@ -57,7 +57,7 @@ Delegation to industry best practices technologies is used in referencing schema
   * Common Vulnerability Scoring System (CVSS) Version 2.0 [cite](#CVSS2)
     * JSON Schema Reference: https://www.first.org/cvss/cvss-v2.0.json
 
-Even though not all - especially the referenced ones - JSON schemas prohibit specifically additional properties and custom keywords,
+Even though not all - especially the referenced - JSON schemas prohibit specifically additional properties and custom keywords,
 it is strongly recommended not to use them. Suggestions for new fields SHOULD be made through issues in the TC's GitHub.
 The JSON schemas defined in this standard do not allow the use of additional properties and custom keywords.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
@@ -9,8 +9,8 @@ The relevant path for this test is:
   /
 ```
 
-> To implement this test it is deemed sufficient to validate the CSAF document against a "strict" version schema that
-> has all references integrated and sets `additionalProperties` to `false` for every key of type `object`.
+> To implement this test it is deemed sufficient to validate the CSAF document against a "strict" version schema that has all references integrated
+> and sets `additionalProperties` respectively `unevaluatedProperties` to `false` at all appropriate places to detect additional properties.
 
 *Example 1 (which fails the test):*
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
@@ -1,6 +1,7 @@
 ### Additional Properties
 
 It MUST be tested that there is no additional property in the CSAF document that was not defined in the CSAF JSON schema.
+This also applies for referenced schemas.
 
 The relevant path for this test is:
 
@@ -9,17 +10,18 @@ The relevant path for this test is:
 ```
 
 > To implement this test it is deemed sufficient to validate the CSAF document against a "strict" version schema that
-> sets `additionalProperties` to `false` for every key of type `object`.
+> has all references integrated and sets `additionalProperties` to `false` for every key of type `object`.
 
 *Example 1 (which fails the test):*
 
 ```
-  "document": {
-    "category": "csaf_base",
-    "csaf_version": "2.1",
-    "custom_property": "any",
-    // ...
-  }
+            "cvss_v3": {
+              "baseScore": 6.4,
+              "baseSeverity": "MEDIUM",
+              "custom_property": "any",
+              "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:N/I:H/A:L",
+              "version": "3.1"
+            }
 ```
 
 > The key `custom_property` is not defined in the JSON schema.

--- a/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
+++ b/csaf_2.1/referenced_schema/first/cvss-v4.0_strict.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://www.first.org/cvss/cvss-v4.0.json?20240216",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "unevaluatedProperties": false,
   "allOf": [
     {
@@ -8,50 +8,50 @@
         {
           "properties": {
             "baseScore": {
-              "$ref": "#/definitions/noneScoreType"
+              "$ref": "#/$defs/noneScoreType"
             },
             "baseSeverity": {
-              "$ref": "#/definitions/noneSeverityType"
+              "$ref": "#/$defs/noneSeverityType"
             }
           }
         },
         {
           "properties": {
             "baseScore": {
-              "$ref": "#/definitions/lowScoreType"
+              "$ref": "#/$defs/lowScoreType"
             },
             "baseSeverity": {
-              "$ref": "#/definitions/lowSeverityType"
+              "$ref": "#/$defs/lowSeverityType"
             }
           }
         },
         {
           "properties": {
             "baseScore": {
-              "$ref": "#/definitions/mediumScoreType"
+              "$ref": "#/$defs/mediumScoreType"
             },
             "baseSeverity": {
-              "$ref": "#/definitions/mediumSeverityType"
+              "$ref": "#/$defs/mediumSeverityType"
             }
           }
         },
         {
           "properties": {
             "baseScore": {
-              "$ref": "#/definitions/highScoreType"
+              "$ref": "#/$defs/highScoreType"
             },
             "baseSeverity": {
-              "$ref": "#/definitions/highSeverityType"
+              "$ref": "#/$defs/highSeverityType"
             }
           }
         },
         {
           "properties": {
             "baseScore": {
-              "$ref": "#/definitions/criticalScoreType"
+              "$ref": "#/$defs/criticalScoreType"
             },
             "baseSeverity": {
-              "$ref": "#/definitions/criticalSeverityType"
+              "$ref": "#/$defs/criticalSeverityType"
             }
           }
         }
@@ -62,50 +62,50 @@
         {
           "properties": {
             "threatScore": {
-              "$ref": "#/definitions/noneScoreType"
+              "$ref": "#/$defs/noneScoreType"
             },
             "threatSeverity": {
-              "$ref": "#/definitions/noneSeverityType"
+              "$ref": "#/$defs/noneSeverityType"
             }
           }
         },
         {
           "properties": {
             "threatScore": {
-              "$ref": "#/definitions/lowScoreType"
+              "$ref": "#/$defs/lowScoreType"
             },
             "threatSeverity": {
-              "$ref": "#/definitions/lowSeverityType"
+              "$ref": "#/$defs/lowSeverityType"
             }
           }
         },
         {
           "properties": {
             "threatScore": {
-              "$ref": "#/definitions/mediumScoreType"
+              "$ref": "#/$defs/mediumScoreType"
             },
             "threatSeverity": {
-              "$ref": "#/definitions/mediumSeverityType"
+              "$ref": "#/$defs/mediumSeverityType"
             }
           }
         },
         {
           "properties": {
             "threatScore": {
-              "$ref": "#/definitions/highScoreType"
+              "$ref": "#/$defs/highScoreType"
             },
             "threatSeverity": {
-              "$ref": "#/definitions/highSeverityType"
+              "$ref": "#/$defs/highSeverityType"
             }
           }
         },
         {
           "properties": {
             "threatScore": {
-              "$ref": "#/definitions/criticalScoreType"
+              "$ref": "#/$defs/criticalScoreType"
             },
             "threatSeverity": {
-              "$ref": "#/definitions/criticalSeverityType"
+              "$ref": "#/$defs/criticalSeverityType"
             }
           }
         }
@@ -116,57 +116,57 @@
         {
           "properties": {
             "environmentalScore": {
-              "$ref": "#/definitions/noneScoreType"
+              "$ref": "#/$defs/noneScoreType"
             },
             "environmentalSeverity": {
-              "$ref": "#/definitions/noneSeverityType"
+              "$ref": "#/$defs/noneSeverityType"
             }
           }
         },
         {
           "properties": {
             "environmentalScore": {
-              "$ref": "#/definitions/lowScoreType"
+              "$ref": "#/$defs/lowScoreType"
             },
             "environmentalSeverity": {
-              "$ref": "#/definitions/lowSeverityType"
+              "$ref": "#/$defs/lowSeverityType"
             }
           }
         },
         {
           "properties": {
             "environmentalScore": {
-              "$ref": "#/definitions/mediumScoreType"
+              "$ref": "#/$defs/mediumScoreType"
             },
             "environmentalSeverity": {
-              "$ref": "#/definitions/mediumSeverityType"
+              "$ref": "#/$defs/mediumSeverityType"
             }
           }
         },
         {
           "properties": {
             "environmentalScore": {
-              "$ref": "#/definitions/highScoreType"
+              "$ref": "#/$defs/highScoreType"
             },
             "environmentalSeverity": {
-              "$ref": "#/definitions/highSeverityType"
+              "$ref": "#/$defs/highSeverityType"
             }
           }
         },
         {
           "properties": {
             "environmentalScore": {
-              "$ref": "#/definitions/criticalScoreType"
+              "$ref": "#/$defs/criticalScoreType"
             },
             "environmentalSeverity": {
-              "$ref": "#/definitions/criticalSeverityType"
+              "$ref": "#/$defs/criticalSeverityType"
             }
           }
         }
       ]
     }
   ],
-  "definitions": {
+  "$defs": {
     "attackComplexityType": {
       "enum": [
         "HIGH",
@@ -231,7 +231,6 @@
     "highScoreType": {
       "maximum": 8.9,
       "minimum": 7.0,
-      "multipleOf": 0.1,
       "type": "number"
     },
     "highSeverityType": {
@@ -448,88 +447,88 @@
   ],
   "properties": {
     "Automatable": {
-      "$ref": "#/definitions/automatableType"
+      "$ref": "#/$defs/automatableType"
     },
     "Recovery": {
-      "$ref": "#/definitions/recoveryType"
+      "$ref": "#/$defs/recoveryType"
     },
     "Safety": {
-      "$ref": "#/definitions/safetyType"
+      "$ref": "#/$defs/safetyType"
     },
     "attackComplexity": {
-      "$ref": "#/definitions/attackComplexityType"
+      "$ref": "#/$defs/attackComplexityType"
     },
     "attackRequirements": {
-      "$ref": "#/definitions/attackRequirementsType"
+      "$ref": "#/$defs/attackRequirementsType"
     },
     "attackVector": {
-      "$ref": "#/definitions/attackVectorType"
+      "$ref": "#/$defs/attackVectorType"
     },
     "availabilityRequirement": {
-      "$ref": "#/definitions/ciaRequirementType"
+      "$ref": "#/$defs/ciaRequirementType"
     },
     "confidentialityRequirement": {
-      "$ref": "#/definitions/ciaRequirementType"
+      "$ref": "#/$defs/ciaRequirementType"
     },
     "exploitMaturity": {
-      "$ref": "#/definitions/exploitMaturityType"
+      "$ref": "#/$defs/exploitMaturityType"
     },
     "integrityRequirement": {
-      "$ref": "#/definitions/ciaRequirementType"
+      "$ref": "#/$defs/ciaRequirementType"
     },
     "modifiedAttackComplexity": {
-      "$ref": "#/definitions/modifiedAttackComplexityType"
+      "$ref": "#/$defs/modifiedAttackComplexityType"
     },
     "modifiedAttackRequirements": {
-      "$ref": "#/definitions/modifiedAttackRequirementsType"
+      "$ref": "#/$defs/modifiedAttackRequirementsType"
     },
     "modifiedAttackVector": {
-      "$ref": "#/definitions/modifiedAttackVectorType"
+      "$ref": "#/$defs/modifiedAttackVectorType"
     },
     "modifiedPrivilegesRequired": {
-      "$ref": "#/definitions/modifiedPrivilegesRequiredType"
+      "$ref": "#/$defs/modifiedPrivilegesRequiredType"
     },
     "modifiedSubAvailabilityImpact": {
-      "$ref": "#/definitions/modifiedSubIaType"
+      "$ref": "#/$defs/modifiedSubIaType"
     },
     "modifiedSubConfidentialityImpact": {
-      "$ref": "#/definitions/modifiedSubCType"
+      "$ref": "#/$defs/modifiedSubCType"
     },
     "modifiedSubIntegrityImpact": {
-      "$ref": "#/definitions/modifiedSubIaType"
+      "$ref": "#/$defs/modifiedSubIaType"
     },
     "modifiedUserInteraction": {
-      "$ref": "#/definitions/modifiedUserInteractionType"
+      "$ref": "#/$defs/modifiedUserInteractionType"
     },
     "modifiedVulnAvailabilityImpact": {
-      "$ref": "#/definitions/modifiedVulnCiaType"
+      "$ref": "#/$defs/modifiedVulnCiaType"
     },
     "modifiedVulnConfidentialityImpact": {
-      "$ref": "#/definitions/modifiedVulnCiaType"
+      "$ref": "#/$defs/modifiedVulnCiaType"
     },
     "modifiedVulnIntegrityImpact": {
-      "$ref": "#/definitions/modifiedVulnCiaType"
+      "$ref": "#/$defs/modifiedVulnCiaType"
     },
     "privilegesRequired": {
-      "$ref": "#/definitions/privilegesRequiredType"
+      "$ref": "#/$defs/privilegesRequiredType"
     },
     "providerUrgency": {
-      "$ref": "#/definitions/providerUrgencyType"
+      "$ref": "#/$defs/providerUrgencyType"
     },
     "subAvailabilityImpact": {
-      "$ref": "#/definitions/subCiaType"
+      "$ref": "#/$defs/subCiaType"
     },
     "subConfidentialityImpact": {
-      "$ref": "#/definitions/subCiaType"
+      "$ref": "#/$defs/subCiaType"
     },
     "subIntegrityImpact": {
-      "$ref": "#/definitions/subCiaType"
+      "$ref": "#/$defs/subCiaType"
     },
     "userInteraction": {
-      "$ref": "#/definitions/userInteractionType"
+      "$ref": "#/$defs/userInteractionType"
     },
     "valueDensity": {
-      "$ref": "#/definitions/valueDensityType"
+      "$ref": "#/$defs/valueDensityType"
     },
     "vectorString": {
       "pattern": "^CVSS:4[.]0/AV:[NALP]/AC:[LH]/AT:[NP]/PR:[NLH]/UI:[NPA]/VC:[HLN]/VI:[HLN]/VA:[HLN]/SC:[HLN]/SI:[HLN]/SA:[HLN](/E:[XAPU])?(/CR:[XHML])?(/IR:[XHML])?(/AR:[XHML])?(/MAV:[XNALP])?(/MAC:[XLH])?(/MAT:[XNP])?(/MPR:[XNLH])?(/MUI:[XNPA])?(/MVC:[XNLH])?(/MVI:[XNLH])?(/MVA:[XNLH])?(/MSC:[XNLH])?(/MSI:[XNLHS])?(/MSA:[XNLHS])?(/S:[XNP])?(/AU:[XNY])?(/R:[XAUI])?(/V:[XDC])?(/RE:[XLMH])?(/U:(X|Clear|Green|Amber|Red))?$",
@@ -543,16 +542,16 @@
       "type": "string"
     },
     "vulnAvailabilityImpact": {
-      "$ref": "#/definitions/vulnCiaType"
+      "$ref": "#/$defs/vulnCiaType"
     },
     "vulnConfidentialityImpact": {
-      "$ref": "#/definitions/vulnCiaType"
+      "$ref": "#/$defs/vulnCiaType"
     },
     "vulnIntegrityImpact": {
-      "$ref": "#/definitions/vulnCiaType"
+      "$ref": "#/$defs/vulnCiaType"
     },
     "vulnerabilityResponseEffort": {
-      "$ref": "#/definitions/vulnerabilityResponseEffortType"
+      "$ref": "#/$defs/vulnerabilityResponseEffortType"
     }
   },
   "required": [

--- a/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-02.json
+++ b/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-02.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Recommended Test: Additional Properties (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-20-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v4": {
+              "baseScore": 7.3,
+              "baseSeverity": "HIGH",
+              "custom_property": "any",
+              "vectorString": "CVSS:4.0/AV:A/AC:L/AT:P/PR:L/UI:A/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+              "version": "4.0"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-11.json
+++ b/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-11.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Recommended Test: Additional Properties (failing example 1)",
+    "title": "Recommended Test: Additional Properties (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-20-01",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-20-11",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {
@@ -45,7 +45,6 @@
             "cvss_v3": {
               "baseScore": 6.4,
               "baseSeverity": "MEDIUM",
-              "custom_property": "any",
               "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:C/C:N/I:H/A:L",
               "version": "3.1"
             }

--- a/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-12.json
+++ b/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-12.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/csaf_json_schema.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Recommended Test: Additional Properties (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-20-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v4": {
+              "baseScore": 7.3,
+              "baseSeverity": "HIGH",
+              "vectorString": "CVSS:4.0/AV:A/AC:L/AT:P/PR:L/UI:A/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+              "version": "4.0"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -2394,11 +2394,19 @@
         {
           "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json",
           "valid": true
+        },
+        {
+          "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-02.json",
+          "valid": true
         }
       ],
       "valid": [
         {
           "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-11.json",
+          "valid": true
+        },
+        {
+          "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-12.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -2395,6 +2395,12 @@
           "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json",
           "valid": true
         }
+      ],
+      "valid": [
+        {
+          "name": "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-11.json",
+          "valid": true
+        }
       ]
     },
     {

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -12,7 +12,7 @@ SSVC_101_DPVS_SCHEMA=csaf_2.1/referenced_schema/certcc/Decision_Point_Value_Sele
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json|oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json'
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json|oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json|oasis_csaf_tc-csaf_2_1-2024-6-2-20-02.json'
 EXCLUDE_LEAP='oasis_csaf_tc-csaf_2_1-2024-6-1-37-12.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-13.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-14.json'
 
 FAIL=0

--- a/csaf_2.1/test/validator/run_tests.sh
+++ b/csaf_2.1/test/validator/run_tests.sh
@@ -12,9 +12,8 @@ SSVC_101_DPVS_SCHEMA=csaf_2.1/referenced_schema/certcc/Decision_Point_Value_Sele
 VALIDATOR=csaf_2.1/test/validator.py
 STRICT_GENERATOR=csaf_2.1/test/generate_strict_schema.py
 TESTPATH=csaf_2.1/test/validator/data/$1/*.json
-EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json'
+EXCLUDE='oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-08-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-09-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-03.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-04.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-05.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-06.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json|oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json|oasis_csaf_tc-csaf_2_1-2024-6-2-10-01.json|oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json'
 EXCLUDE_LEAP='oasis_csaf_tc-csaf_2_1-2024-6-1-37-12.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-13.json|oasis_csaf_tc-csaf_2_1-2024-6-1-37-14.json'
-EXCLUDE_STRICT=oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json
 
 FAIL=0
 
@@ -40,7 +39,7 @@ test_all() {
 }
 
 test_all_strict() {
-  for i in $(ls -1 ${TESTPATH} | grep -Ev "${EXCLUDE}" | grep -Ev "${EXCLUDE_LEAP}" | grep -v ${EXCLUDE_STRICT})
+  for i in $(ls -1 ${TESTPATH} | grep -Ev "${EXCLUDE}" | grep -Ev "${EXCLUDE_LEAP}" )
   do
     validate $i
   done


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/877
- set `"additionalProperties": false` in CSAF schema
- update PMD JSON schema with new rule
- update Aggregator JSON schema with new rule
- add comment in prose to reflect that some schemas do allow additional keywords
- add comment in prose to explain that defined schema to not allow for additional keywords
- clarify test 6.2.20
- mention referenced schemas explicit
- update invalid example
- add valid example
- update run script
- update CVSS v4 stored strict schema (needed to be updated to Draft 2020-12)
- add invalid example for CVSS v4
- add valid example for CVSS v4
- add conversion rule