### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -544,6 +544,7 @@ A CSAF extended validator satisfies the "CSAF full validator" conformance profil
 
 * satisfies the "CSAF extended validator" conformance profile.
 * additionally performs all informative tests as given in section [sec](#informative-tests).
+* provides an option to additionally use a custom dictionary for test [sec](#spell-check).
 
 A CSAF full validator MAY provide an additional function to only run one or more selected informative tests.
 

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -257,7 +257,7 @@ The relevant paths for this test are:
 
 > The `category` is `self` and a request to that URL does not resolve with a status code from the 2xx (Successful) or 3xx (Redirection) class.
 
-### Spell check
+### Spell Check
 
 If the document language is given it MUST be tested that a spell check for the given language does not find any mistakes.
 The test SHALL be skipped if not document language is set. It SHALL fail it the given language is not supported.


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1003
- use title case in 6.3.8
- add custom dict requirement for CSAF full validators