### PR TITLE
Fixed #1421 - simplified revision history section

### DIFF
--- a/csaf_2.1/prose/edit/src/revision-history.md
+++ b/csaf_2.1/prose/edit/src/revision-history.md
@@ -1,31 +1,6 @@
 # Appendix B. Revision History
 
-\columns=25%,10%,40%,
+Revision tracking is publicly available in the version control system at
+<https://github.com/oasis-tcs/csaf/commits/master>.
 
-| Revision                 | Date       | Editor                          | Changes Made                                |
-|:-------------------------|:-----------|:--------------------------------|:--------------------------------------------|
-| csaf-v2.1-wd20240124-dev | 2024-01-24 | Stefan Hagen and Thomas Schmidt | Preparing initial Editor Revision           |
-| csaf-v2.1-wd20240228-dev | 2024-02-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240327-dev | 2024-03-27 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240424-dev | 2024-04-24 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240529-dev | 2024-05-29 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240626-dev | 2024-06-26 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240731-dev | 2024-07-31 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20240828-dev | 2024-08-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20241030-dev | 2024-10-30 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20241127-dev | 2024-11-27 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250129-dev | 2025-01-29 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250226-dev | 2025-02-26 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250326-dev | 2025-03-26 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250430-dev | 2025-04-30 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250528-dev | 2025-05-28 | Stefan Hagen and Thomas Schmidt | Next Editor Revision                        |
-| csaf-v2.1-wd20250827-dev | 2025-08-27 | Stefan Hagen and Thomas Schmidt | Editor Revision containing CSD01PR feedback |
-| csaf-v2.1-wd20250910-dev | 2025-09-10 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20251029-dev | 2025-10-29 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20251126-dev | 2025-11-26 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20251217-dev | 2025-12-17 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20260128-dev | 2026-01-28 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20260225-dev | 2026-02-25 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-| csaf-v2.1-wd20260429-dev | 2026-04-29 | Stefan Hagen and Thomas Schmidt | Editor Revision for CSD02                   |
-
--------
+---


### PR DESCRIPTION
Recent OASIS standards offer diverse statements and pointers to a revision history via GitHub links.

I went ahead and implemented my proposal from https://github.com/oasis-tcs/csaf/issues/1421#issuecomment-4338819456

I also reduced the funny horizontal line indicator to only three dashes because that is what came out of publication of another TC's CSD at https://docs.oasis-open.org/dps/prov-meta/v1.0/csd01/prov-meta-v1.0-csd01.md