### PR TITLE
Involvements document level

### DIFF
--- a/.github/workflows/csaf_2.1_mandatory-tests.yml
+++ b/.github/workflows/csaf_2.1_mandatory-tests.yml
@@ -25,7 +25,7 @@ jobs:
         cd csaf-validator-lib && npm ci --prod
     - name: Run mandatory tests on examples
       run:  |
-        for i in `ls -1 ../csaf/csaf_2.1/examples/csaf/*.json | grep -Ev 'rhsa-2021_5186.json|rhsa-2021_5217|rhsa-2022_0011.json'`
+        for i in `ls -1 ../csaf/csaf_2.1/examples/csaf/*.json | grep -Ev 'rhsa-2021_5186.json|rhsa-2021_5217|rhsa-2022_0011.json|certcc-vu_834248.json'`
         do
           printf "%s%s\n" "Starting test of " $i
           ../csaf-validator-lib/scripts/runTest.js -f $i -t base -c 2.1

--- a/csaf_2.1/examples/csaf/certcc-vu_834248.json
+++ b/csaf_2.1/examples/csaf/certcc-vu_834248.json
@@ -1,0 +1,170 @@
+{
+    "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+    "document": {
+        "title": "A buffer overflow in Product Acme makes it expose credentials of all users directly",
+        "acknowledgments": [
+            {
+                "names": [
+                    "John Doe "
+                ],
+                "organization": "Hacking Enterprise"
+            }
+        ],
+        "category": "CERT/CC Vulnerability Request Form",
+        "csaf_version": "2.1",
+        "distribution": {
+            "tlp": {
+                "label": "AMBER",
+                "url": "https://www.first.org/tlp/"
+            }
+        },
+        "involvements": [
+            {
+                "party": "discoverer",
+                "summary": "Disclosure Plans\n",
+                "status": "open"
+            },
+            {
+                "date": "2026-04-08T00:00:00.000Z",
+                "party": "discoverer",
+                "status": "contact_attempted",
+                "summary": "Summary of previous vendor communications "
+            }
+        ],
+        "publisher": {
+            "category": "discoverer",
+            "contact_details": "Researcher Contact",
+            "issuing_authority": "Hacking Enterprise",
+            "name": "John Doe",
+            "namespace": "mailto:johndoe@example.com"
+        },
+        "tracking": {
+            "current_release_date": "2026-06-30T16:03:15.790Z",
+            "generator": {
+                "date": "2026-06-30T16:03:15.790Z",
+                "engine": {
+                    "name": "VINCE",
+                    "version": "2.6.4"
+                }
+            },
+            "id": "CERTCC-VU#834248",
+            "initial_release_date": "2025-11-03T17:02:39.000Z",
+            "revision_history": [
+                {
+                    "date": "2025-11-03T17:02:39+00:00",
+                    "number": "1.20251103170239.1",
+                    "summary": "Released on 2025-11-03T17:02:39+00:00"
+                }
+            ],
+            "status": "final",
+            "version": "1.20251103170239.1"
+        }
+    },
+    "product_tree": {
+        "branches": [
+            {
+                "branches": [
+                    {
+                        "category": "product_version",
+                        "name": "1.0.0",
+                        "product": {
+                            "name": "Acme IDManager",
+                            "product_id": "CSAFPID-0001"
+                        }
+                    }
+                ],
+                "category": "vendor",
+                "name": "Acme Inc."
+            }
+        ]
+    },
+    "vulnerabilities": [
+        {
+            "metrics": [
+                {
+                    "content": {
+                        "ssvc_v2": {
+                            "schemaVersion": "2.0.0",
+                            "selections": [
+                                {
+                                    "key": "E",
+                                    "name": "Exploitation",
+                                    "namespace": "ssvc",
+                                    "values": [
+                                        {
+                                            "key": "A",
+                                            "name": "Active"
+                                        }
+                                    ],
+                                    "version": "1.1.0"
+                                }
+                            ],
+                            "timestamp": "2024-01-24T10:00:00.000Z"
+                        }
+                    },
+                    "products": [
+                        "CSAFPID-0001"
+                    ]
+                }
+            ],
+            "notes": [
+                {
+                    "category": "description",
+                    "text": "A buffer overflow in Product Acme makes it expose credentials of all users directly",
+                    "title": "Vulnerability Description"
+                },
+                {
+                    "audience": "coordinator",
+                    "category": "other",
+                    "text": "How this was discovered",
+                    "title": "Vulnerability Discovery Method"
+                }
+            ],
+            "product_status": {
+                "under_investigation": [
+                    "CSAFPID-0001"
+                ]
+            },
+            "references": [
+                {
+                    "category": "external",
+                    "summary": "Publicly Known",
+                    "url": "https://example.com/public/"
+                },
+                {
+                    "category": "external",
+                    "summary": "Publicy Exploited References",
+                    "url": "https://example.com/attack"
+                }
+            ],
+            "threats": [
+                {
+                    "category": "impact",
+                    "details": "Impact of the Vulnerability "
+                },
+                {
+                    "category": "exploit_status",
+                    "details": "Exploitation Method"
+                }
+            ],
+            "title": "A buffer overflow in Product Acme makes it expose credentials of all users directly"
+        }
+    ],
+    "x_extensions": [
+        {
+            "$schema": "https://democert.org/cvd/csaf_2.1_root_extension_1.0.1.json",
+            "category": "high_value",
+            "critical": false,
+            "content": {
+                "ai/ml": false,
+                "ics_impact": false,
+                "share_contact_with_vendor": true,
+                "private_comments": "I want to report more things later",
+                "contact_pgp_url": "https://example.com/johndoe.key",
+                "Related_IDs": [
+                    "CVE-1900-0000"
+                ]
+            }
+        }
+    ]
+}

