### PR TITLE
Fix informative comment rendering

### DIFF
--- a/csaf_2.1/prose/edit/src/additional-conventions.md
+++ b/csaf_2.1/prose/edit/src/additional-conventions.md
@@ -11,12 +11,14 @@ The following rules MUST be applied to determine the filename for the CSAF docum
    * Lower case ASCII letters (0x61 - 0x7A)
    * digits (0x30 - 0x39)
    * special characters: `+` (0x2B), `-` (0x2D)
+
    > The regex `[^+\-a-z0-9]+` can be used to find a character sequence which has to be replaced by an underscore.
    > However, it SHALL NOT be applied before completing the first step.
    >
    > Even though the underscore `_` (0x5F) is a valid character in the filename it is replaced to avoid situations
    > where the conversion rule might lead to multiple consecutive underscores.
    > As a result, a `/document/tracking/id` with the value `2022_#01-A` is converted into `2022_01-a` instead of `2022__01-a`.
+
 3. The file extension `.json` MUST be appended.
 
 *Examples 1:*

--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -143,6 +143,7 @@ Secondly, the program fulfills the following for all items of:
       the CVRF CSAF converter MUST try to convert all data into a valid CSAF document in the profile "Superseded" according to CSAF 2.1.
     * If the `cvrf:DocumentTitle` starts with the string `Withdrawn` or the `cvrf:DocumentType` starts with `Withdrawn` (case-insensitive),
       the CVRF CSAF converter MUST try to convert all data into a valid CSAF document in the profile "Withdrawn" according to CSAF 2.1.
+
     > A tool MAY provide a non-default option to remove or transform certain or all elements the hinder the creation of a valid CSAF document according
     > to the profile.
 
@@ -182,6 +183,7 @@ Secondly, the program fulfills the following for all items of:
     `/document/tracking/current_release_date` of the source document.
     If no such version exist, the first matching version published after the value of `/document/tracking/current_release_date`
     of the source document SHOULD be used.
+
     > This is done to create a deterministic conversion.
 
     If the CWE does not match at all, the CVRF CSAF converter MUST omit this CWE and output a warning that an invalid CWE was found and has
@@ -247,8 +249,10 @@ Secondly, the program fulfills the following for all items of:
        (As CSAF CVRF v1.2 predates CVSS v3.1.) The CVRF CSAF converter outputs a warning that this value was taken from the config.
 * `/vulnerabilities[]/metrics/cvss_v4`: If an external reference in the vulnerability linking to the official FIRST.org CVSS v4.0 calculator exists,
   the CVRF CSAF converter MUST convert the vector given in the fragment into a `cvss_v4` object linked to all affected products of the vulnerability.
+
   > A tool MAY implement an option to suppress this conversion.
-   If the CVRF CSAF converter converter is unable to construct a valid object with the information given, the CVRF CSAF converter converter SHALL
+
+  If the CVRF CSAF converter converter is unable to construct a valid object with the information given, the CVRF CSAF converter converter SHALL
   remove the invalid `cvss_v4` object and output a warning that the automatic conversion of the CVSS v4.0 reference failed.
   Such warning SHOULD include the specific error that occurred.
 * `/vulnerabilities[]/notes`: If any `vuln:Note` item contains one of the `category` and `title` combinations specified in
@@ -314,8 +318,10 @@ A CSAF content management system satisfies the "CSAF content management system" 
     the configuration (default: 3 weeks)
   * suggest to publish a new version of the CSAF document with the document status `final` if the document status was
     `interim` and no new release has be done during the given threshold in the configuration (default: 6 weeks)
+
     > Note that the terms "publish", "publication" and their derived forms are used in this conformance profile independent of
       whether the specified target group is the public or a closed group.
+
   * support the following workflows:
 
     * "New Advisory": create a new advisory, request a review, provide review comments or approve it, resolve review comments;
