### PR TITLE
Test 6.1.4

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -8,8 +8,8 @@ The relevant paths for this test are:
 
 ```
   /document/notes[]/group_ids[]
-  /vulnerabilities[]/flags[]/group_ids[]
   /vulnerabilities[]/first_known_exploitation_dates[]/group_ids[]
+  /vulnerabilities[]/flags[]/group_ids[]
   /vulnerabilities[]/involvements[]/group_ids[]
   /vulnerabilities[]/notes[]/group_ids[]
   /vulnerabilities[]/remediations[]/group_ids[]

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-02.json
@@ -124,6 +124,15 @@
   },
   "vulnerabilities": [
     {
+      "first_known_exploitation_dates": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "exploitation_date": "2024-01-11T15:53:00.000Z",
+          "group_ids": [
+            "CSAFGID-1020301"
+          ]
+        }
+      ],
       "flags": [
         {
           "group_ids": [

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-12.json
@@ -141,6 +141,15 @@
   },
   "vulnerabilities": [
     {
+      "first_known_exploitation_dates": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "exploitation_date": "2024-01-11T15:53:00.000Z",
+          "group_ids": [
+            "CSAFGID-1020301"
+          ]
+        }
+      ],
       "flags": [
         {
           "group_ids": [


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1296
- add `/vulnerabilities[]/first_known_exploitation_dates[]/group_ids[]` also to the test files