### PR TITLE
Language fixes

### DIFF
--- a/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
+++ b/csaf_2.1/prose/edit/src/introduction-03-normative-references.md
@@ -30,6 +30,12 @@ RFC3339
 RFC4180
 :    Shafranovich, Y., "Common Format and MIME Type for Comma-Separated Values (CSV) Files", RFC 4180, DOI 10.17487/RFC4180, October 2005, <https://www.rfc-editor.org/info/rfc4180>.
 
+RFC4647
+:    Phillips, A., Ed. and M. Davis, Ed., "Matching of Language Tags", BCP 47, RFC 4647, DOI 10.17487/RFC4647, September 2006, <https://www.rfc-editor.org/info/rfc4647/>.
+
+RFC5646
+:    Phillips, A., Ed. and M. Davis, Ed., "Tags for Identifying Languages", BCP 47, RFC 5646, DOI 10.17487/RFC5646, September 2009, <https://www.rfc-editor.org/info/rfc5646/>.
+
 RFC7230
 :    Roy T. Fielding and Julian Reschke, "Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing", RFC 7230, DOI 10.17487/RFC7230, June 2014, <https://www.rfc-editor.org/info/rfc7230>.
 

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-05-language.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-05-language.md
@@ -9,7 +9,7 @@ Language type (`lang_t`) has value type `string` with `pattern` (regular express
 The value identifies a language, corresponding to IETF BCP 47 / RFC 5646.
 See IETF language registry: <https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry>
 
-> The pattern given above is derived from the ABNF given in Figure 1 in [cite](#RFC5646).
+> The pattern given above is derived from the ABNF depicted in Figure 1 in [cite](#RFC5646).
 > CSAF skips those grandfathered language tags that are deprecated at the time of writing the specification.
 > Even though the private use language tags are supported they should not be used to ensure readability across the ecosystem.
 > It is recommended to follow the conventions for the capitalization of the subtags even though it is not mandatory as most users are used to that.

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-05-language.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-05-language.md
@@ -9,6 +9,7 @@ Language type (`lang_t`) has value type `string` with `pattern` (regular express
 The value identifies a language, corresponding to IETF BCP 47 / RFC 5646.
 See IETF language registry: <https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry>
 
+> The pattern given above is derived from the ABNF given in Figure 1 in [cite](#RFC5646).
 > CSAF skips those grandfathered language tags that are deprecated at the time of writing the specification.
 > Even though the private use language tags are supported they should not be used to ensure readability across the ecosystem.
 > It is recommended to follow the conventions for the capitalization of the subtags even though it is not mandatory as most users are used to that.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -509,10 +509,10 @@ a translation then the value of this property describes from which language this
 The property MUST be present for any CSAF document with the value `translator` in `$.document.publisher.category`.
 The property SHALL NOT be present if the document was not translated.
 
-> If an issuing party publishes a CSAF document with the same content in more than one language,
-> one of these documents SHOULD be deemed the "original", the other ones SHOULD be considered translations from the "original".
-> The issuing party can retain its original publisher information including the `category`.
-> However, other rules defined in the conformance clause "CSAF translator" SHOULD be applied.
+If an issuing party publishes a CSAF document with the same content in more than one language,
+one of these documents SHOULD be deemed the "original", the other ones SHOULD be considered translations from the "original".
+The issuing party can retain its original publisher information including the `category`.
+However, other rules defined in the conformance clause "CSAF translator" SHOULD be applied.
 
 #### Document Property - Title
 


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1349
- add comment that pattern is derived from ABNF in RFC 5646
- add references to RFCs from BCP 47
- correct: normative statement was hidden in informative comment