### PR TITLE
Editorial - 6.3.19 references

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
@@ -1,7 +1,8 @@
-### Overlapping Product Version Range{informative-tests--overlapping-product-version-range}
+### Overlapping Product Version Range{#informative-tests--overlapping-product-version-range}
 
 This subsubsection structures the informative tests for overlapping product version ranges.
 These tests provide weak indicators of potential errors in the construction of the product tree.
+The abbreviations for groups are defined in section [sec](#overlapping-product-version-range).
 
 #### Overlapping Product Version Range with vers in Same Product Status Group
 


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1293
- correct reference definition in 6.3.19
- mention that definition for groups are in 6.2.50