--- a/csaf_2.1/examples/csaf/certcc-vu_834248.json
+++ b/csaf_2.1/examples/csaf/certcc-vu_834248.json
@@ -149,22 +149,5 @@
             ],
             "title": "A buffer overflow in Product Acme makes it expose credentials of all users directly"
         }
-    ],
-    "x_extensions": [
-        {
-            "$schema": "https://democert.org/cvd/csaf_2.1_root_extension_1.0.1.json",
-            "category": "high_value",
-            "critical": false,
-            "content": {
-                "ai/ml": false,
-                "ics_impact": false,
-                "share_contact_with_vendor": true,
-                "private_comments": "I want to report more things later",
-                "contact_pgp_url": "https://example.com/johndoe.key",
-                "Related_IDs": [
-                    "CVE-1900-0000"
-                ]
-            }
-        }
     ]
 }

--- a/csaf_2.1/json_schema/csaf.json
+++ b/csaf_2.1/json_schema/csaf.json
@@ -557,6 +557,74 @@
         "1.4.3",
         "2.40.0+21AF26D3"
       ]
+    },
+    "involvements_t": {
+      "title": "List of involvements",
+      "description": "Contains a list of involvements.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "title": "Involvement",
+        "description": "Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process.",
+        "type": "object",
+        "required": [
+          "party",
+          "status"
+        ],
+        "properties": {
+          "contact": {
+            "title": "Party contact information",
+            "description": "Contains the contact information of the party that was used in this state.",
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "title": "Date of involvement",
+            "description": "Holds the date and time of the involvement entry.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "group_ids": {
+            "$ref": "#/$defs/product_groups_t"
+          },
+          "party": {
+            "title": "Party category",
+            "description": "Defines the category of the involved party.",
+            "type": "string",
+            "enum": [
+              "coordinator",
+              "discoverer",
+              "other",
+              "user",
+              "vendor"
+            ]
+          },
+          "product_ids": {
+            "$ref": "#/$defs/products_t"
+          },
+          "status": {
+            "title": "Party status",
+            "description": "Defines contact status of the involved party.",
+            "type": "string",
+            "enum": [
+              "completed",
+              "contact_attempted",
+              "disputed",
+              "in_progress",
+              "not_contacted",
+              "open"
+            ]
+          },
+          "summary": {
+            "title": "Summary of the involvement",
+            "description": "Contains additional context regarding what is going on.",
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
     }
   },
   "required": [
@@ -1000,6 +1068,9 @@
           "title": "Document-level Extensions",
           "description": "Contains a list of extensions valid at the document property level of the CSAF document and associated with this document metadata.",
           "$ref": "#/$defs/extensions_t"
+        },
+        "involvements": {
+          "$ref": "#/$defs/involvements_t"
         }
       },
       "additionalProperties": false
@@ -1314,72 +1385,7 @@
             }
           },
           "involvements": {
-            "title": "List of involvements",
-            "description": "Contains a list of involvements.",
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-              "title": "Involvement",
-              "description": "Is a container, that allows the document producers to comment on the level of involvement (or engagement) of themselves or third parties in the vulnerability identification, scoping, and remediation process.",
-              "type": "object",
-              "required": [
-                "party",
-                "status"
-              ],
-              "properties": {
-                "contact": {
-                  "title": "Party contact information",
-                  "description": "Contains the contact information of the party that was used in this state.",
-                  "type": "string",
-                  "minLength": 1
-                },
-                "date": {
-                  "title": "Date of involvement",
-                  "description": "Holds the date and time of the involvement entry.",
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "group_ids": {
-                  "$ref": "#/$defs/product_groups_t"
-                },
-                "party": {
-                  "title": "Party category",
-                  "description": "Defines the category of the involved party.",
-                  "type": "string",
-                  "enum": [
-                    "coordinator",
-                    "discoverer",
-                    "other",
-                    "user",
-                    "vendor"
-                  ]
-                },
-                "product_ids": {
-                  "$ref": "#/$defs/products_t"
-                },
-                "status": {
-                  "title": "Party status",
-                  "description": "Defines contact status of the involved party.",
-                  "type": "string",
-                  "enum": [
-                    "completed",
-                    "contact_attempted",
-                    "disputed",
-                    "in_progress",
-                    "not_contacted",
-                    "open"
-                  ]
-                },
-                "summary": {
-                  "title": "Summary of the involvement",
-                  "description": "Contains additional context regarding what is going on.",
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
-              "additionalProperties": false
-            }
+            "$ref": "#/$defs/involvements_t"
           },
           "metrics": {
             "title": "List of metrics",


### PR DESCRIPTION
This pull request introduces a refactor to the CSAF 2.1 JSON schema, specifically extracting the definition of the `involvements` array into a new schema definition (`involvements_t`) and referencing it in both the `document` and `vulnerabilities` sections. Additionally, a new example document (`certcc-vu_834248.json`) is added to test plan.

**Schema refactoring and extension:**

* Extracted the `involvements` array schema from the `vulnerabilities` section into a new `$defs.involvements_t` definition in `csaf.json`, improving schema reuse and maintainability. (`csaf_2.1/json_schema/csaf.json`) 
* Updated both the `vulnerabilities` and `document` sections to reference the new `involvements_t` definition, enabling involvements to be specified at the document level as well as per vulnerability. (`csaf_2.1/json_schema/csaf.json`) 
**Example data:**

* Added a new example CSAF document (`certcc-vu_834248.json`) that demonstrates the use of the involvements array and various other CSAF features. (`csaf_2.1/examples/csaf/certcc-vu_834248.json`)