### PR TITLE
Editorial - warning consistency

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance.md
+++ b/csaf_2.1/prose/edit/src/conformance.md
@@ -107,8 +107,7 @@ Firstly, the program:
 * outputs a warning that an additional property was detected and not converted if it detects an additional property in the input.
   Such a warning MUST include the additional property and its path.
   The CVRF CSAF Converter SHALL ignore that additional property during the conversion.
-* includes in each warning the appropriate paths and values from the original file which caused the warning
-  unless specified otherwise in this standard.
+* includes in every warning the relevant paths and values ​​from the original file that triggered the alert, unless otherwise specified in this standard.
 * additionally satisfies the normative requirements given below.
 
 Secondly, the program fulfills the following for all items of:
@@ -695,8 +694,7 @@ Firstly, the program:
 * outputs a warning that an additional property was detected and not converted if it detects an additional property in the input.
   Such a warning MUST include the additional property and its path.
   The CSAF 2.0 to CSAF 2.1 Converter SHALL ignore that additional property during the conversion.
-* includes in each warning the appropriate paths and values from the original file which caused the warning
-  unless specified otherwise in this standard.
+* includes in every warning the relevant paths and values ​​from the original file that triggered the alert, unless otherwise specified in this standard.
 * additionally satisfies the normative requirements given below.
 
 Secondly, the program fulfills the following for all items of:


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1343
- add catch-all for warnings to always include paths and values (unless otherwise specified) for consistency
- add specific mention to additional properties (as stated above that consistency rule)