### PR TITLE
Test 6.1.25 - add missing word "file"

### DIFF
--- a/csaf_2.0/known_issues.md
+++ b/csaf_2.0/known_issues.md
@@ -39,3 +39,6 @@
   See [#1265](https://github.com/oasis-tcs/csaf/issues/1265).
 - Confusion could occur around the depth of PURL checking in test [6.1.13](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#6113-purl).
   See [#1303](https://github.com/oasis-tcs/csaf/issues/1303).
+- The test [6.1.25](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#6125-multiple-use-of-same-hash-algorithm)
+  is missing the word "file" in the description and explanation but shows the correct relevant paths.
+  See [#1330](https://github.com/oasis-tcs/csaf/issues/1330).

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
@@ -1,6 +1,6 @@
 ### Multiple Use of Same Hash Algorithm
 
-It MUST be tested that the same hash algorithm is not used multiple times in one item of hashes.
+It MUST be tested that the same hash algorithm is not used multiple times in one item of file hashes.
 
 The relevant paths for this test are:
 
@@ -40,4 +40,4 @@ The relevant paths for this test are:
   }
 ```
 
-> The hash algorithm `sha256` is used two times in one item of hashes.
+> The hash algorithm `sha256` is used two times in one item of file hashes.

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-11.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Multiple Use of Same Hash Algorithm (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-25-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha256",
+                  "value": "026a37919b182ef7c63791e82c9645e2f897a3f0b73c7a6028c7febf62e93838"
+                },
+                {
+                  "algorithm": "sha384",
+                  "value": "35fe8d330025569f903b84f434fb0cbbc5bb5706bc89e101de3eb2aef36c8328b62f3bbc1bb5685bd383465ddb764632"
+                }
+              ],
+              "filename": "product_a.so"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-12.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Multiple Use of Same Hash Algorithm (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-25-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha256",
+                  "value": "026a37919b182ef7c63791e82c9645e2f897a3f0b73c7a6028c7febf62e93838"
+                },
+                {
+                  "algorithm": "sha384",
+                  "value": "35fe8d330025569f903b84f434fb0cbbc5bb5706bc89e101de3eb2aef36c8328b62f3bbc1bb5685bd383465ddb764632"
+                }
+              ],
+              "filename": "product_a-one-file.so"
+            },
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha384",
+                  "value": "25222e538a6c9256ee1e876414f8d4fc443f7b7ade2b1ab81d43d007e159fbbca21bb54bfbc7c1ca9bf93a95b73bd6ed"
+                },
+                {
+                  "algorithm": "sha256",
+                  "value": "af13a3ac44eb4e528246608f5dc18b5403b51046e7a6a32828fa4349345afcda"
+                }
+              ],
+              "filename": "product_a-another-file.so"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -778,6 +778,16 @@
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-01.json",
           "valid": false
         }
+      ],
+      "valid": [
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-11.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-12.json",
+          "valid": true
+        }
       ]
     },
     {


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1330, addresses parts of oasis-tcs/csaf#341
- add missing word "file" to description and explanation to match paths (and test intension)
- add valid examples
- document as known issue for CSAF 2.0
- update test metadata