### PR TITLE
Workaround to avoid greedy mermaid filterwhen not needed

### DIFF
--- a/csaf_2.1/prose/edit/makefile
+++ b/csaf_2.1/prose/edit/makefile
@@ -100,10 +100,10 @@ render-pdf:
 		cp -a $(liitos_templates)structure.yml $(build_root) && \
 		cp -a etc/etiketti/etiketti.yml $(build_pdf) && \
 		cd $(build_pdf) && \
-		max_print_line=10000 liitos render ../../ -t csaf -f pdf -p -l "etiketti --config etiketti.yml --enforce"  && \
+		max_print_line=10000 liitos render ../../ --target csaf --facet pdf --patch-tables --filters ' ' --label "etiketti --config etiketti.yml --enforce"  && \
 		$(optimize_pdf) -- this.pdf && \
 		cp -a this.pdf ../../../$(out_pdf) && \
-		open ../../../$(out_pdf) && cd -
+		open ../../../$(out_pdf); cd -
 
 .PHONY: build
 build: render status


### PR DESCRIPTION
This change set should remove an error source from the PDF rendering on some machines.

## Content changes:

n/a

## Editorial changes:

n/a

## Tool changes:

- call liitos with --filters ' ' (a space between quotes) to create an unfiltered call to pandoc (when we klnow that there are no fenced blocks with mermaid diagrams in the source files).
- translated some short to long options in the liitos call (maintainability)
- kept the platform specific open call in render-pdf recipe, but changed the final change directory command to unconditional