### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/etc/bind.txt
+++ b/csaf_2.1/prose/edit/etc/bind.txt
@@ -87,6 +87,7 @@ tests-01-mndtr-52-inconsistent-first-known-exploitation-dates.md
 tests-01-mndtr-53-inconsistent-exploitation-date.md
 tests-01-mndtr-54-license-expression.md
 tests-01-mndtr-55-license-text.md
+tests-01-mndtr-56-use-of-cvss-and-qualitative-severity-rating.md
 tests-02-recommended.md
 tests-02-rcmmndd-01-unused-definition-of-product-id.md
 tests-02-rcmmndd-02-missing-remediation.md


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1187
- add missing test 6.1.56 to bind.txt