### PR TITLE
Test 6.1.26 - wrong metadata

### DIFF
--- a/csaf_2.0/test/validator/data/testcases.json
+++ b/csaf_2.0/test/validator/data/testcases.json
@@ -586,11 +586,11 @@
       "valid": [
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-11.json",
-          "valid": false
+          "valid": true
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-12.json",
-          "valid": false
+          "valid": true
         }
       ]
     },


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1322
- correct cpsr mistake and mark valid test cases as valid