### PR TITLE
Comment Resolution CSD01PR: #1083

### DIFF
--- a/csaf_2.1/prose/edit/src/distributing-01-requirements.md
+++ b/csaf_2.1/prose/edit/src/distributing-01-requirements.md
@@ -424,7 +424,7 @@ ROLIE categories SHOULD be used for to further dissect CSAF documents by one or 
 All CSAF documents SHALL have at least one hash file computed with a secure cryptographic hash algorithm (e.g. SHA-512 or SHA-3)
 to ensure their integrity. The filename is constructed by appending the file extension which is given by the algorithm.
 
-MD5 and SHA1 MUST NOT be used.
+MD5 and SHA1 SHALL NOT be used.
 
 *Example 1:*
 

--- a/csaf_2.1/prose/edit/src/distributing-01-requirements.md
+++ b/csaf_2.1/prose/edit/src/distributing-01-requirements.md
@@ -424,7 +424,7 @@ ROLIE categories SHOULD be used for to further dissect CSAF documents by one or 
 All CSAF documents SHALL have at least one hash file computed with a secure cryptographic hash algorithm (e.g. SHA-512 or SHA-3)
 to ensure their integrity. The filename is constructed by appending the file extension which is given by the algorithm.
 
-MD5 and SHA1 SHOULD NOT be used.
+MD5 and SHA1 MUST NOT be used.
 
 *Example 1:*
 

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -151,7 +151,7 @@ Any File hash object has the 2 mandatory properties `algorithm` and `value`.
 The algorithm of the cryptographic hash representation (`algorithm`) of value type `string` with one or more characters contains
 the name of the cryptographic hash algorithm used to calculate the value.
 The default value for `algorithm` is `sha256`.
-Secure cryptographic hash algorithm SHOULD be preferred.
+Secure cryptographic hash algorithms SHOULD be preferred.
 
 *Examples 1:*
 

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-full-product-name.md
@@ -151,6 +151,7 @@ Any File hash object has the 2 mandatory properties `algorithm` and `value`.
 The algorithm of the cryptographic hash representation (`algorithm`) of value type `string` with one or more characters contains
 the name of the cryptographic hash algorithm used to calculate the value.
 The default value for `algorithm` is `sha256`.
+Secure cryptographic hash algorithm SHOULD be preferred.
 
 *Examples 1:*
 


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1083
- disallow MD5 and SHA1 in distribution
- no change to 6.2.8 and 6.2.9 to not force users to remove weak hashes in existing documents and loose information
- clarify that secure cryptographic hash algorithms should be preferred