### PR TITLE
Editorial - remove `product_id` from 6.1.43 and 6.1.44 

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
@@ -8,8 +8,8 @@ The relevant paths for this test are:
 
 ```
   /product_tree/branches[](/branches[])*/product/product_identification_helper/model_numbers[]
-  /product_tree/full_product_names[]/product_id/product_identification_helper/model_numbers[]
-  /product_tree/relationships[]/full_product_name/product_id/product_identification_helper/model_numbers[]
+  /product_tree/full_product_names[]/product_identification_helper/model_numbers[]
+  /product_tree/relationships[]/full_product_name/product_identification_helper/model_numbers[]
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
@@ -8,8 +8,8 @@ The relevant paths for this test are:
 
 ```
   /product_tree/branches[](/branches[])*/product/product_identification_helper/serial_numbers[]
-  /product_tree/full_product_names[]/product_id/product_identification_helper/serial_numbers[]
-  /product_tree/relationships[]/full_product_name/product_id/product_identification_helper/serial_numbers[]
+  /product_tree/full_product_names[]/product_identification_helper/serial_numbers[]
+  /product_tree/relationships[]/full_product_name/product_identification_helper/serial_numbers[]
 ```
 
 *Example 1 (which fails the test):*


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1091
- remove `product_id` from relevant paths as it does not belong there