### PR TITLE
Involvements: add options `contact` and `product_ids`/`group_ids`

### DIFF
--- a/csaf_2.1/json_schema/csaf.json
+++ b/csaf_2.1/json_schema/csaf.json
@@ -1274,11 +1274,20 @@
                 "status"
               ],
               "properties": {
+                "contact": {
+                  "title": "Party contact information",
+                  "description": "Contains the contact information of the party that was used in this state.",
+                  "type": "string",
+                  "minLength": 1
+                },
                 "date": {
                   "title": "Date of involvement",
                   "description": "Holds the date and time of the involvement entry.",
                   "type": "string",
                   "format": "date-time"
+                },
+                "group_ids": {
+                  "$ref": "#/$defs/product_groups_t"
                 },
                 "party": {
                   "title": "Party category",
@@ -1291,6 +1300,9 @@
                     "user",
                     "vendor"
                   ]
+                },
+                "product_ids": {
+                  "$ref": "#/$defs/products_t"
                 },
                 "status": {
                   "title": "Party status",

--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -125,6 +125,8 @@ An array SHOULD NOT have more than:
   * `/vulnerabilities[]/flags`
   * `/vulnerabilities[]/flags[]/group_ids`
   * `/vulnerabilities[]/flags[]/product_ids`
+  * `/vulnerabilities[]/involvements[]/group_ids`
+  * `/vulnerabilities[]/involvements[]/product_ids`
   * `/vulnerabilities[]/metrics`
   * `/vulnerabilities[]/metrics[]/products`
   * `/vulnerabilities[]/notes[]/group_ids`
@@ -217,6 +219,7 @@ A string SHOULD NOT have a length greater than:
   * `/vulnerabilities[]/flags[]/product_ids[]`
   * `/vulnerabilities[]/ids[]/system_name`
   * `/vulnerabilities[]/ids[]/text`
+  * `/vulnerabilities[]/involvements[]/contact`
   * `/vulnerabilities[]/metrics[]/content/cvss_v2/vectorString`
   * `/vulnerabilities[]/metrics[]/content/cvss_v3/vectorString`
   * `/vulnerabilities[]/metrics[]/content/cvss_v4/vectorString`

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
@@ -382,18 +382,27 @@ List of involvements (`involvements`) of value type `array` with 1 or more uniqu
 ```
 
 Every Involvement item of value type `object` with the 2 mandatory properties Party (`party`), Status (`status`) and
-the 2 optional properties Date of involvement (`date`) and Summary (`summary`) is a container that allows the document producers to
-comment on the level of involvement (or engagement) of themselves (or third parties) in the vulnerability identification, scoping,
-and remediation process.
+the 5 optional properties Party contact information (`contact`), Date of involvement (`date`), Group IDs (`group_ids`),
+Product IDs (`product_ids`), and Summary (`summary`) is a container that allows the document producers to comment on the level of
+involvement (or engagement) of themselves (or third parties) in the vulnerability identification, scoping, and remediation process.
 It can also be used to convey the disclosure timeline.
 The ordered tuple of the values of `party` and `date` (if present) SHALL be unique within `involvements`.
 
 ```
         "properties": {
+          "contact": {
+            // ...
+          },
           "date": {
             // ...
           },
+          "group_ids" {
+            // ...
+          },
           "party": {
+            // ...
+          },
+          "product_ids": {
             // ...
           },
           "status": {
@@ -405,7 +414,14 @@ The ordered tuple of the values of `party` and `date` (if present) SHALL be uniq
         }
 ```
 
+Party contact information (`contact`) contains the contact information of the party that was used in this state.
+
+> In many cases, that could be an email address.
+
 Date of involvement (`date`) of value type `string` with format `date-time` holds the date and time of the involvement entry.
+
+Group IDs (`group_ids`) are of value type Product Groups (`product_groups_t`) and contain a list of Product Groups the current
+involvement item applies to.
 
 Party category (`party`) of value type `string` and `enum` defines the category of the involved party.
 Valid values are:
@@ -419,6 +435,9 @@ Valid values are:
 ```
 
 These values follow the same definitions as given for the publisher category (cf. section [sec](#document-property-publisher-category)).
+
+Product IDs (`product_ids`) are of value type Products (`products_t`) and contain a list of Products the current
+involvement item applies to.
 
 Party status (`status`) of value type `string` and `enum` defines contact status of the involved party.
 Valid values are:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
@@ -11,6 +11,7 @@ The relevant paths for this test are:
   /product_tree/product_groups[]/product_ids[]
   /product_tree/relationships[]/product_reference
   /product_tree/relationships[]/relates_to_product_reference
+  /vulnerabilities[]/involvements[]/product_ids[]
   /vulnerabilities[]/flags[]/product_ids[]
   /vulnerabilities[]/metrics[]/products[]
   /vulnerabilities[]/notes[]/product_ids[]

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -9,6 +9,7 @@ The relevant paths for this test are:
 ```
   /document/notes[]/group_ids[]
   /vulnerabilities[]/flags[]/group_ids[]
+  /vulnerabilities[]/involvements[]/group_ids[]
   /vulnerabilities[]/notes[]/group_ids[]
   /vulnerabilities[]/remediations[]/group_ids[]
   /vulnerabilities[]/threats[]/group_ids[]


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/597
- add new optional field `contact`, `product_ids` and `group_ids` to schema
- adapt prose
- add missing fields and explanation
- add new fields to guidance on size
- update part of tests (6.1.1 and 6.1.4 by integration)