@@ -432,8 +438,10 @@ The resulting translated document:
   It SHOULD NOT use the original `/document/tracking/id` as a suffix.
   If an issuer uses a CSAF translator to publish his advisories in multiple languages they MAY use the combination of
   the original `/document/tracking/id` and translated `/document/lang` as a `/document/tracking/id` for the translated document.
+
   > Note that the term "publish" is used in this conformance profile independent of whether the specified target group is the public
     or a closed group.
+
 * provides the `/document/lang` property with a value matching the language of the translation.
 * provides the `/document/source_lang` to contain the language of the original document (and SHOULD only be set by CSAF translators).
 * has the value `translator` set in `/document/publisher/category`
@@ -511,8 +519,10 @@ A CSAF asset matching system satisfies the "CSAF asset matching system" conforma
     * when a new CSAF document is inserted (for this CSAF document)
     * when a new asset is inserted (for this asset)
     * when the Major version in a CSAF document with semantic versioning changes (for this CSAF document)
+
     > These also apply if more than one CSAF document or asset was added.
     > To reduce the computational efforts the runs can be pooled into one run which fulfills all the tasks at once (batch mode).
+
   * Manually and automatically triggered runs SHOULD NOT be pooled.
 * provides at least the following statistics for the count of assets:
   * matching that CSAF document at all
@@ -558,7 +568,9 @@ A CSAF SBOM matching system satisfies the "CSAF SBOM matching system" conformanc
 
 * satisfies the "CSAF management system" conformance profile.
 * is an SBOM database or connects to one.
+
   > A repository or any other location that can be queried for SBOMs and their content is also considered an SBOM database.
+
 * matches the CSAF documents within the system to the respective SBOM components.
   This might be done with a probability which gives the user the chance to broaden or narrow the results.
   The process of matching is also referred to as "run of the SBOM matching module".
@@ -581,9 +593,12 @@ A CSAF SBOM matching system satisfies the "CSAF SBOM matching system" conformanc
     * when a new CSAF document is inserted (for this CSAF document)
     * when a new SBOM component is inserted (for this SBOM component)
     * when the Major version in a CSAF document with semantic versioning changes (for this CSAF document)
+
     > These also apply if more than one CSAF document or SBOM component was added.
     > To reduce the computational efforts the runs can be pooled into one run which fulfills all the tasks at once (batch mode).
+
   > Manually and automatically triggered runs should not be pooled.
+
 * provides at least the following statistics for the count of SBOM component:
   * matching that CSAF document at all
   * marked with a given status
@@ -655,6 +670,7 @@ Secondly, the program fulfills the following for all items of:
       the CSAF 2.0 to CSAF 2.1 converter MUST try to convert all data into a valid CSAF document in the profile "Superseded" according to CSAF 2.1.
     * If the `/document/title` starts with the string `Withdrawn` or the `/document/category` has the value `Withdrawn` (case-insensitive),
       the CSAF 2.0 to CSAF 2.1 converter MUST try to convert all data into a valid CSAF document in the profile "Withdrawn" according to CSAF 2.1.
+
     > A tool MAY provide a non-default option to remove or transform certain or all elements the hinder the creation of a valid CSAF document according
     > to the profile.
 
@@ -676,6 +692,7 @@ Secondly, the program fulfills the following for all items of:
   option to use this label instead. If the TLP label changes through such conversion in a way that is not reflected in the table above, the
   the CSAF 2.0 to CSAF 2.1 converter MUST output a warning that the TLP label was taken from the distribution text. Such a warning MUST include
   both values: the converted one based on the table and the one from the distribution text.
+
   > This is a common case for CSAF 2.0 documents labeled as `TLP:RED` but actually intended to be `TLP:AMBER+STRICT`.
 
   If no TLP label was given, the CSAF 2.0 to CSAF 2.1 converter SHOULD assign `TLP:CLEAR` and output a warning that the default TLP has been set.
@@ -702,6 +719,7 @@ Secondly, the program fulfills the following for all items of:
     `/document/tracking/current_release_date` of the source document.
     If no such version exist, the first matching version published after the value of `/document/tracking/current_release_date`
     of the source document SHOULD be used.
