### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/etc/liitos/patch.yml
+++ b/csaf_2.1/prose/edit/etc/liitos/patch.yml
@@ -49,6 +49,8 @@
   - 'users are used to that.\n\end{blockquote}\newpage'
 - - ',height=\textheight]'
   - ']'
+- - 'hardware-and-software-within-the-product-tree-eg-1'
+  - 'hardware-and-software-within-the-product-tree'
 - - 'requirement-12-index-txt-eg-1'
   - 'requirement-12-index-txt'
 - - 'requirement-12-index-txt-eg-2'


### PR DESCRIPTION
- supersedes oasis-tcs/csaf#1247
- use patch.yml to circumvent missing link in pdf