### PR TITLE
Editorial clarification: "present and set"

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
@@ -1,6 +1,8 @@
 ### Translator
 
-It MUST be tested that `/document/source_lang` is present if the value `translator` is used for `/document/publisher/category`.
+It MUST be tested that `/document/source_lang` is present and set if the value `translator` is used for `/document/publisher/category`.
+A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
+not being present at all.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
@@ -26,3 +26,6 @@ The relevant path for this test is:
 ```
 
 > The required element `source_lang` is missing.
+
+> A tool MAY add the key as a quick fix.
+> In such case, the value still needs to be set - either manually or by other means from the tool, e.g. through a given configuration.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
@@ -1,6 +1,8 @@
 ### Missing Document Language
 
-It MUST be tested that the document language member is present.
+It MUST be tested that the document language member is present and set.
+A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
+not being present at all.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
@@ -29,3 +29,6 @@ The relevant path for this test is:
 ```
 
 > The document language is not defined.
+
+> A tool MAY add the key as a quick fix.
+> In such case, the value still needs to be set - either manually or by other means from the tool, e.g. through a given configuration.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
@@ -24,3 +24,6 @@ The relevant path for this test is:
 ```
 
 > The license expression is not defined.
+
+> A tool MAY add the key as a quick fix.
+> In such case, the value still needs to be set - either manually or by other means from the tool, e.g. through a given configuration.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
@@ -1,6 +1,8 @@
 ### Missing License Expression
 
 It MUST be tested that the license expression is present and set.
+A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
+not being present at all.
 
 The relevant path for this test is:
 


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1345
- clarify expectation of different error messages for different situations