### PR TITLE
Fix invalid references

### DIFF
--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -170,7 +170,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 This profile MAY be used to provide information which is related to vulnerabilities and corresponding remediations,
 e.g. when converting CSAF documents from older CSAF versions or a human-readable format.
 It SHOULD NOT be used for newly created documents.
-The profile "Security Advisory" from section [sec]{#profiles-profile-4-security-advisory} SHOULD be used instead.
+The profile "Security Advisory" from section [sec](#profiles-profile-4-security-advisory) SHOULD be used instead.
 
 > The definition of the profile "Deprecated Security Advisory" in CSAF 2.1 matches the definition of profile "Security Advisory" in CSAF 2.0.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
@@ -1,6 +1,6 @@
 ### Date and Time{#mandatory-tests--date-and-time}
 
-For each item of type `string` and format `date-time` it MUST be tested that it conforms to the rules given in section [sec]{#date-and-time}.
+For each item of type `string` and format `date-time` it MUST be tested that it conforms to the rules given in section [sec](#date-and-time).
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-40-product-description-without-product.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-40-product-description-without-product.md
@@ -3,7 +3,7 @@
 For each product description it MUST be tested that it includes at least one of the elements `group_ids` or `product_ids`.
 
 > If the document language is English or unspecified, the product description can be identified by checking for a note containing the corresponding
-> `category` and `title` combination from [sec]{#document-property-notes}.
+> `category` and `title` combination from [sec](#document-property-notes).
 > For other languages, the language specific translation is used.
 
 If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no translation for


### PR DESCRIPTION
- based on #1082 
- resolves https://github.com/oasis-tcs/csaf/issues/1064
- change curly brackets to round brackets to correct syntax for Markdown links