### PR TITLE
CVSS v4.0

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
@@ -18,11 +18,10 @@ The relevant paths for this test are:
   /vulnerabilities[]/metrics[]/content/cvss_v3/environmentalSeverity
   /vulnerabilities[]/metrics[]/content/cvss_v4/baseScore
   /vulnerabilities[]/metrics[]/content/cvss_v4/baseSeverity
-  /vulnerabilities[]/metrics[]/content/cvss_v4/threatScore
-  /vulnerabilities[]/metrics[]/content/cvss_v4/threatSeverity
-  /vulnerabilities[]/metrics[]/content/cvss_v4/environmentalScore
-  /vulnerabilities[]/metrics[]/content/cvss_v4/environmentalSeverity
 ```
+
+> Note: CVSS v4 does not define `threatScore`, `threatSeverity`, `environmentalScore` and `environmentalSeverity`.
+> The existence of these JSON keys in an older version of the schema was fixed with version `4.0.1`.
 
 *Example 1 (which fails the test):*
 


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1174, addresses part of oasis-tcs/csaf#1070, oasis-tcs/csaf#652
- clarify that CVSS v4 does not have `threatScore`, `threatSeverity`, `environmentalScore` and `environmentalSeverity`
- remove them from the path