### PR TITLE
Test 6.1.1

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
@@ -11,6 +11,7 @@ The relevant paths for this test are:
   /product_tree/product_groups[]/product_ids[]
   /product_tree/relationships[]/product_reference
   /product_tree/relationships[]/relates_to_product_reference
+  /vulnerabilities[]/first_known_exploitation_dates[]/product_ids[]
   /vulnerabilities[]/flags[]/product_ids[]
   /vulnerabilities[]/involvements[]/product_ids[]
   /vulnerabilities[]/metrics[]/products[]

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json
@@ -126,6 +126,16 @@
   },
   "vulnerabilities": [
     {
+      "first_known_exploitation_dates": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "exploitation_date": "2024-01-11T15:53:00.000Z",
+          "product_ids": [
+            "CSAFPID-9080700",
+            "CSAFPID-9080701"
+          ]
+        }
+      ],
       "flags": [
         {
           "label": "vulnerable_code_not_present",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-12.json
@@ -158,6 +158,16 @@
   },
   "vulnerabilities": [
     {
+      "first_known_exploitation_dates": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "exploitation_date": "2024-01-11T15:53:00.000Z",
+          "product_ids": [
+            "CSAFPID-9080700",
+            "CSAFPID-9080701"
+          ]
+        }
+      ],
       "flags": [
         {
           "label": "vulnerable_code_not_present",


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1302
- add `/vulnerabilities[]/first_known_exploitation_dates[]/product_ids[]` to path of 6.1.1
- add path also to examples