+
     > This is done to create a deterministic conversion.
 
     The tool SHOULD implement an option to use the latest available CWE version at the time of the conversion that still matches.
@@ -710,7 +728,9 @@ Secondly, the program fulfills the following for all items of:
   into the `disclosure_date` element.
 * `/vulnerabilities[]/metrics/cvss_v4`: If an external reference in the vulnerability linking to the official FIRST.org CVSS v4.0 calculator exists,
   the CSAF 2.0 to CSAF 2.1 converter MUST convert the vector given in the fragment into a `cvss_v4` object linked to all affected products of the vulnerability.
+
   > A tool MAY implement an option to suppress this conversion.
+
    If the CSAF 2.0 to CSAF 2.1 converter is unable to construct a valid object with the information given, the CSAF 2.0 to CSAF 2.1 converter SHALL
   remove the invalid `cvss_v4` object and output a warning that the automatic conversion of the CVSS v4.0 reference failed.
   Such warning SHOULD include the specific error that occurred.

--- a/csaf_2.1/prose/edit/src/distributing-04-transition-20-21.md
+++ b/csaf_2.1/prose/edit/src/distributing-04-transition-20-21.md
@@ -15,17 +15,23 @@ Different scenarios can be encountered:
 
 In the last scenario, a temporary parallel distribution of CSAF 2.0 and CSAF 2.1 documents and provider metadata is RECOMMENDED.
 The provider SHOULD announce a transition period containing three points in time:
-- The begin of the transition period, where the provider is starting to serve CSAF 2.1 documents, while CSAF 2.0 being authoritative.
+
+- The beginning of the transition period, where the provider is starting to serve CSAF 2.1 documents, while CSAF 2.0 being authoritative.
+
   > It is expected that the CSAF 2.1 files can be used in production from this point onward.
+
 - The roll-over-date at which CSAF 2.1 becomes authoritative but CSAF 2.0 is still supported.
 - The end of the transition period, after which CSAF 2.0 is not supported, i.e. maintained, any more.
 
 The announcement MAY contain also the following information:
 
 - The first date, when CSAF 2.1 documents are available and automatically retrievable from the server through a CSAF 2.1 `provider-metadata.json`.
+
   > This might be a public beta prior to the begin of the transition period.
   > However, those documents SHOULD NOT be used in production as they may be unstable due to their beta status.
+
 - The last date, when CSAF 2.0 documents are available and automatically retrievable from the server through a CSAF 2.0 `provider-metadata.json`.
+
   > This date is usually at the end of the transition period.
 
 ### Transition Process for a CSAF Provider
@@ -34,14 +40,18 @@ The following process SHOULD be followed:
 
 - A `provider-metadata.json` in conformance to CSAF 2.0 SHOULD be placed at `/.well-known/csaf/v2.0/provider-metadata.json`.
   - Its `canonical_url` MUST be set to an URL corresponding to the `/.well-known/csaf/v2.0/provider-metadata.json` path.
+
     > The property `maintained_until` was not defined in CSAF 2.0 and therefore cannot be used -
     > otherwise it would be set to the end of the transition period.
+
   - The URL SHALL also be added as an entry in the security.txt, if used.
 - A `provider-metadata.json` in conformance to CSAF 2.1 SHOULD be placed at `/.well-known/csaf/v2.1/provider-metadata.json`.
   - Its `canonical_url` MUST be set to an URL corresponding to the `/.well-known/csaf/v2.1/provider-metadata.json` path.
   - Optionally, the property `maintained_from` can be set to an appropriate date in the future, if the service is not considered stable yet.
+
     > The transition officially starts at the date and time noted in the property `maintained_from` as this is the point in time
     > when both CSAF 2.0 and CSAF 2.1 documents are retrievable in production-grade quality.
+
   - The URL SHALL also be added to the security.txt, if used.
 - At the begin of the transition period, a `provider-metadata.json` in conformance to CSAF 2.0 SHOULD be placed at `/.well-known/csaf/provider-metadata.json`.
   - The content of the resource SHALL be equal to the resource accessible at `/.well-known/csaf/v2.0/provider-metadata.json`.
