### PR TITLE
Fixed informative block display in 2.3 at the source

### DIFF
--- a/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
@@ -8,10 +8,12 @@ In accordance with [cite](#RFC3339) and [cite](#ISO8601-1), the following rules 
 * The letter `Z` indicating the timezone UTC SHALL be upper case.
 * Fractions of seconds are allowed as specified in the standards mention above with the full stop (`.`) as separator.
 * Leap seconds MUST NOT be used.
+
   > While a full support of RFC 3339 would be preferred, significant challenges have been mentioned by implementers as most libraries are lacking
   > the support for leap seconds.
   > To ensure interoperability, the decision was made to prohibit leap seconds.
-* Empty timezones MUST NOT be used.
+
+Empty timezones MUST NOT be used.
 * The ABNF of RFC 3339, section 5.6 applies.
 
 -------

--- a/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
@@ -13,7 +13,7 @@ In accordance with [cite](#RFC3339) and [cite](#ISO8601-1), the following rules 
   > the support for leap seconds.
   > To ensure interoperability, the decision was made to prohibit leap seconds.
 
-Empty timezones MUST NOT be used.
+* Empty timezones MUST NOT be used.
 * The ABNF of RFC 3339, section 5.6 applies.
 
 -------


### PR DESCRIPTION
The authors did not correctly separate the structural elements in section 2.3 namely the informative statement from its embedding list item.

This commit fixes / closes issue #1035 (2.3: Informative comment not displayed correctly).