### PR TITLE
Standing rules

### DIFF
--- a/standing_rules/MMR.md
+++ b/standing_rules/MMR.md
@@ -1,0 +1,10 @@
+# Maintainer Merge Right
+
+## Text
+
+Maintainers of the OASIS CSAF TC repositories can merge any editorial, test, technical, and tool related PRs after
+approval from another maintainer without a formal motion with the TC.
+
+## Adoption
+
+Voting during [TC meeting 2025-08-27](https://github.com/oasis-tcs/csaf/blob/17f90fd3078feaf05109f016ec3bda9d696100b2/meeting_minutes/2025/2025-08-27.md?plain=1#L120-L127)

--- a/standing_rules/README.md
+++ b/standing_rules/README.md
@@ -1,0 +1,8 @@
+# Standing Rules
+
+This folder lists the standing rules adopted by the TC.
+
+| ID                 | Name                         | Date adopted | Scope                                                          |
+| ------------------ | ---------------------------- | ------------ | -------------------------------------------------------------- |
+| [#MMR](MMR.md)     | Maintainer Merge Right       | 2025-08-27   | any editorial, test, technical, and tool related pull requests |
+| [#SR1BP](SR1BP.md) | Editor CSD Publication Right | 2026-02-25   | publication of additional CSDs                                 |

--- a/standing_rules/SR1BP.md
+++ b/standing_rules/SR1BP.md
@@ -1,0 +1,10 @@
+# Standing Rule [#SR1BP](https://www.oasis-open.org/policies-guidelines/document-life-cycle-best-practices/#SR1BP)
+
+## Text
+
+As a standing rule, the TC may authorize the editor(s) to publish additional versions of a CSD or CND either on a regular basis
+or at their discretion without additional motions, calls for consent, or ballots.
+
+## Adoption
+
+Voting during [TC meeting 2026-02-25](https://github.com/oasis-tcs/csaf/blob/17f90fd3078feaf05109f016ec3bda9d696100b2/meeting_minutes/2026/2026-02-25.md?plain=1#L109-L120)


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1419
- add first files to document standing rules adopted by the TC