### PR TITLE
Fixed undefined label hardware-and-software-within-the-product-tree-eg-1

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
@@ -51,5 +51,4 @@ The relevant paths for this test are:
 
 > The `product_tree` mentions the hardware product Example Company Controller A and combines it with the Firmware version 4.1.
 
-> A correct representation for hardware and software in the `product_tree` is given in example
-> \[[eg](#hardware-and-software-within-the-product-tree-eg-1)\] in section [sec](#hardware-and-software-within-the-product-tree).
+> A correct representation for hardware and software in the `product_tree` is given in example 1 in section [sec](#hardware-and-software-within-the-product-tree).


### PR DESCRIPTION
Editorial Changes:

- [x] Fixed undefined label hardware-and-software-within-the-product-tree-eg-1
  - the example is directly following the section anchor, so we can easily refer to teh example 1 by teleporting the reader to the hosting section's title
  - this fixes the undefined label warning/error in PDF generation
  - we currently do have labels we can jump to only for selected structural elements like sections and tables