### PR TITLE
Test results (for Editor Revision 2026-05-27)

### DIFF
--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json
@@ -112,8 +112,8 @@
       "ids": [
         {
           "product_ids": [
-            "CSAFPID-9080700",
-            "CSAFPID-9080701",
+            "CSAFPID-9080710",
+            "CSAFPID-9080711",
             "CSAFPID-9080704"
           ],
           "system_name": "https://github.com/oasis-tcs/csaf",
@@ -121,16 +121,16 @@
         },
         {
           "product_ids": [
-            "CSAFPID-9080702",
+            "CSAFPID-9080712",
             "CSAFPID-9080703",
-            "CSAFPID-9080704"
+            "CSAFPID-9080714"
           ],
           "system_name": "https://example.com",
           "text": "some-example-id"
         },
         {
           "product_ids": [
-            "CSAFPID-9080705"
+            "CSAFPID-9080715"
           ],
           "system_name": "https://example.org",
           "text": "some-example-id"

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.result.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": false,
+  "primary_result": {
+    "errors": [
+      {
+        "instance_path": "/vulnerabilities/0/ids/0/product_ids/0",
+        "message": "definition of product id missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/0/product_ids/1",
+        "message": "definition of product id missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/1/product_ids/0",
+        "message": "definition of product id missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/1/product_ids/2",
+        "message": "definition of product id missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/2/product_ids/0",
+        "message": "definition of product id missing"
+      }
+    ],
+    "id": "6.1.1",
+    "passed": false
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.result.json
@@ -5,23 +5,23 @@
     "errors": [
       {
         "instance_path": "/vulnerabilities/0/ids/0/product_ids/0",
-        "message": "definition of product id missing"
+        "message": "definition of product id `CSAFPID-9080710` missing"
       },
       {
         "instance_path": "/vulnerabilities/0/ids/0/product_ids/1",
-        "message": "definition of product id missing"
+        "message": "definition of product id `CSAFPID-9080711` missing"
       },
       {
         "instance_path": "/vulnerabilities/0/ids/1/product_ids/0",
-        "message": "definition of product id missing"
+        "message": "definition of product id `CSAFPID-9080712` missing"
       },
       {
         "instance_path": "/vulnerabilities/0/ids/1/product_ids/2",
-        "message": "definition of product id missing"
+        "message": "definition of product id `CSAFPID-9080714` missing"
       },
       {
         "instance_path": "/vulnerabilities/0/ids/2/product_ids/0",
-        "message": "definition of product id missing"
+        "message": "definition of product id `CSAFPID-9080715` missing"
       }
     ],
     "id": "6.1.1",

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json
@@ -112,8 +112,8 @@
       "ids": [
         {
           "product_ids": [
-            "CSAFPID-9080710",
-            "CSAFPID-9080711",
+            "CSAFPID-9080700",
+            "CSAFPID-9080701",
             "CSAFPID-9080704"
           ],
           "system_name": "https://github.com/oasis-tcs/csaf",
@@ -121,16 +121,16 @@
         },
         {
           "product_ids": [
-            "CSAFPID-9080712",
+            "CSAFPID-9080702",
             "CSAFPID-9080703",
-            "CSAFPID-9080714"
+            "CSAFPID-9080704"
           ],
           "system_name": "https://example.com",
           "text": "some-example-id"
         },
         {
           "product_ids": [
-            "CSAFPID-9080715"
+            "CSAFPID-9080705"
           ],
           "system_name": "https://example.org",
           "text": "some-example-id"

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.result.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": true,
+  "primary_result": {
+    "id": "6.1.1",
+    "passed": true
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.result.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": false,
+  "primary_result": {
+    "errors": [
+      {
+        "instance_path": "/vulnerabilities/0/ids/0/group_ids/0",
+        "message": "definition of group id `CSAFGID-1020314` missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/1/group_ids/2",
+        "message": "definition of group id `CSAFGID-1020313` missing"
+      },
+      {
+        "instance_path": "/vulnerabilities/0/ids/2/group_ids/0",
+        "message": "definition of group id `CSAFPID-9080700` missing"
+      }
+    ],
+    "id": "6.1.4",
+    "passed": false
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.result.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": true,
+  "primary_result": {
+    "id": "6.1.4",
+    "passed": true
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.result.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": false,
+  "primary_result": {
+    "errors": [
+      {
+        "instance_path": "/vulnerabilities/0/product_status/known_not_affected/2",
+        "message": "product id `CSAFPID-9080702` does not have a vulnerability id assigned nor a CVE or general vulnerability id is given"
+      },
+      {
+        "instance_path": "/vulnerabilities/1/product_status/known_not_affected/3",
+        "message": "product id `CSAFPID-9080703` does not have a vulnerability id assigned nor a CVE or general vulnerability id is given"
+      },
+      {
+        "instance_path": "/vulnerabilities/2/product_status/known_not_affected/3",
+        "message": "product id `CSAFPID-9080703` does not have a vulnerability id assigned nor a CVE or general vulnerability id is given"
+      }
+    ],
+    "id": "6.1.27.8",
+    "passed": false
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.result.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": true,
+  "primary_result": {
+    "id": "6.1.27.8",
+    "passed": true
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.result.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": true,
+  "primary_result": {
+    "id": "6.1.27.8",
+    "passed": true
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -88,6 +88,7 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-03.result.json",
           "valid": false
         }
       ],
@@ -102,6 +103,7 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.result.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -16,6 +16,7 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-03.result.json",
           "valid": false
         }
       ],
@@ -30,6 +31,7 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.result.json",
           "valid": true
         }
       ]

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1010,16 +1010,19 @@
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.result.json",
           "valid": false
         }
       ],
       "valid": [
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-11.result.json",
           "valid": true
         },
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-12.result.json",
           "valid": true
         }
       ]


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1361, https://github.com/oasis-tcs/csaf/issues/820
- correct issue with switched content of test files (valid was invalid and vice versa)
- add result files for newly added test files to 6.1.1
- correct messages to align them
- add result files for newly added test files to 6.1.4
- add result files for newly added test files to 6.1.27.8