### PR TITLE
Meeting minutes for 2025-05-28

### DIFF
--- a/meeting_minutes/2025/2025-05-28.md
+++ b/meeting_minutes/2025/2025-05-28.md
@@ -1,0 +1,147 @@
+![image](https://user-images.githubusercontent.com/1690898/139102180-5c1e2583-14f1-4f58-ab2b-9e3807ed529c.png)
+
+# Common Security Advisory Framework (CSAF) Technical Committee Working Meeting
+
+- Meeting Date: May 28, 2025
+- Time: 18:00 UTC (19:00 CET, 13:00 EST, 10:00 PST)
+
+## Call to Order and Welcome
+
+Meeting called to order.
+
+## Roll call
+
+Using OQC for roll call and quorum calculation.
+
+## Participants
+
+Quorum requires participation of 7 or more of the 13 voting members (including the officers).
+
+| Given Name | Family Name | Affiliation                                                 | Role          | Present |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|:--------|
+| Christian  | Banse       | Fraunhofer-Gesellschaft e.V. - Fraunhofer AISEC             | Voting Member | Yes     |
+| Christoph  | Plutte      | Ericsson AB                                                 | Voting Member | Yes     |
+| Denny      | Page        | Individual                                                  | Voting Member | Yes     |
+| Dina       | Truxius     | Federal Office for Information Security (BSI)               | Voting Member | Yes     |
+| Duncan     | Sparrell    | sfractal                                                    | Member        | No      |
+| Feng       | Cao         | Oracle                                                      | Member        | Yes     |
+| JD         | Stefaniak   | Dell                                                        | Voting Member | Yes     |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Co-Chair      | Yes     |
+| Martin     | Prpic       | Red Hat                                                     | Voting Member | Yes     |
+| Michael    | Reeder      | Dell                                                        | Voting Member | Yes     |
+| Omar       | Santos      | Cisco Systems                                               | Co-Chair      | Yes     |
+| Sergii     | Demianchuk  | Cisco Systems                                               | Observer      | Yes     |
+| Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member | Yes     |
+| Stefan     | Hagen       | Individual                                                  | Co-Chair      | Yes     |
+| Thomas     | Proell      | Siemens AG                                                  | Member        | No      |
+| Thomas     | Schaffer    | Cisco Systems                                               | Member        | Yes     |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI)               | Voting Member | Yes     |
+| Tobias     | Limmer      | Siemens AG                                                  | Member        | No      |
+| Vijay      | Sarvepalli  | SEI                                                         | Member        | No      |
+| Vivek      | Nair        | Microsoft Corporation                                       | Voting Member | Yes     |
+
+### Observers present
+
+- Sergii Demianchuk
+
+Note: Observers of this committee that are ready to become Members should follow the specific instructions displayed the OASIS Open Notices tab.
+
+### Quorum
+
+Quorum was reached (13 voting members present).
+
+## Agenda
+
+- Roll Call
+- Updates or news to the TC
+- Review all open GitHub issues and pull requests requiring TC discussion.
+- CSAF 2.1 Committee Specification Draft
+- Next steps
+- Adjourn
+
+## Identification of TC voting members (Secretary)
+
+### Prospective voting members attending their first meeting
+
+### Members attaining voting rights at the end of this meeting
+
+### Members losing voting rights if they have not joined this meeting by the time it ends
+
+### Members who previously lost voting rights who are attending this meeting
+
+- Feng Cao
+- Thomas Schaffer
+
+### Members who have declared a leave of absence
+
+## Meeting Notes
+
+- Omar Santos calls the meeting to order.
+- Justin Murphy sets the motion to approve the meeting minutes for the April TC Meeting as seen in PR [#1011](https://github.com/oasis-tcs/csaf/pull/1011).
+- Thomas Schmidt seconded. No discussion. No objections. Motion passed.
+
+## GitHub Issues & Pull Requests
+
+- Issues [#812](https://github.com/oasis-tcs/csaf/issues/812)
+  - Thomas Schmidt presents the issue which details a change in the implementation with the CSAF validation process that identifies and flags discrepancies in `product_identification_helper`, to change the test from a mandatory test to a recommended test.
+  - Omar supports the change.
+  - Thomas Schmidt sets the motion to change the test detailed in Issue [#812](https://github.com/oasis-tcs/csaf/issues/812) to NOT be mandatory, and to be changed to a recommended test.
+  - Justin seconded. No discussion. No objections. Motion passed.
+- Issues [#884](https://github.com/oasis-tcs/csaf/issues/884)
+  - This was discussed during the TC meeting on 2025-03-26. A motion was set to include `license` as an optional field under `distribution` in CSAF files.
+  - Thomas read through the schema and realized it should shift up one level to be a direct child of `/document`, and that the name of the field should be changed to `license_expression` for consistency with other standards.
+    - An SPDX `license_expression` is a standardized, machine-readable way to specify the licensing terms that apply to a piece of software, especially when those terms may be complex or involve multiple licenses.
+  - Thomas sets the motion to move the `license` field to the `/document` level and rename the field to be `license_expression`.
+  - Justin seconded. No discussion. No objections. Motion passed.
+- PR [#991](https://github.com/oasis-tcs/csaf/pull/991)
+  - Thomas presents the PR which describes the process for the transition from CSAF v2.0 to v2.1.
+  - The skeleton for the PR is in Issue [#843](https://github.com/oasis-tcs/csaf/issues/843).
+  - Thomas Schmidt sets the motion to accept the transition as stated in PR [#991](https://github.com/oasis-tcs/csaf/pull/991).
+  - Stefan seconded. No discussion. No objections. Motion passed.
+- Issue [#965](https://github.com/oasis-tcs/csaf/issues/965) and PR #[1015](https://github.com/oasis-tcs/csaf/pull/1015)
+  - Allow for other vulnerability identifiers. Idea is to allow for the addition of CNVD, EUVD, and GCVE.
+  - Omar asks for clarification on GCVE and EUVD and if the TC sees these as lasting solutions.
+  - Thomas clarifies that the EUVD is established by law in Europe and is not diverting from CVE, and GCVE came up in response to the funding problems encountered by CVE last month and is founded by CIRCL.
+  - Omar cautions providing support for identifiers that do not currently have widespread adoption or support.
+    - Martin and Justin also caution against providing support for other identifiers beyond CVE.
+  - Sonny points out that as a TC that we should be clear on what criteria an identifier system must meet to be included in the CSAF standard.
+  - Omar suggests removing GCVE for the time being and we can reconsider down the road once we get a sense of adoption.
+    - Thomas removed GCVE from PR [#1015](https://github.com/oasis-tcs/csaf/pull/1015) and Omar will take for action to notify the commenter about the TCs decision.
+  - Martin asked if we could make a mandatory rule that if an alternative vulnerability identifier is used, that a CVE MUST also be used.
+    - Thomas said that is unfortunately not possible as there might be a delay in the process with timing of when one vulnerability identifier is released and when a CVE is released.
+    - Thomas suggests that we could make the test a recommended test.
+  - Omar, Martin, Thomas, and Feng discuss CVEs, CNAs, and the ability to reserve CVEs.
+  - Martin and Feng encourage the TC not to move away from CVE as the main vulnerability identifier for the CSAF standard. While they understand the need for other identification mechanisms, they believe moving away from CVE sets the community back in standardization.
+    - Omar mentions we as a committee do not want to set the wrong precedent.
+  - Thomas presents two options:
+    - One, we drop the topic and do not include support for alternate IDs, which could make things challenging for automation.
+    - Two, we add the alternate IDs as stated in Issue [#965](https://github.com/oasis-tcs/csaf/issues/965) and PR [#1015](https://github.com/oasis-tcs/csaf/pull/1015) and add an additional recommended test.
+  - Christian suggests that we should avoid making CVE mandatory as well as we do not want to put the CSAF standard in a position where all CSAFs would potentially be invalid.
+  - Omar suggests we shy away from this topic since we as the TC are not a group of policy makers and we can consider again at a later date when things are normalized.
+  - Omar additonally suggests that we table the topic for discussion at a later time and that we could have a ballot to gather the majority between the two options Thomas presented.
+  - Thomas presents a third option that we not mention the specific identifiers in the standard, but have a separate register.
+  - For the sake of time, Thomas suggests we table the topic and move on.
+    - Thomas closes PR [#1015](https://github.com/oasis-tcs/csaf/pull/1015).
+  - No objections from TC to move on.
+- PR [#1013](https://github.com/oasis-tcs/csaf/pull/1013)
+  - Thomas presents the PR that is a requirement by IANA for ROLIE feed.
+  - Thomas sets the motion to accept the IANA requirement for ROLIE specified in PR [#1013](https://github.com/oasis-tcs/csaf/pull/1013).
+  - Omar seconded. No discussion. No objections. Motion passed.
+
+## Other Business
+- Thomas suggests to the TC that we are in a position to move forward with publishing the Committee Specification Draft (CSD) after resolving some merge conflicts.
+- The TC discusses the CSD approval process for OASIS, with a ballot and public review.
+- Thomas sets the motion to accept the current editor revision, including the conflict resolutions, pending merge conflicts and pull requests, and tasks the editors and chairs with working with the OASIS staff to promote the work item as a committee specification draft (CSD01) for CSAF v2.1.
+- Omar and Justin seconded. No discussion. No objections. Motion passed.
+- Thomas mentions that the TC should expect a ballot soon to request the formal consent from the TC members on CSD01 public review period.
+- Thomas mentions that it will be great to have the public review open during the upcoming Annual FIRST Conference and aligns nicely with a chance to publicize the public review.
+  - Omar echoes support for the nice alignment with the Annual FIRST Conference in Copenhagen and heading into Black Hat and DEFCON in the late summer.
+- Omar also mentions that the TC should take steps for v2.1 (once approved) into ISO as well.
+  - Thomas Schmidt says we are required to submit to ISO as part of our submission for CSAF v2.0.
+- The TC confirmed that no new features will be added to the current specification version for the standards track.
+
+## Adjourn
+
+- The meeting was adjourned.
+
+**Note**: All monthly meetings take place on the last Wednesday of each month at 13:00 ET (19:00 CEST/19:00 CET, 10:00 PT, 17:00/18:00 UTC).


### PR DESCRIPTION
- Meeting minutes as provided in #1019 by @justmurphy 
- moved to the OASIS repo **in a dedicated branch `2025-05-28_meeting_minutes`** to be ready for CSD01 submission
- Motion to approve this meeting minutes at: https://groups.oasis-open.org/discussion/motion-to-approve-the-oasis-csaf-tcs-monthly-meeting-held-on-may-28-2025 