### PR TITLE
Comment Resolution CSD02PR: #1361

### DIFF
--- a/csaf_2.1/json_schema/csaf.json
+++ b/csaf_2.1/json_schema/csaf.json
@@ -1287,6 +1287,12 @@
                 "text"
               ],
               "properties": {
+                "group_ids": {
+                  "$ref": "#/$defs/product_groups_t"
+                },
+                "product_ids": {
+                  "$ref": "#/$defs/products_t"
+                },
                 "system_name": {
                   "title": "System name",
                   "description": "Indicates the name of the vulnerability tracking or numbering system.",

--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -121,6 +121,8 @@ An array SHOULD NOT have more than:
   - `$.vulnerabilities[*].flags`
   - `$.vulnerabilities[*].flags[*].group_ids`
   - `$.vulnerabilities[*].flags[*].product_ids`
+  - `$.vulnerabilities[*].ids[*].group_ids`
+  - `$.vulnerabilities[*].ids[*].product_ids`
   - `$.vulnerabilities[*].involvements[*].group_ids`
   - `$.vulnerabilities[*].involvements[*].product_ids`
   - `$.vulnerabilities[*].metrics`
@@ -215,6 +217,8 @@ A string SHOULD NOT have a length greater than:
   - `$.vulnerabilities[*].flags[*].group_ids[*]`
   - `$.vulnerabilities[*].flags[*].product_ids[*]`
   - `$.vulnerabilities[*].first_known_exploitation_dates[*].group_ids[*]`
+  - `$.vulnerabilities[*].ids[*].group_ids[*]`
+  - `$.vulnerabilities[*].ids[*].product_ids[*]`
   - `$.vulnerabilities[*].ids[*].system_name`
   - `$.vulnerabilities[*].ids[*].text`
   - `$.vulnerabilities[*].involvements[*].contact`

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
@@ -317,6 +317,7 @@ tracking IDs for the vulnerability (if such information exists).
 
 Every ID item of value type `object` with the two mandatory properties System Name (`system_name`) and Text (`text`) contains a single
 unique label or tracking ID for the vulnerability.
+In addition, any ID item MAY expose the optional properties Group IDs (`group_ids`) and Product IDs (`product_ids`).
 
 ```yaml <!--json-path($..vulnerabilities..ids..properties)-->
 <csaf-instance>:
@@ -326,10 +327,20 @@ unique label or tracking ID for the vulnerability.
     # ...
     ids:
     - # <id-instance>:
+      group_ids: $defs.product_groups_t
+      product_ids: $defs.products_t
       system_name: String
       text: String
     # ...
 ```
+
+Group IDs (`group_ids`) are of value type Product Groups (`product_groups_t`) and contain a list of Product Groups the current ID item applies to.
+
+> This can be used to provide the information that this specific ID applies only to a specific set of product groups.
+
+Product IDs (`product_ids`) are of value type Products (`products_t`) and contain a list of Products the current ID item applies to.
+
+> This can be used to provide the information that this specific ID applies only to a specific set of products.
 
 System name (`system_name`) of value type `string` with `1` or more characters indicates the name of the vulnerability tracking or numbering system.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
@@ -13,6 +13,7 @@ The relevant paths for this test are:
   $.product_tree.product_paths[*].subpaths[*].next_product_reference
   $.vulnerabilities[*].first_known_exploitation_dates[*].product_ids[*]
   $.vulnerabilities[*].flags[*].product_ids[*]
+  $.vulnerabilities[*].ids[*].product_ids[*]
   $.vulnerabilities[*].involvements[*].product_ids[*]
   $.vulnerabilities[*].metrics[*].products[*]
   $.vulnerabilities[*].notes[*].product_ids[*]

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -10,6 +10,7 @@ The relevant paths for this test are:
   $.document.notes[*].group_ids[*]
   $.vulnerabilities[*].first_known_exploitation_dates[*].group_ids[*]
   $.vulnerabilities[*].flags[*].group_ids[*]
+  $.vulnerabilities[*].ids[*].group_ids[*]
   $.vulnerabilities[*].involvements[*].group_ids[*]
   $.vulnerabilities[*].notes[*].group_ids[*]
   $.vulnerabilities[*].remediations[*].group_ids[*]

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-profile-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-profile-tests.md
@@ -236,6 +236,13 @@ The relevant paths for this test are:
 #### Vulnerability ID
 
 For each item in `$.vulnerabilities` it MUST be tested that at least one of the elements `cve` or `ids` is present.
+If no `cve` is present and all items in `ids` contain `group_ids` or `product_ids`,
+it MUST be tested that each product mentioned in `product_status[*][*]` is assigned at least one item in `ids`.
+This is independent from whether the product is referenced directly or indirectly through a product group.
+
+> Without this rule, a product could be mentioned in a VEX that has no clear reference to a vulnerability identifier.
+> If a CVE is present, or at least one item in `ids` without `group_ids` and `product_ids`,
+> the corresponding vulnerability identifier applies to the vulnerability itself and therefore to all products mention in this vulnerability.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "notes": [
+      {
+        "category": "description",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "text": "Product A is a software to plan and simulate bridges. It is mainly used during the design and construction phase. However, it can be extended to provide the functionality of a digital twin.",
+        "title": "Product description"
+      }
+    ],
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Missing Definition of Product ID (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-01-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.0.0",
+                "product": {
+                  "name": "Example Company Product A 1.0.0",
+                  "product_id": "CSAFPID-9080700"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.1.0",
+                "product": {
+                  "name": "Example Company Product A 1.1.0",
+                  "product_id": "CSAFPID-9080701"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.2.0",
+                "product": {
+                  "name": "Example Company Product A 1.2.0",
+                  "product_id": "CSAFPID-9080702"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.0.0",
+                "product": {
+                  "name": "Example Company Product A 2.0.0",
+                  "product_id": "CSAFPID-9080703"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "3.0.0",
+                "product": {
+                  "name": "Example Company Product A 3.0.0",
+                  "product_id": "CSAFPID-9080704"
+                }
+              }
+            ],
+            "category": "product_name",
+            "name": "Product A"
+          },
+          {
+            "category": "product_name",
+            "name": "Extension I",
+            "product": {
+              "name": "Example Company Extension I",
+              "product_id": "CSAFPID-9080705"
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "product_ids": [
+            "CSAFPID-9080700",
+            "CSAFPID-9080701",
+            "CSAFPID-9080704"
+          ],
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703",
+            "CSAFPID-9080704"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080705"
+          ],
+          "system_name": "https://example.org",
+          "text": "some-example-id"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "notes": [
+      {
+        "category": "description",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "text": "Product A is a software to plan and simulate bridges. It is mainly used during the design and construction phase. However, it can be extended to provide the functionality of a digital twin.",
+        "title": "Product description"
+      }
+    ],
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Missing Definition of Product ID (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-01-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.0.0",
+                "product": {
+                  "name": "Example Company Product A 1.0.0",
+                  "product_id": "CSAFPID-9080700"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.1.0",
+                "product": {
+                  "name": "Example Company Product A 1.1.0",
+                  "product_id": "CSAFPID-9080701"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.2.0",
+                "product": {
+                  "name": "Example Company Product A 1.2.0",
+                  "product_id": "CSAFPID-9080702"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.0.0",
+                "product": {
+                  "name": "Example Company Product A 2.0.0",
+                  "product_id": "CSAFPID-9080703"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "3.0.0",
+                "product": {
+                  "name": "Example Company Product A 3.0.0",
+                  "product_id": "CSAFPID-9080704"
+                }
+              }
+            ],
+            "category": "product_name",
+            "name": "Product A"
+          },
+          {
+            "category": "product_name",
+            "name": "Extension I",
+            "product": {
+              "name": "Example Company Extension I",
+              "product_id": "CSAFPID-9080705"
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "product_ids": [
+            "CSAFPID-9080710",
+            "CSAFPID-9080711",
+            "CSAFPID-9080704"
+          ],
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080712",
+            "CSAFPID-9080703",
+            "CSAFPID-9080714"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080715"
+          ],
+          "system_name": "https://example.org",
+          "text": "some-example-id"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "notes": [
+      {
+        "category": "description",
+        "group_ids": [
+          "CSAFGID-1020304"
+        ],
+        "text": "Product A is a software to plan and simulate IACS. It is mainly used during the design and construction phase. However, it can be extended to provide the functionality of a digital twin.",
+        "title": "Product description"
+      }
+    ],
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Missing Definition of Product Group ID (failing example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-04-03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "branches": [
+                  {
+                    "category": "product_version",
+                    "name": "1.0.0",
+                    "product": {
+                      "name": "Example Company Product A 1.0.0",
+                      "product_id": "CSAFPID-9080700"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "1.1.0",
+                    "product": {
+                      "name": "Example Company Product A 1.1.0",
+                      "product_id": "CSAFPID-9080701"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "1.2.0",
+                    "product": {
+                      "name": "Example Company Product A 1.2.0",
+                      "product_id": "CSAFPID-9080702"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "2.0.0",
+                    "product": {
+                      "name": "Example Company Product A 2.0.0",
+                      "product_id": "CSAFPID-9080703"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "3.0.0",
+                    "product": {
+                      "name": "Example Company Product A 3.0.0",
+                      "product_id": "CSAFPID-9080704"
+                    }
+                  }
+                ],
+                "category": "product_name",
+                "name": "Product A"
+              }
+            ],
+            "category": "product_family",
+            "name": "IACS Software"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ],
+    "product_groups": [
+      {
+        "group_id": "CSAFGID-1020301",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ],
+        "summary": "Products with reliable exploits."
+      },
+      {
+        "group_id": "CSAFGID-1020302",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702"
+        ],
+        "summary": "Affected products."
+      },
+      {
+        "group_id": "CSAFGID-1020303",
+        "product_ids": [
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "summary": "Products known not affected."
+      },
+      {
+        "group_id": "CSAFGID-1020304",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "summary": "All versions of Product A (at the time of publication)."
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "group_ids": [
+            "CSAFGID-1020314"
+          ],
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020301",
+            "CSAFGID-1020302",
+            "CSAFGID-1020313"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "group_ids": [
+            "CSAFPID-9080700"
+          ],
+          "system_name": "https://example.org",
+          "text": "some-example-id"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "notes": [
+      {
+        "category": "description",
+        "group_ids": [
+          "CSAFGID-1020304"
+        ],
+        "text": "Product A is a software to plan and simulate IACS. It is mainly used during the design and construction phase. However, it can be extended to provide the functionality of a digital twin.",
+        "title": "Product description"
+      }
+    ],
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Missing Definition of Product Group ID (valid example 3)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-04-13",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "branches": [
+                  {
+                    "category": "product_version",
+                    "name": "1.0.0",
+                    "product": {
+                      "name": "Example Company Product A 1.0.0",
+                      "product_id": "CSAFPID-9080700"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "1.1.0",
+                    "product": {
+                      "name": "Example Company Product A 1.1.0",
+                      "product_id": "CSAFPID-9080701"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "1.2.0",
+                    "product": {
+                      "name": "Example Company Product A 1.2.0",
+                      "product_id": "CSAFPID-9080702"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "2.0.0",
+                    "product": {
+                      "name": "Example Company Product A 2.0.0",
+                      "product_id": "CSAFPID-9080703"
+                    }
+                  },
+                  {
+                    "category": "product_version",
+                    "name": "3.0.0",
+                    "product": {
+                      "name": "Example Company Product A 3.0.0",
+                      "product_id": "CSAFPID-9080704"
+                    }
+                  }
+                ],
+                "category": "product_name",
+                "name": "Product A"
+              }
+            ],
+            "category": "product_family",
+            "name": "IACS Software"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ],
+    "product_groups": [
+      {
+        "group_id": "CSAFGID-1020301",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ],
+        "summary": "Products with reliable exploits."
+      },
+      {
+        "group_id": "CSAFGID-1020302",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702"
+        ],
+        "summary": "Affected products."
+      },
+      {
+        "group_id": "CSAFGID-1020303",
+        "product_ids": [
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "summary": "Products known not affected."
+      },
+      {
+        "group_id": "CSAFGID-1020304",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703",
+          "CSAFPID-9080704"
+        ],
+        "summary": "All versions of Product A (at the time of publication)."
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "group_ids": [
+            "CSAFGID-1020304"
+          ],
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020301",
+            "CSAFGID-1020302",
+            "CSAFGID-1020303"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020303"
+          ],
+          "system_name": "https://example.org",
+          "text": "some-example-id"
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Vulnerability ID (failing example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-08-02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
+      },
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-9080701"
+      },
+      {
+        "name": "Product C",
+        "product_id": "CSAFPID-9080702"
+      },
+      {
+        "name": "Product D",
+        "product_id": "CSAFPID-9080703"
+      }
+    ],
+    "product_groups": [
+      {
+        "group_id": "CSAFGID-1020300",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702"
+          ]
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "system_name": "https://example.com",
+          "text": "a-specific-example-id-group-based"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://example.org",
+          "text": "a-specific-example-id-product-based"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0145, and CVE-2017-0148.",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703"
+          ]
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "system_name": "https://example.com",
+          "text": "a-specific-example-id-group-based"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://example.org",
+          "text": "a-specific-example-id-product-based"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to obtain sensitive information from process memory via a crafted packets, aka \"Windows SMB Information Disclosure Vulnerability.\"",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Vulnerability ID (valid example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-08-11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
+      },
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-9080701"
+      },
+      {
+        "name": "Product C",
+        "product_id": "CSAFPID-9080702"
+      }
+    ],
+    "product_groups": [
+      {
+        "group_id": "CSAFGID-1020300",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2017-0145",
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "OASIS CSAF TC",
+      "namespace": "https://csaf.io"
+    },
+    "title": "Mandatory Test: Vulnerability ID (valid example 2)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-08-12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-9080700"
+      },
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-9080701"
+      },
+      {
+        "name": "Product C",
+        "product_id": "CSAFPID-9080702"
+      },
+      {
+        "name": "Product D",
+        "product_id": "CSAFPID-9080703"
+      }
+    ],
+    "product_groups": [
+      {
+        "group_id": "CSAFGID-1020300",
+        "product_ids": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701"
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1361"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702"
+          ]
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "system_name": "https://example.com",
+          "text": "a-specific-example-id-group-based"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://example.org",
+          "text": "a-specific-example-id-product-based"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0145, and CVE-2017-0148.",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703"
+          ]
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703"
+          ],
+          "system_name": "https://example.com",
+          "text": "some-example-id"
+        },
+        {
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "system_name": "https://example.com",
+          "text": "a-specific-example-id-group-based"
+        },
+        {
+          "product_ids": [
+            "CSAFPID-9080702"
+          ],
+          "system_name": "https://example.org",
+          "text": "a-specific-example-id-product-based"
+        }
+      ],
+      "notes": [
+        {
+          "category": "summary",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to obtain sensitive information from process memory via a crafted packets, aka \"Windows SMB Information Disclosure Vulnerability.\"",
+          "title": "Vulnerability summary"
+        }
+      ],
+      "product_status": {
+        "known_not_affected": [
+          "CSAFPID-9080700",
+          "CSAFPID-9080701",
+          "CSAFPID-9080702",
+          "CSAFPID-9080703"
+        ]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "The vulnerable code is not present in these products.",
+          "group_ids": [
+            "CSAFGID-1020300"
+          ],
+          "product_ids": [
+            "CSAFPID-9080702",
+            "CSAFPID-9080703"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1003,6 +1003,20 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-01.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.json",
+          "valid": true
         }
       ]
     },

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -13,6 +13,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json",
+          "valid": false
         }
       ],
       "valid": [
@@ -22,6 +26,10 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json",
           "valid": true
         }
       ]
@@ -75,6 +83,10 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-02.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.json",
+          "valid": false
         }
       ],
       "valid": [
@@ -84,6 +96,10 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-12.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.json",
           "valid": true
         }
       ]


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1361
- add option to provide `group_ids` and `product_ids` for in `$.vulnerabilities[*].ids[*]` in schema
- adapt prose
- update guidance on size to reflect new paths
- add JSONPath to 6.1.1 and 6.1.4
- add invalid examples
- add valid examples
- add JSONPath to 6.1.27.8
- add clarification about product / group specific `ids`
- add invalid example
- add valid examples