### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance-01-cls-14-basic-validator.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-14-basic-validator.md
@@ -6,7 +6,7 @@ A program satisfies the "CSAF Basic Validator" conformance profile if the progra
   including also the format validation (cf. section [sec](#format-validation)).
 * performs all tests of the preset `mandatory` as given in section [sec](#presets-defined-through-test-subsections).
 * does not change the CSAF Documents.
-* satisfies those normative requirements in sections [sec](#extensions), [sec](#schema-elements)  [sec](#mandatory-tests),
+* satisfies those normative requirements in sections [sec](#extensions), [sec](#schema-elements), [sec](#mandatory-tests),
   [sec](#test-presets), and [sec](#safety-security-and-data-protection-considerations) that are designated as applying to
   CSAF Validators.
 * issues a warning if an "not implemented warning" occurs as the validation status might not be correct.

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -51,7 +51,7 @@ For any restricted feeds, standard authentication methods SHOULD be used that ar
 CSAF producers, CSAF consumers and CSAF validators SHOULD NOT automatically retrieve JSON schemas from a URL declared in CSAF documents
 as this poses a security risk.
 Loading files from an untrusted source can result in information leakage or remotely triggered automated exploitation.
-If CSAF producers, CSAF consumers or CSAF validators provide a option to interactively or automatically load missing schemes,
+If CSAF producers, CSAF consumers or CSAF validators provide an option to interactively or automatically load missing schemes,
 they SHALL point out the risks of setting the option and actively warn the user about it.
 Such option SHALL NOT be set by default.
 CSAF producers, CSAF consumers and CSAF validators SHOULD keep a local copy of all schemas necessary to fulfill their tasks.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-profile-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-profile-tests.md
@@ -2,7 +2,7 @@
 
 This subsubsection structures the mandatory tests for the profiles. Not all tests apply for all profiles.
 Tests SHOULD be skipped if the document category does not match the one given in the test.
-Each of the following tests SHOULD be treated as they where listed similar to the other tests.
+Each of the following tests SHOULD be treated as they were listed similar to the other tests.
 
 > An application MAY group these tests by profiles when providing the additional function to only run one or more selected tests.
 > This results in one virtual test per profile.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
@@ -15,6 +15,8 @@ The relevant path for this test is:
   /vulnerabilities[]/first_known_exploitation_dates[]/exploitation_date
   /vulnerabilities[]/flags[]/date
   /vulnerabilities[]/involvements[]/date
+  /vulnerabilities[]/metrics[]/content/epss/timestamp
+  /vulnerabilities[]/metrics[]/content/ssvc_v2/timestamp
   /vulnerabilities[]/remediations[]/date
   /vulnerabilities[]/threats[]/date
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in Model Number
 
-For each model number it MUST be tested that the it does not contain multiple unescaped stars.
+For each model number it MUST be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a model number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in Serial Number
 
-For each serial number it MUST be tested that the it does not contain multiple unescaped stars.
+For each serial number it MUST be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a serial number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-49-inconsistent-ssvc-timestamp.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-49-inconsistent-ssvc-timestamp.md
@@ -1,6 +1,6 @@
 ### Inconsistent SSVC Timestamp
 
-For each vulnerability, it MUST be tested that the each SSVC `timestamp` is earlier than or equal to the `date` of the newest item of the
+For each vulnerability, it MUST be tested that each SSVC `timestamp` is earlier than or equal to the `date` of the newest item of the
 `revision_history` if the document status is `final` or `interim`.
 As the timestamps might use different timezones, the sorting MUST take timezones into account.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
@@ -3,7 +3,7 @@
 For each element of type `/$defs/branches_t` with `category` of `product_version_range`, it MUST be tested that the value of `name` complies with
 the rules given in section [sec](#branches-type---name-under-product-version-range).
 Version schemes of vers not supported by the implementation SHALL result in a warning which MUST include the version scheme name used.
-Nevertheless, all other rules MUST be checked to the extend possible.
+Nevertheless, all other rules MUST be checked to the extent possible.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-51-inconsistent-epss-timestamp.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-51-inconsistent-epss-timestamp.md
@@ -1,6 +1,6 @@
 ### Inconsistent EPSS Timestamp
 
-For each vulnerability, it MUST be tested that the each EPSS `timestamp` is earlier than or equal to the `date` of the newest item of the
+For each vulnerability, it MUST be tested that each EPSS `timestamp` is earlier than or equal to the `date` of the newest item of the
 `revision_history` if the document status is `final` or `interim`.
 As the timestamps might use different timezones, the sorting MUST take timezones into account.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-54-license-expression.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-54-license-expression.md
@@ -2,7 +2,7 @@
 
 It MUST be tested that the license expression is valid.
 
-> To implement this test, it it deemed sufficient to check for the ABNF defined in annex B of [cite](#SPDX301) and
+> To implement this test, it is deemed sufficient to check for the ABNF defined in annex B of [cite](#SPDX301) and
 > the restriction on the `DocumentRef` part given in [sec](#document-property---license-expression).
 > Although a match against the SPDX License List (`license-id`) or a specific `LicenseRef` or `AdditionalRef` list
 > is not in scope for this test, it checks all other constraints given in the ABNF.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
@@ -1,7 +1,7 @@
 ### Extension Tests{#mandatory-tests--extension-tests}
 
 This subsubsection structures the mandatory tests for extensions.
-Each of the following tests SHOULD be treated as they where listed similar to the other tests.
+Each of the following tests SHOULD be treated as they were listed similar to the other tests.
 
 > An application MAY group these tests when providing the additional function to only run one or more selected tests.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in SKU
 
-For each stock keeping unit it MUST be tested that the it does not contain multiple unescaped stars.
+For each stock keeping unit it MUST be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a model number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-profile-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-profile-tests.md
@@ -2,7 +2,7 @@
 
 This subsubsection structures the recommended tests for the profiles. Not all tests apply for all profiles.
 Tests SHOULD be skipped if the document category does not match the one given in the test.
-Each of the following tests SHOULD be treated as they where listed similar to the other tests.
+Each of the following tests SHOULD be treated as they were listed similar to the other tests.
 
 #### Missing Fixed Product
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-53-matching-text-for-registered-id-system.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-53-matching-text-for-registered-id-system.md
@@ -1,6 +1,6 @@
 ### Matching Text for Registered ID System
 
-For each item in `/vulnerabilities[]/ids` that the value of a registered vulnerability ID system as `system_name`,
+For each item in `/vulnerabilities[]/ids` that has the value of a registered vulnerability ID system as `system_name`,
 it MUST be tested that the `text` in the CSAF document matches the `text_pattern` given by the
 "Registry for Vulnerability ID Systems for CSAF" (RVISC).
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
@@ -1,7 +1,7 @@
 ### Extension Tests{#recommended-tests--extension-tests}
 
 This subsubsection structures the recommended tests for extensions.
-Each of the following tests SHOULD be treated as they where listed similar to the other tests.
+Each of the following tests SHOULD be treated as they were listed similar to the other tests.
 
 > An application MAY group these tests when providing the additional function to only run one or more selected tests.
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-20-use-of-unregistered-id-system.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-20-use-of-unregistered-id-system.md
@@ -1,6 +1,6 @@
 ### Use of Unregistered ID System
 
-For each item in `/vulnerabilities[]/ids` it MUST be tested that the the value of `system_name` belongs to a
+For each item in `/vulnerabilities[]/ids` it MUST be tested that the value of `system_name` belongs to a
 registered vulnerability ID system in RVISC.
 
 > The RVISC is available at [cite](#RVISC).

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
@@ -1,7 +1,7 @@
 ### Extension Tests{#informative-tests--extension-tests}
 
 This subsubsection structures the informative tests for extensions.
-Each of the following tests SHOULD be treated as they where listed similar to the other tests.
+Each of the following tests SHOULD be treated as they were listed similar to the other tests.
 
 > An application MAY group these tests when providing the additional function to only run one or more selected tests.
 


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1405
  - correct spelling mistake
  - add missing word
- resolves https://github.com/oasis-tcs/csaf/issues/1356
  - correct various spelling mistakes
  - correct formatting
- resolves https://github.com/oasis-tcs/csaf/issues/1357
  - add missing paths from `/vulnerabilities[]/metrics[]/content` in `epss` and `ssvc_v2`