### PR TITLE
Fixed Guidance Appendix Metadata

### DIFF
--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -5,18 +5,20 @@ toc:
   label: Guidance on the Size of CSAF Documents
   enumerate: Appendix C.
   children:
-  - label: File size
+  - label: File Size
     enumerate: C.1
-  - label: Array length
+  - label: Array Length
     enumerate: C.2
-  - label: String length
+  - label: String Length
     enumerate: C.3
-  - label: URI length
+  - label: Date
     enumerate: C.4
   - label: Enum
     enumerate: C.5
-  - label: Date
+  - label: URI Length
     enumerate: C.6
+  - label: UUID Length
+    enumerate: C.7
 ---
 -->
 # Guidance on the Size of CSAF Documents


### PR DESCRIPTION
The CSD01 has duplicated heading labels visible in appendix C and this change-set fixes that.

- Title Case aligned with heading text to be matched
- Order aligned with order of sections in document
- Added missing UUID Length entry (Added in v2.1)

Fixes issue #1037.