### PR TITLE
Requirement 18: case-sensitive

### DIFF
--- a/csaf_2.1/prose/edit/src/distributing-01-requirements.md
+++ b/csaf_2.1/prose/edit/src/distributing-01-requirements.md
@@ -535,6 +535,7 @@ File name of SHA-512 hash file: esa-2022-02723.json.sha512
 ```
 
 The file content SHALL start with the first byte of the hexadecimal hash value.
+The hash value SHALL be represented in lower case.
 Any subsequent data (like a filename) which is optional SHALL be separated by at least one space.
 
 *Example 2:*


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1201
- clarify that the hash is expected to be lower case