### PR TITLE
Comment Resolution CSD01PR: #1053

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -421,7 +421,7 @@ The relevant paths for this test are:
 ### Missing CVSS v4.0
 
 For each item in the list of metrics that contains any CVSS object it MUST be tested that a `cvss_v4` object is present.
-The test MUST fail, if any Product ID (type `/$defs/product_id_t`) in the product status group Affected is not covered by
+The test MUST fail, if any Product ID (type `/$defs/product_id_t`) in the product status group Affected (see section [sec](#vulnerabilities-property-product-status)) is not covered by
 any CVSS object.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -420,7 +420,9 @@ The relevant paths for this test are:
 
 ### Missing CVSS v4.0
 
-For each item in the list of metrics it MUST be tested that a `cvss_v4` object is present.
+For each item in the list of metrics that contains any CVSS object it MUST be tested that a `cvss_v4` object is present.
+The test MUST fail, if any Product ID (type `/$defs/product_id_t`) in the product status group Affected is not covered by
+any CVSS object.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-05.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-05.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative Test: Informative Test: Missing CVSS v4.0 (failing example 5)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-05",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      },
+      {
+        "product_id": "CSAFPID-9080701",
+        "name": "Product B"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "metrics": [
+        {
+          "content": {
+            "epss": {
+              "percentile": "0.247020000",
+              "probability": "0.000820000",
+              "timestamp": "2024-01-24T10:00:00.000Z"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    },
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v2": {
+              "version": "2.0",
+              "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+              "baseScore": 10
+            },
+            "cvss_v3": {
+              "version": "3.1",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+              "baseScore": 10,
+              "baseSeverity": "CRITICAL"
+            },
+            "cvss_v4": {
+              "version": "4.0",
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+              "baseScore": 10,
+              "baseSeverity": "CRITICAL"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ],
+      "product_status": {
+        "first_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    },
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v2": {
+              "version": "2.0",
+              "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+              "baseScore": 4.3
+            },
+            "cvss_v3": {
+              "version": "3.1",
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+              "baseScore": 3.1,
+              "baseSeverity": "LOW"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ],
+      "product_status": {
+        "known_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-16.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-16.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Informative Test: Informative Test: Missing CVSS v4.0 (valid example 6)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-12-16",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "CSAFPID-9080700",
+        "name": "Product A"
+      },
+      {
+        "product_id": "CSAFPID-9080701",
+        "name": "Product B"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "metrics": [
+        {
+          "content": {
+            "epss": {
+              "percentile": "0.247020000",
+              "probability": "0.000820000",
+              "timestamp": "2024-01-24T10:00:00.000Z"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        }
+      ]
+    },
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v2": {
+              "version": "2.0",
+              "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+              "baseScore": 10
+            },
+            "cvss_v3": {
+              "version": "3.1",
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+              "baseScore": 10,
+              "baseSeverity": "CRITICAL"
+            },
+            "cvss_v4": {
+              "version": "4.0",
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+              "baseScore": 10,
+              "baseSeverity": "CRITICAL"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700",
+            "CSAFPID-9080701"
+          ]
+        }
+      ],
+      "product_status": {
+        "first_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    },
+    {
+      "metrics": [
+        {
+          "content": {
+            "cvss_v2": {
+              "version": "2.0",
+              "vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
+              "baseScore": 4.3
+            },
+            "cvss_v3": {
+              "version": "3.1",
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+              "baseScore": 3.1,
+              "baseSeverity": "LOW"
+            },
+            "cvss_v4": {
+              "baseScore": 2.3,
+              "baseSeverity": "LOW",
+              "vectorString": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:P/VC:L/VI:N/VA:N/SC:L/SI:N/SA:N",
+              "version": "4.0"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700"
+          ]
+        },
+        {
+          "content": {
+            "cvss_v4": {
+              "baseScore": 2.1,
+              "baseSeverity": "LOW",
+              "vectorString": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:L/VI:N/VA:N/SC:L/SI:N/SA:N",
+              "version": "4.0"
+            }
+          },
+          "products": [
+            "CSAFPID-9080700",
+            "CSAFPID-9080701"
+          ],
+          "source": "https://www.example.com/some-website-containing-that-vector"
+        }
+      ],
+      "product_status": {
+        "known_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -3564,6 +3564,10 @@
         {
           "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-04.json",
           "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-05.json",
+          "valid": true
         }
       ],
       "valid": [
@@ -3585,6 +3589,10 @@
         },
         {
           "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-15.json",
+          "valid": true
+        },
+        {
+          "name": "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-16.json",
           "valid": true
         }
       ]


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1053
- add restriction to exclude content objects without CVSS
- add requirement that at least one CVSS needs to be there per affected product
- add additional examples
