### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-29-usage-of-nil-uuid.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-29-usage-of-nil-uuid.md
@@ -13,8 +13,8 @@ The relevant path for this test is:
 ```
     "distribution": {
       "sharing_group": {
-        "id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-        "name": "Public"
+        "id": "00000000-0000-0000-0000-000000000000",
+        "name": "No sharing allowed"
       },
       // ...
     },


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1376
- correct typo (Max UUID instead of Nil UUID)