### PR TITLE
CWEs Usage property - 6.2.25 and 6.2.26

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-25-usage-of-cwe-not-allowed-for-vulnerability-mapping.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-25-usage-of-cwe-not-allowed-for-vulnerability-mapping.md
@@ -3,6 +3,9 @@
 For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed.
 
 > Currently, this includes the two usage state `Allowed` and `Allowed-with-Review`.
+>
+> Note: The property `Usage` within the `MappingNotesType` was introduced in version `7.0` of the CWE schema definition.
+> As a consequence, this information might not be available before CWE version `4.12`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-26-usage-of-cwe-allowed-with-review-for-vulnerability-mapping.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-26-usage-of-cwe-allowed-with-review-for-vulnerability-mapping.md
@@ -4,6 +4,9 @@ For each item in the CWE array it MUST be tested that the vulnerability mapping 
 
 > Reasoning: CWEs marked with a vulnerability mapping state of `Allowed-with-Review` should only be used if a thorough review was done.
 > This test helps to flag such mappings which can be used to trigger processes that ensure the extra review, e.g. by a senior analyst.
+>
+> Note: The property `Usage` within the `MappingNotesType` was introduced in version `7.0` of the CWE schema definition.
+> As a consequence, this information might not be available before CWE version `4.12`.
 
 The relevant path for this test is:
 


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1181
- add hint that CWE usage property was just introduced in CWE Schema 7.0 (CWE version 4.12) for test 6.2.25 and 6.2.26