### PR TITLE
Updated editor config to cover lowercase makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ indent_style = space
 indent_size = 2
 
 # Makefiles require tabs
-[Makefile]
+[{M,m}akefile]
 indent_style = tab
 indent_size = 4
 max_line_length = 256


### PR DESCRIPTION
Fixes #1039 (Editor config does not cover makefile).