### PR TITLE
fix: change document category for test 6.1.27.5 to csaf_deprecated_security_advisory

### DIFF
--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-03.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
   "document": {
-    "category": "csaf_vex",
+    "category": "csaf_deprecated_security_advisory",
     "csaf_version": "2.1",
     "distribution": {
       "tlp": {


### PR DESCRIPTION
`-02` file already covers `csaf_vex` and `-03` should be `csaf_deprecated_security_advisory` as in the testfiles for 6.1.27.4

- resolves #1339 