### PR TITLE
Added bump tool to seed editor revisions

### DIFF
--- a/csaf_2.1/prose/edit/bin/bump.py
+++ b/csaf_2.1/prose/edit/bin/bump.py
@@ -41,12 +41,13 @@ MONTHS_EN = (
 here = pathlib.Path().absolute()
 tool = pathlib.Path(__file__)
 path = tool.relative_to(here)
+usage = f'usage: {path} [--commit] "DD Month YYYY"'
 
 args = sys.argv[1:]
 
 if not args:
-    print(f'usage: {path} [--commit] "DD Month YYYY"')
-    sys.exit(2)
+    print(usage)
+    sys.exit(0)
 
 commit = False
 for slot, arg in enumerate(args):
@@ -54,15 +55,15 @@ for slot, arg in enumerate(args):
         commit = True
         del args[slot]
 
-if not commit:
-    print('INFO: Dry-run only - only diffs are shown and no files changed.')
-else:
-    print('INFO: Commit mode - the magical four files will be bumped.')
-
 try:
     DD, Month, YYYY = args[0].split(SPACE)
 except ValueError:
-    print(f'usage: {path} "DD Month YYYY"')
+    print(usage)
+    print(f'ERROR: Parsing date value ({args[0]})')
+    sys.exit(2)
+except IndexError:
+    print(usage)
+    print(f'ERROR: Not enough arguments')
     sys.exit(2)
 
 PUB_DAY = DD
@@ -121,6 +122,11 @@ _, max_days_of_month = cal.monthrange(y, m)
 if d > max_days_of_month:
     print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
     sys.exit(2)
+
+if not commit:
+    print('INFO: Dry-run only - only diffs are shown and no files changed.')
+else:
+    print('INFO: Commit mode - the magical four files will be bumped.')
 
 PUB_DATE = f'{PUB_DAY} {PUB_MONTH_EN} {PUB_YEAR}'
 DEBUG = bool(os.getenv('BUMP_DEBUG', ''))
@@ -303,6 +309,8 @@ sys.stdout.writelines(difflib.unified_diff(
 if commit:
     with open(SRC_HISTORY, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
         target.write(NL.join(bumped) + NL)
-
-print()
-print('Bumped - OK')
+    print()
+    print('Bumped - OK')
+else:
+    print()
+    print('Dry-Bumped - OK')


### PR DESCRIPTION
# Tool Addition

Added bump tool to seed editor revisions

- linear think-write styled 250 lines of code
- works only for CSAF 2.1 drafts with date changes
- different stages require adaptation of the trigger tokens (some)
- the magical four files are hard coded
- default is a dry-run mode showing the diffs directly
- you can pipe the output into a coloring pager like bat -l diff for fun and profit
- the --commit option, well, causes the changes to be committed (not as in git commit, but as in written back to the incoming source files
- setting the BUMP_DEBUG environment variable to a non-empty value triggers a few presumably chatty log messages (not adding real value on top of the diff)
- calling the tool without arguments prints the usage message
- the tool is lax about too many parameters, so you are on your own if the expected 'DD Month YYYY' positional argument is not the first (ignoring any --commit argument which will be removed before processing the date argument)
- minor UX enhancements

# Example sessions

## Use Case

Seeding a new editor revision with target publication date 2026-02-25.

### Dry-run first:

```diff
❯ bin/bump.py "25 February 2026"
INFO: Dry-run only - only diffs are shown and no files changed.
# - - - 8< - -(( etc/liitos/bookmatter.tex.in )) - - - - - - - - - - - - - - >

--- bookmatter.tex.in
+++ bookmatter-bumped.tex.in
@@ -11,7 +11,7 @@
 \subsection*{Committee Specification Draft
 02}\label{committee-specification-draft-02}

-\subsection*{17 December 2025}\label{pub-date}
+\subsection*{25 February 2026}\label{pub-date}

 \paragraph*{This stage:}\label{this-stage}

@@ -173,7 +173,7 @@
 \textbf{{[}csaf-v2.1{]}}

 \emph{Common Security Advisory Framework Version 2.1}. Edited by Stefan
-Hagen, and Thomas Schmidt. 17 December 2025. OASIS Committee Specification
+Hagen, and Thomas Schmidt. 25 February 2026. OASIS Committee Specification
 Draft 02.
 \href{https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html}{https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html}.
 Latest stage: \href{https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html}{https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html}.

# - - - 8< - -(( etc/liitos/meta.yml )) - - - - - - - - - - - - - - - - - - >

--- meta.yml
+++ meta-bumped.yml
@@ -16,7 +16,7 @@
     font_path: /opt/fonts/
     font_suffix: .otf
     footer_frame_note: csaf-v2.1-csd02
-    footer_outer_field_normal_pages: 17 December 2025 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
+    footer_outer_field_normal_pages: 25 February 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
     footer_page_number_prefix: Page
     has_approvals: false
     has_changes: false

# - - - 8< - -(( src/frontmatter.md )) - - - - - - - - - - - - - - - - - - >

--- frontmatter.md
+++ frontmatter-bumped.md
@@ -7,7 +7,7 @@

 ## Committee Specification Draft 02

-## 17 December 2025
+## 25 February 2026

 #### This stage:
 https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.md (Authoritative) \
@@ -78,14 +78,14 @@

 **[csaf-v2.1]**

-_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen and Thomas Schmidt. 17 December 2025. OASIS Committee Specification Draft 02. https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
+_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen and Thomas Schmidt. 25 February 2026. OASIS Committee Specification Draft 02. https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.


 -------

 ## Notices

-Copyright © OASIS Open 2025. All Rights Reserved.
+Copyright © OASIS Open 2026. All Rights Reserved.

 All capitalized terms in the following text have the meanings assigned to them in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full [Policy](https://www.oasis-open.org/policies-guidelines/ipr/) may be found at the OASIS website.


# - - - 8< - -(( src/revision-history.md )) - - - - - - - - - - - - - - - - - - >

--- revision-history.md
+++ revision-history-bumped.md
@@ -30,5 +30,6 @@
 | csaf-v2.1-wd20251029-dev | 2025-10-29 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
 | csaf-v2.1-wd20251126-dev | 2025-11-26 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
 | csaf-v2.1-wd20251217-dev | 2025-12-17 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
+| csaf-v2.1-wd20260225-dev | 2026-02-25 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |

 -------

Dry-Bumped - OK
```

### Run committing to filesystem second:

```diff
❯ bin/bump.py --commit "25 February 2026"
INFO: Commit mode - the magical four files will be bumped.
# - - - 8< - -(( etc/liitos/bookmatter.tex.in )) - - - - - - - - - - - - - - >

--- bookmatter.tex.in
+++ bookmatter-bumped.tex.in
@@ -11,7 +11,7 @@
 \subsection*{Committee Specification Draft
 02}\label{committee-specification-draft-02}

-\subsection*{17 December 2025}\label{pub-date}
+\subsection*{25 February 2026}\label{pub-date}

 \paragraph*{This stage:}\label{this-stage}

@@ -173,7 +173,7 @@
 \textbf{{[}csaf-v2.1{]}}

 \emph{Common Security Advisory Framework Version 2.1}. Edited by Stefan
-Hagen, and Thomas Schmidt. 17 December 2025. OASIS Committee Specification
+Hagen, and Thomas Schmidt. 25 February 2026. OASIS Committee Specification
 Draft 02.
 \href{https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html}{https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html}.
 Latest stage: \href{https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html}{https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html}.

# - - - 8< - -(( etc/liitos/meta.yml )) - - - - - - - - - - - - - - - - - - >

--- meta.yml
+++ meta-bumped.yml
@@ -16,7 +16,7 @@
     font_path: /opt/fonts/
     font_suffix: .otf
     footer_frame_note: csaf-v2.1-csd02
-    footer_outer_field_normal_pages: 17 December 2025 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
+    footer_outer_field_normal_pages: 25 February 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
     footer_page_number_prefix: Page
     has_approvals: false
     has_changes: false

# - - - 8< - -(( src/frontmatter.md )) - - - - - - - - - - - - - - - - - - >

--- frontmatter.md
+++ frontmatter-bumped.md
@@ -7,7 +7,7 @@

 ## Committee Specification Draft 02

-## 17 December 2025
+## 25 February 2026

 #### This stage:
 https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.md (Authoritative) \
@@ -78,14 +78,14 @@

 **[csaf-v2.1]**

-_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen and Thomas Schmidt. 17 December 2025. OASIS Committee Specification Draft 02. https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.
+_Common Security Advisory Framework Version 2.1_. Edited by Stefan Hagen and Thomas Schmidt. 25 February 2026. OASIS Committee Specification Draft 02. https://docs.oasis-open.org/csaf/csaf/v2.1/csd02/csaf-v2.1-csd02.html. Latest stage: https://docs.oasis-open.org/csaf/csaf/v2.1/csaf-v2.1.html.


 -------

 ## Notices

-Copyright © OASIS Open 2025. All Rights Reserved.
+Copyright © OASIS Open 2026. All Rights Reserved.

 All capitalized terms in the following text have the meanings assigned to them in the OASIS Intellectual Property Rights Policy (the "OASIS IPR Policy"). The full [Policy](https://www.oasis-open.org/policies-guidelines/ipr/) may be found at the OASIS website.


# - - - 8< - -(( src/revision-history.md )) - - - - - - - - - - - - - - - - - - >

--- revision-history.md
+++ revision-history-bumped.md
@@ -30,5 +30,6 @@
 | csaf-v2.1-wd20251029-dev | 2025-10-29 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
 | csaf-v2.1-wd20251126-dev | 2025-11-26 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
 | csaf-v2.1-wd20251217-dev | 2025-12-17 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
+| csaf-v2.1-wd20260225-dev | 2026-02-25 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |

 -------

Bumped - OK
```

## Other Cases

Get help (kind of):

```bash
❯ bin/bump.py
usage: bin/bump.py [--commit] "DD Month YYYY"
```

Why read?

```bash
❯ bin/bump.py foo
usage: bin/bump.py [--commit] "DD Month YYYY"
ERROR: Parsing date value (foo)
```

Invalid day (too large number):

```bash
❯ bin/bump.py "123 February 2026"
ERROR: Day part must be two-digits (zero-padded)
```

Invalid day (too large for the month)

```bash
❯ bin/bump.py "31 February 2026"
ERROR: Day part must be inside days of month [1, 28]
```

Invalid Month (typo):

```bash
❯ bin/bump.py "25 Feburary 2026"
ERROR: English month part must be in (January, February, March, April, May, June, July, August, September, October, November, December)
```

A blast into the past (only current year minus one or any other future year considered) with prepended date call for context:

```bash
❯ date; bin/bump.py "25 February 2024"
Thu Feb 12 21:45:31 CET 2026
ERROR: Year part must be an integral number >= 2025
```

Invalid year (not a number):

```bash
❯ bin/bump.py "25 February Now"
ERROR: Year part must be four-digits
```

Just commit mode, no date:

```bash
❯ bin/bump.py --commit
usage: bin/bump.py [--commit] "DD Month YYYY"
ERROR: Not enough arguments
```