### PR TITLE
Softlimit Size

### DIFF
--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -38,7 +38,7 @@ All _CSAF producers_ SHOULD NOT produce CSAF documents which exceed those limits
 ## File Size
 
 A CSAF document in the specified JSON format encoded in UTF-8 SHOULD conform to known size limits of current technologies parsing JSON content,
-e.g.: 50 MiB.
+e.g.: 150 MiB.
 
 > The CSAF documents observed in the wild expose strongly varying sizes as per the use cases they serve.
 > At least one database technology in wide use for storing CSAF documents rejects insert attempts when


### PR DESCRIPTION
- addresses real-world documents as discussed as the CSAF Community Days 2025
- bump limit to 150 MiB