@@ -59,8 +69,10 @@ The following process SHOULD be followed:
 If a DNS path (cf. section [sec](#requirement-10-dns-path)) is used instead of the well-known URL, the same process SHOULD be followed taking the rules below into account:
 
 - The leading and authoritative `provider-metadata.json` is always served according to the DNS path requirement (see section [sec](#requirement-10-dns-path)).
-  > This implies that a CSAF 2.0 `provider-metadata.json` is served at the beginning and 
-  > replaced by the CSAF 2.1 `provider-metadata.json`  at the roll-over-date.
+
+  > This implies that a CSAF 2.0 `provider-metadata.json` is served at the beginning and
+  > replaced by the CSAF 2.1 `provider-metadata.json` at the roll-over-date.
+
 - It is recommended to use the folders `v2.0` and `v2.1` to differentiate between the CSAF versions.
 
 ### Archive of CSAF Document from Previous Version

--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -205,9 +205,13 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   * `/product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   * `/vulnerabilities` which lists all vulnerabilities.
   * `/vulnerabilities[]/notes`
+
     > Provides details about the vulnerability.
+
   * `/vulnerabilities[]/product_status`
+
     > Lists each product's status in regard to the vulnerability.
+
 * The value of `/document/category` SHALL be `csaf_deprecated_security_advisory`.
 
 ## Profile 7: Withdrawn
@@ -220,14 +224,18 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   * all elements required by the profile "CSAF Base".
   * `/document[]/notes` with exactly one item using the `category` `description`
     describing the original content and the reasons for the withdrawal
+
     > Other items, such as a legal disclaimer, may exist alongside the required one.
 
     The `title` MUST be `Reasoning for Withdrawal` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.
-  * `/document/tracking/revision_history` with at least 2 entries. Any previous items MUST NOT be removed.
+  * `/document/tracking/revision_history` with at least 2 entries.
+    Any previous items MUST NOT be removed.
+
     > A CSAF document cannot be withdrawn during the initial release to its specified target group.
     > In such case, the CSAF document should not be released at all.
     > If it was shared previously in draft status, then the `/document/tracking/status` is kept in `draft`.
+
 * The value of `/document/category` SHALL be `csaf_withdrawn`.
 * The elements `/product_tree` and `/vulnerabilities` SHALL NOT exist.
 
@@ -242,14 +250,17 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 * The following elements MUST exist and be valid:
   * all elements required by the profile "CSAF Base".
   * `/document[]/notes` with exactly one item using the `category` `description`
+
       > Other items, such as a legal disclaimer, may exist alongside the required one.
 
     The `title` MUST be `Reasoning for Supersession` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.
   * `/document/tracking/revision_history` with at least 2 entries. Any previous items MUST NOT be removed.
+
     > A CSAF document cannot be superseded during the initial release to its specified target group.
     > In such case, the CSAF document should not be released at all.
     > If it was shared previously in draft status, then the `/document/tracking/status` is kept in `draft`.
+
   * `/document/references` containing at least one item with `category` `external`
     The `summary` MUST start with `Superseding Document` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.

--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -75,10 +75,14 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 * The following elements MUST exist and be valid:
   * all elements required by the profile "CSAF Base".
   * `/document/notes` with at least one item which has a `category` of `description`, `details`, `general` or `summary`
+
     > Reasoning: Without at least one note item which contains information about response to the event referred to this doesn't provide
     > any useful information.
+
   * `/document/references` with at least one item which has a `category` of `external`
+
     > The intended use for this field is to refer to one or more documents or websites which provides more details about the incident.
+
 * The value of `/document/category` SHALL be `csaf_security_incident_response`.
 
 ## Profile 3: Informational Advisory
@@ -90,11 +94,15 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 * The following elements MUST exist and be valid:
   * all elements required by the profile "CSAF Base".
   * `/document/notes` with at least one item which has a `category` of `description`, `details`, `general` or `summary`
+
     > Reasoning: Without at least one note item which contains information about the "issue" which is the topic of the advisory it is useless.
+
   * `/document/references` with at least one item which has a `category` of `external`
+
     > The intended use for this field is to refer to one or more documents or websites which provide more details about
     > the issue or its remediation (if possible).
     > This could be a hardening guide, a manual, best practices or any other helpful information.
+
 * The value of `/document/category` SHALL be `csaf_informational_advisory`.
 * The element `/vulnerabilities` SHALL NOT exist.
   If there is any information that would reside in the element `/vulnerabilities` the CSAF document SHOULD use another profile,
@@ -113,18 +121,29 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   * `/product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   * `/vulnerabilities` which lists all vulnerabilities.
   * `/vulnerabilities[]/notes`
+
     > Provides details about the vulnerability.
+
   * `/vulnerabilities[]/product_status`
+
     > Lists each product's status in regard to the vulnerability.
+
   * `/vulnerabilities[]/product_status/known_affected`
+
     > Lists affected products in regard to the vulnerability.
+
   * For each product given in `/vulnerabilities[]/product_status/fixed`, the corresponding affected version SHALL be given.
+
     > Corresponding versions are usually in the same `branches` element.
+
 * The value of `/document/category` SHALL be `csaf_security_advisory`.
 * The following elements SHOULD exist:
   * `/vulnerabilities[]/product_status/fixed`
+
     > Lists fixed products in regard to the vulnerability.
+
   * `/vulnerabilities[]/remediations`
+
     > Lists for each affected product in regard to the vulnerability appropriate remediations.
 
 ## Profile 5: VEX
@@ -148,7 +167,9 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
     * `/vulnerabilities[]/cve`
     * `/vulnerabilities[]/ids`
   * `/vulnerabilities[]/notes`
+
     > Provides details about the vulnerability.
+
 * For each item in
   * `/vulnerabilities[]/product_status/known_not_affected` an impact statement SHALL exist as machine readable flag
     in `/vulnerabilities[]/flags` or as human readable justification in `/vulnerabilities[]/threats`.
@@ -157,12 +178,15 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   * `/vulnerabilities[]/product_status/known_affected` additional product specific information SHALL be provided
     in `/vulnerabilities[]/remediations` as an action statement.
     Optional, additional information MAY also be provide through `/vulnerabilities[]/notes` and `/vulnerabilities[]/threats`.
+
     > The use of the categories `no_fix_planned` and `none_available` for an action statement is permitted.
+
   > Even though Product status lists Product IDs, Product Group IDs can be used in the `remediations` and `threats` object.
   > However, it MUST be ensured that for each Product ID the required information according to its product status as stated
   > in the two points above is available. This implies that all products with the status `known_not_affected` MUST have an
   > impact statement and all products with the status `known_affected` MUST have additional product specific information
   > regardless of whether that is referenced through the Product ID or a Product Group ID.
+
 * The value of `/document/category` SHALL be `csaf_vex`.
 
 ## Profile 6: Deprecated Security Advisory

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -1,6 +1,7 @@
 # Safety, Security, and Data Protection Considerations
 
 CSAF documents are based on JSON, thus the security considerations of [cite](#RFC8259) apply and are repeated here as service for the reader:
+
 > Generally, there are security issues with scripting languages.  JSON is a subset of JavaScript but excludes assignment and invocation.
 >
 > Since JSON's syntax is borrowed from JavaScript, it is possible to use that language's `eval()` function to parse most JSON texts
@@ -28,6 +29,7 @@ CSAF consumers that are not prepared to deal with the security implications of f
 render them and SHALL instead fall back to the corresponding plain text messages. As also any other programming code can
 be contained within a CSAF document, CSAF consumers SHALL ensure that none of the values of a CSAF document is run as code.
 Moreover, it SHALL be treated as unsafe (user) input.
+
   > Additional, supporting mitigation measures like retrieving only CSAF documents from trusted sources and check their integrity and
   > signature before parsing the document SHOULD be in place to reduce the risk further.
 

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -216,9 +216,12 @@ The following ID values SHOULD NOT be used unless there are technical reasons fo
 Therefore, they are reserved for implementation-specific situations:
 
 - A system MAY use the Max UUID for `TLP:CLEAR` CSAF documents.
+
   > For example, the system uses the UUID as an indication whether a user allowed to see the document.
   > The security considerations from [cite](#RFC9562) should be reflected on.
+
 - A system MAY use the Nil UUID for CSAF documents that MUST NOT be shared.
+
   > For example, the CSAF document is just being drafted and the accidental leakage should be prevented.
 
 > Note, that both values do not indicate a closed sharing group.
@@ -326,11 +329,14 @@ In addition, the following rules apply:
      construct an expression based on a SPDX license identifier.
      Deprecated license identifiers SHOULD NOT be used.
      SPDX license identifiers that were deprecated before the version listed above MUST NOT be used.
+
      > The list is available at <https://spdx.org/licenses/>.
      > It includes also the exceptions.
+
   2. If the appropriate license identifier is not found in the SPDX License List or expression been possible to constructed,
      the license database AboutCode's "ScanCode LicenseDB" MUST be consulted as a next step.
      License identifiers from this database MUST use the prefix `LicenseRef-scancode-`.
+
      > The database is currently available at <https://scancode-licensedb.aboutcode.org/>.
 
      The construction of a license expression with such an identifier is also allowed.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
@@ -303,13 +303,17 @@ The given values reflect the VEX not affected justifications. See [VEX-Justifica
 
 * `component_not_present`: The software is not affected because the vulnerable component is not in the product.
 * `vulnerable_code_not_present`: The product is not affected because the code underlying the vulnerability is not present in the product.
+
   > Unlike `component_not_present`, the component in question is present, but for whatever reason (e.g. compiler options)
   > the specific code causing the vulnerability is not present in the component.
+
 * `vulnerable_code_cannot_be_controlled_by_adversary`: The vulnerable component is present, and the component contains the vulnerable code.
   However, vulnerable code is used in such a way that an attacker cannot mount any anticipated attack.
 * `vulnerable_code_not_in_execute_path`: The affected code is not reachable through the execution of the code,
   including non-anticipated states of the product.
+
   > Components that are neither used nor executed by the product.
+
 * `inline_mitigations_already_exist`: Built-in inline controls or mitigations prevent an adversary from leveraging the vulnerability.
 
 Product IDs (`product_ids`) are of value type Products (`products_t`) and contain a list of Products the current flag item applies to.

--- a/csaf_2.1/prose/edit/src/tests-04-presets.md
+++ b/csaf_2.1/prose/edit/src/tests-04-presets.md
@@ -10,8 +10,10 @@ A CSAF validator MUST implement all tests for any supported preset.
 Names of presets not defined in this CSAF standard SHALL have the following prefix before their name:
 
 - `x_`: for any CSAF validator specific preset.
+
   > Multiple CSAF validators might use the same preset name for different sets of tests.
   > Users are advised to carefully check the documentation of the tools to avoid incorrect assumptions.
+
 - `org_` followed by an organization identifier and an underscore (`_`): for any preset specified by an organization as a part of a public definition
   that can be implemented by different CSAF validators.
   The organization identifier MUST only use the characters identified by the pattern `[0-9a-zA-Z-]`.
@@ -45,8 +47,10 @@ Additional presets are defined as follows:
 
 - `external-request-free`:
   - Description: Any test that can be executed without a request into the Internet or a different network.
+
     > This is intended to be used for browser-based tools as external requests may result in CORS issues.
     > Request over network to a tool that is delivered with or an install requirement for a CSAF validator are not considered external.
+
   - Set: `full` excluding tests [sec](#use-of-non-self-referencing-urls-failing-to-resolve)
     and [sec](#use-of-self-referencing-urls-failing-to-resolve)
 - `consistent-revision-history`:


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1061
- correct display of informative blocks by adding newlines around them
- correct display of informative blocks by adding newlines around them
- separately correct a style issue