### PR TITLE
GitHub Action

### DIFF
--- a/.github/workflows/csaf_2.1_mandatory-tests.yml
+++ b/.github/workflows/csaf_2.1_mandatory-tests.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         cd ..
         git clone https://github.com/secvisogram/csaf-validator-lib.git
-        cd csaf-validator-lib && git checkout 196-csaf-2.1 && npm ci --prod
+        cd csaf-validator-lib && npm ci --prod
     - name: Run mandatory tests on examples
       run:  |
         for i in `ls -1 ../csaf/csaf_2.1/examples/csaf/*.json | grep -Ev 'rhsa-2021_5186.json|rhsa-2021_5217|rhsa-2022_0011.json'`


### PR DESCRIPTION
- resolves #1073
- use main branch of csaf-validator-lib as it provides experimental support for CSAF 2.1