### PR TITLE
Tests - Sorting and removing `generator`

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -22,8 +22,8 @@ The relevant paths for this test are:
   "product_tree": {
     "full_product_names": [
       {
-        "product_id": "CSAFPID-9080700",
-        "name": "Product A"
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
       }
     ]
   },

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-01.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version Range in Branch (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-04-01",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-02.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version Range in Branch (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-04-02",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-11.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version Range in Branch (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-04-11",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-12.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version Range in Branch (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-04-12",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-01.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-01.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version in Branch (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-05-01",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-02.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-02.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version in Branch (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-05-02",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-11.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-11.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version in Branch (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-05-11",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-12.json
+++ b/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-12.json
@@ -16,13 +16,6 @@
     "title": "Informative Test: Overlapping Product Version Range with Product Version in Branch (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-27T23:24:16.742Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-3-19-05-12",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json
@@ -30,13 +30,6 @@
     "title": "Mandatory Test: Missing Definition of Product ID (failing example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-02-19T14:06:11.633Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.43"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-01-02",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-11.json
@@ -32,12 +32,12 @@
   "product_tree": {
     "full_product_names": [
       {
-        "product_id": "CSAFPID-9080700",
-        "name": "Product A"
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
       },
       {
-        "product_id": "CSAFPID-9080701",
-        "name": "Product B"
+        "name": "Product B",
+        "product_id": "CSAFPID-9080701"
       }
     ],
     "product_groups": [

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-12.json
@@ -30,13 +30,6 @@
     "title": "Mandatory Test: Missing Definition of Product ID (valid example 2)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-02-19T14:06:11.633Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.43"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-01-12",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json
@@ -32,8 +32,8 @@
   "product_tree": {
     "full_product_names": [
       {
-        "product_id": "CSAFPID-9080700",
-        "name": "Product A"
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
       }
     ]
   },

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-11.json
@@ -32,12 +32,12 @@
   "product_tree": {
     "full_product_names": [
       {
-        "product_id": "CSAFPID-9080700",
-        "name": "Product A"
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
       },
       {
-        "product_id": "CSAFPID-9080701",
-        "name": "Product B"
+        "name": "Product B",
+        "product_id": "CSAFPID-9080701"
       }
     ],
     "product_groups": [

--- a/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-01.json
+++ b/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-01.json
@@ -16,13 +16,6 @@
     "title": "Recommended Test: Matching Text for Registered ID System (failing example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-28T17:28:58.163Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-53-01",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [

--- a/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-11.json
+++ b/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-11.json
@@ -16,13 +16,6 @@
     "title": "Recommended Test: Matching Text for Registered ID System (valid example 1)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "generator": {
-        "date": "2026-01-28T17:28:58.163Z",
-        "engine": {
-          "name": "Secvisogram",
-          "version": "2.5.42"
-        }
-      },
       "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-53-11",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1319
- check sorting of "newer" test files
- remove generator where applicable
- adapt prose to match examples