### PR TITLE
JSONPath recursion - clarification

### DIFF
--- a/csaf_2.1/prose/edit/src/guidance-on-size.md
+++ b/csaf_2.1/prose/edit/src/guidance-on-size.md
@@ -40,18 +40,12 @@ An array SHOULD NOT have more than:
   - `$.document.acknowledgments[*].urls`
   - `$.document.tracking.aliases`
   - `$.document.x_extensions`
-  - `$.product_tree.branches[*]..product.product_identification_helper.hashes`
-  - `$.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes`
-  - `$.product_tree.branches[*]..product.product_identification_helper.purls`
-  - `$.product_tree.branches[*]..product.product_identification_helper.sbom_urls`
-  - `$.product_tree.branches[*]..product.product_identification_helper.x_generic_uris`
-  - `$.product_tree.branches[*]..product.x_extensions`
-  - `$.product_tree.branches[*].product.product_identification_helper.hashes`
-  - `$.product_tree.branches[*].product.product_identification_helper.hashes[*].file_hashes`
-  - `$.product_tree.branches[*].product.product_identification_helper.purls`
-  - `$.product_tree.branches[*].product.product_identification_helper.sbom_urls`
-  - `$.product_tree.branches[*].product.product_identification_helper.x_generic_uris`
-  - `$.product_tree.branches[*].product.x_extensions`
+  - `$.product_tree..branches[*].product.product_identification_helper.hashes`
+  - `$.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes`
+  - `$.product_tree..branches[*].product.product_identification_helper.purls`
+  - `$.product_tree..branches[*].product.product_identification_helper.sbom_urls`
+  - `$.product_tree..branches[*].product.product_identification_helper.x_generic_uris`
+  - `$.product_tree..branches[*].product.x_extensions`
   - `$.product_tree.full_product_names[*].product_identification_helper.hashes`
   - `$.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes`
   - `$.product_tree.full_product_names[*].product_identification_helper.purls`
@@ -90,12 +84,9 @@ An array SHOULD NOT have more than:
   - `$.document.tracking.revision_history`
   - `$.product_tree.branches`
   - `$.product_tree..branches`
-  - `$.product_tree.branches[*]..product.product_identification_helper.model_numbers`
-  - `$.product_tree.branches[*]..product.product_identification_helper.serial_numbers`
-  - `$.product_tree.branches[*]..product.product_identification_helper.skus`
-  - `$.product_tree.branches[*].product.product_identification_helper.model_numbers`
-  - `$.product_tree.branches[*].product.product_identification_helper.serial_numbers`
-  - `$.product_tree.branches[*].product.product_identification_helper.skus`
+  - `$.product_tree..branches[*].product.product_identification_helper.model_numbers`
+  - `$.product_tree..branches[*].product.product_identification_helper.serial_numbers`
+  - `$.product_tree..branches[*].product.product_identification_helper.skus`
   - `$.product_tree.full_product_names`
   - `$.product_tree.full_product_names[*].product_identification_helper.model_numbers`
   - `$.product_tree.full_product_names[*].product_identification_helper.serial_numbers`
@@ -170,24 +161,15 @@ A string SHOULD NOT have a length greater than:
   - `$.document.tracking.revision_history[*].legacy_version`
   - `$.document.tracking.revision_history[*].number`
   - `$.document.tracking.version`
-  - `$.product_tree.branches[*]..name`
-  - `$.product_tree.branches[*]..product.name`
-  - `$.product_tree.branches[*]..product.product_id`
-  - `$.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes[*].algorithm`
-  - `$.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes[*].value`
-  - `$.product_tree.branches[*]..product.product_identification_helper.hashes[*].filename`
-  - `$.product_tree.branches[*]..product.product_identification_helper.model_numbers[*]`
-  - `$.product_tree.branches[*]..product.product_identification_helper.serial_numbers[*]`
-  - `$.product_tree.branches[*]..product.product_identification_helper.skus[*]`
-  - `$.product_tree.branches[*].name`
-  - `$.product_tree.branches[*].product.name`
-  - `$.product_tree.branches[*].product.product_id`
-  - `$.product_tree.branches[*].product.product_identification_helper.hashes[*].file_hashes[*].algorithm`
-  - `$.product_tree.branches[*].product.product_identification_helper.hashes[*].file_hashes[*].value`
-  - `$.product_tree.branches[*].product.product_identification_helper.hashes[*].filename`
-  - `$.product_tree.branches[*].product.product_identification_helper.model_numbers[*]`
-  - `$.product_tree.branches[*].product.product_identification_helper.serial_numbers[*]`
-  - `$.product_tree.branches[*].product.product_identification_helper.skus[*]`
+  - `$.product_tree..branches[*].name`
+  - `$.product_tree..branches[*].product.name`
+  - `$.product_tree..branches[*].product.product_id`
+  - `$.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes[*].algorithm`
+  - `$.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes[*].value`
+  - `$.product_tree..branches[*].product.product_identification_helper.hashes[*].filename`
+  - `$.product_tree..branches[*].product.product_identification_helper.model_numbers[*]`
+  - `$.product_tree..branches[*].product.product_identification_helper.serial_numbers[*]`
+  - `$.product_tree..branches[*].product.product_identification_helper.skus[*]`
   - `$.product_tree.full_product_names[*].name`
   - `$.product_tree.full_product_names[*].product_id`
   - `$.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes[*].algorithm`
@@ -261,10 +243,8 @@ A string SHOULD NOT have a length greater than:
   - `$.document.publisher.issuing_authority`
   - `$.document.references[*].summary`
   - `$.document.tracking.revision_history[*].summary`
-  - `$.product_tree.branches[*]..product.product_identification_helper.cpe`
-  - `$.product_tree.branches[*]..product.product_identification_helper.purls[*]`
-  - `$.product_tree.branches[*].product.product_identification_helper.cpe`
-  - `$.product_tree.branches[*].product.product_identification_helper.purls[*]`
+  - `$.product_tree..branches[*].product.product_identification_helper.cpe`
+  - `$.product_tree..branches[*].product.product_identification_helper.purls[*]`
   - `$.product_tree.full_product_names[*].product_identification_helper.cpe`
   - `$.product_tree.full_product_names[*].product_identification_helper.purls[*]`
   - `$.product_tree.product_groups[*].summary`
@@ -329,10 +309,8 @@ This applies to:
 - `$.document.references[*].category` (8)
 - `$.document.tracking.status` (7)
 - `$.document.x_extensions[*].category` (13)
-- `$.product_tree.branches[*]..category` (15)
-- `$.product_tree.branches[*]..product.x_extensions[*].category` (13)
-- `$.product_tree.branches[*].category` (15)
-- `$.product_tree.branches[*].product.x_extensions[*].category` (13)
+- `$.product_tree..branches[*].category` (15)
+- `$.product_tree..branches[*].product.x_extensions[*].category` (13)
 - `$.product_tree.full_product_names[*].x_extensions[*].category` (13)
 - `$.product_tree.product_paths[*].category` (21)
 - `$.product_tree.product_paths[*].full_product_name.x_extensions[*].category` (13)
@@ -435,14 +413,10 @@ A string with format `uri` SHOULD NOT have a length greater than 20000. This app
 - `$.document.publisher.namespace`
 - `$.document.references[*].url`
 - `$.document.x_extensions[*]['$schema']`
-- `$.product_tree.branches[*]..product.product_identification_helper.sbom_urls[*]`
-- `$.product_tree.branches[*]..product.product_identification_helper.x_generic_uris[*].namespace`
-- `$.product_tree.branches[*]..product.product_identification_helper.x_generic_uris[*].uri`
-- `$.product_tree.branches[*]..product.x_extensions[*]['$schema']`
-- `$.product_tree.branches[*].product.product_identification_helper.sbom_urls[*]`
-- `$.product_tree.branches[*].product.product_identification_helper.x_generic_uris[*].namespace`
-- `$.product_tree.branches[*].product.product_identification_helper.x_generic_uris[*].uri`
-- `$.product_tree.branches[*].product.x_extensions[*]['$schema']`
+- `$.product_tree..branches[*].product.product_identification_helper.sbom_urls[*]`
+- `$.product_tree..branches[*].product.product_identification_helper.x_generic_uris[*].namespace`
+- `$.product_tree..branches[*].product.product_identification_helper.x_generic_uris[*].uri`
+- `$.product_tree..branches[*].product.x_extensions[*]['$schema']`
 - `$.product_tree.full_product_names[*].product_identification_helper.sbom_urls[*]`
 - `$.product_tree.full_product_names[*].product_identification_helper.x_generic_uris[*].namespace`
 - `$.product_tree.full_product_names[*].product_identification_helper.x_generic_uris[*].uri`

--- a/csaf_2.1/prose/edit/src/introduction-05-typographical-conventions.md
+++ b/csaf_2.1/prose/edit/src/introduction-05-typographical-conventions.md
@@ -19,6 +19,12 @@ JSONPath is also used within the standard as syntax for specifying paths or refe
 They can have multiple results when being applied to a JSON instance or schema.
 However, when referring to a schema with one of the keywords `$ref` or `$dynamicRef` the value is a `URI-Reference`
 (cf. section 8.2.3 of [cite](#JSON-Schema-Core)).
+To represent paths which contain the branch recursion below `$.product_tree.branches[*]` the descendant segment syntax
+`$.product_tree..branches[*]` is used.
+Implementations need to ensure that only matching paths with the intended type are selected.
+For example, this could be done by checking that the property names that are omitted through the `..` syntax along the path
+between `product_tree` and `branches` are just `branches`.
+Including but not limited to paths containing `x_extensions` could introduce arbitrary other property names.
 
 Some sections of this specification are illustrated with non-normative examples introduced with "Example" or "Examples" like so:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-02-multiple-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-02-multiple-definition-of-product-id.md
@@ -6,7 +6,7 @@ MUST be tested that the `product_id` was not already defined within the same doc
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_id
+  $.product_tree..branches[*].product.product_id
   $.product_tree.full_product_names[*].product_id
   $.product_tree.product_paths[*].full_product_name.product_id
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
@@ -9,7 +9,7 @@ It MUST be tested that all given PURLs are valid.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.purls[*]
+  $.product_tree..branches[*].product.product_identification_helper.purls[*]
   $.product_tree.full_product_names[*].product_identification_helper.purls[*]
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.purls[*]
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
@@ -5,7 +5,7 @@ It MUST be tested that the same hash algorithm is not used multiple times in one
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes
+  $.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes
   $.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.hashes[*].file_hashes
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-31-version-range-in-product-version.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-31-version-range-in-product-version.md
@@ -29,7 +29,7 @@ the value of `name` does not contain a version range.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-34-branches-recursion-depth.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-34-branches-recursion-depth.md
@@ -6,7 +6,7 @@ does not contain more than 30 instances of `branches`.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product
+  $.product_tree..branches[*].product
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-42-purl-qualifiers.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-42-purl-qualifiers.md
@@ -5,7 +5,7 @@ For each `product_identification_helper` object containing multiple PURLs it MUS
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.purls[*]
+  $.product_tree..branches[*].product.product_identification_helper.purls[*]
   $.product_tree.full_product_names[*].product_identification_helper.purls[*]
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.purls[*]
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
@@ -7,7 +7,7 @@ For each model number it MUST be tested that it does not contain multiple unesca
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.model_numbers[*]
+  $.product_tree..branches[*].product.product_identification_helper.model_numbers[*]
   $.product_tree.full_product_names[*].product_identification_helper.model_numbers[*]
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.model_numbers[*]
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
@@ -7,7 +7,7 @@ For each serial number it MUST be tested that it does not contain multiple unesc
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.serial_numbers[*]
+  $.product_tree..branches[*].product.product_identification_helper.serial_numbers[*]
   $.product_tree.full_product_names[*].product_identification_helper.serial_numbers[*]
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.serial_numbers[*]
 ```

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
@@ -8,7 +8,7 @@ Nevertheless, all other rules MUST be checked to the extent possible.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-57-stacked-branch-categories.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-57-stacked-branch-categories.md
@@ -8,7 +8,7 @@ Therefore, `product_family` MUST be ignored in the test.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..category
+  $.product_tree..branches[*].category
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-58-use-of-product-version-in-one-path-with-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-58-use-of-product-version-in-one-path-with-product-version-range.md
@@ -6,7 +6,7 @@ For each `full_product_name_t` element under `$.product_tree.branches`, it MUST 
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..category
+  $.product_tree..branches[*].category
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-59-single-version-as-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-59-single-version-as-product-version-range.md
@@ -6,7 +6,7 @@ identify only a single version.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
@@ -13,7 +13,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]
@@ -47,7 +47,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]
@@ -92,7 +92,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions
-  $.product_tree.branches[*]..product.x_extensions
+  $.product_tree..branches[*].product.x_extensions
   $.product_tree.full_product_names[*].x_extensions
   $.product_tree.product_paths[*].full_product_name.x_extensions
   $.vulnerabilities[*].metrics[*].content.x_extensions

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
@@ -7,7 +7,7 @@ For each stock keeping unit it MUST be tested that it does not contain multiple 
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.skus[*]
+  $.product_tree..branches[*].product.product_identification_helper.skus[*]
   $.product_tree.full_product_names[*].product_identification_helper.skus[*]
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.skus[*]
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-01-unused-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-01-unused-definition-of-product-id.md
@@ -8,7 +8,7 @@ This test SHALL be skipped for CSAF documents conforming the profile "Informatio
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_id
+  $.product_tree..branches[*].product.product_id
   $.product_tree.full_product_names[*].product_id
   $.product_tree.product_paths[*].full_product_name.product_id
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-08-use-of-md5-as-the-only-hash-algorith.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-08-use-of-md5-as-the-only-hash-algorith.md
@@ -8,7 +8,7 @@ It MUST be tested that the hash algorithm `md5` is not the only one present.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes
+  $.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes
   $.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.hashes[*].file_hashes
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-09-use-of-sha-1-as-the-only-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-09-use-of-sha-1-as-the-only-hash-algorithm.md
@@ -8,7 +8,7 @@ It MUST be tested that the hash algorithm `sha1` is not the only one present.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes
+  $.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes
   $.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.hashes[*].file_hashes
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-16-missing-product-identification-helper.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-16-missing-product-identification-helper.md
@@ -5,7 +5,7 @@ For each element of type `$['$defs'].full_product_name_t` it MUST be tested that
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product
+  $.product_tree..branches[*].product
   $.product_tree.full_product_names[*]
   $.product_tree.product_paths[*].full_product_name
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-18-product-version-range-without-vers.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-18-product-version-range-without-vers.md
@@ -21,7 +21,7 @@ For more details, see sections [sec](#branches-type---category) and [sec](#branc
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
@@ -11,7 +11,7 @@ that a product path exists referencing this product.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product
+  $.product_tree..branches[*].product
   $.product_tree.full_product_names[*]
   $.product_tree.product_paths[*].full_product_name
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-32-use-of-same-product-identification-helper-for-different-products.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-32-use-of-same-product-identification-helper-for-different-products.md
@@ -14,7 +14,7 @@ For each Product Identification Helper category it MUST be tested that the same 
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper
+  $.product_tree..branches[*].product.product_identification_helper
   $.product_tree.full_product_names[*].product_id.product_identification_helper
   $.product_tree.product_paths[*].full_product_name.product_id.product_identification_helper
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-42-inconsistent-product-identification-helper.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-42-inconsistent-product-identification-helper.md
@@ -18,8 +18,8 @@ Information that cannot be represented in the specific product identification he
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.cpe
-  $.product_tree.branches[*]..product.product_identification_helper.purls[*]
+  $.product_tree..branches[*].product.product_identification_helper.cpe
+  $.product_tree..branches[*].product.product_identification_helper.purls[*]
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-48-misuse-at-vendor-name.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-48-misuse-at-vendor-name.md
@@ -12,7 +12,7 @@ The comparison is case and white space insensitive.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-49-upper-open-ended-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-49-upper-open-ended-product-version-range.md
@@ -8,7 +8,7 @@ upper open ended product version range.
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-51-unknown-version-scheme-in-vers.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-51-unknown-version-scheme-in-vers.md
@@ -12,7 +12,7 @@ The warning MUST differentiate between officially registered version schemes and
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-52-unknown-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-52-unknown-hash-algorithm.md
@@ -13,7 +13,7 @@ and those not mentioned there.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes[*].algorithm
+  $.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes[*].algorithm
   $.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes[*].algorithm
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.hashes[*].file_hashes[*].algorithm
 ```

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
@@ -14,7 +14,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]
@@ -43,7 +43,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]
@@ -74,7 +74,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*].critical
-  $.product_tree.branches[*]..product.x_extensions[*].critical
+  $.product_tree..branches[*].product.x_extensions[*].critical
   $.product_tree.full_product_names[*].x_extensions[*].critical
   $.product_tree.product_paths[*].full_product_name.x_extensions[*].critical
   $.vulnerabilities[*].metrics[*].content.x_extensions[*].critical
@@ -104,7 +104,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-05-use-of-short-hash.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-05-use-of-short-hash.md
@@ -5,7 +5,7 @@ It MUST be tested that the length of the hash value is not shorter than 64 chara
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.product_identification_helper.hashes[*].file_hashes[*].value
+  $.product_tree..branches[*].product.product_identification_helper.hashes[*].file_hashes[*].value
   $.product_tree.full_product_names[*].product_identification_helper.hashes[*].file_hashes[*].value
   $.product_tree.product_paths[*].full_product_name.product_identification_helper.hashes[*].file_hashes[*].value
 ```

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-06-use-of-non-self-referencing-urls-failing-to-resolve.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-06-use-of-non-self-referencing-urls-failing-to-resolve.md
@@ -17,9 +17,9 @@ The relevant paths for this test are:
   $.product_tree.branches[*].product.product_identification_helper.sbom_urls[*]
   $.product_tree.branches[*].product.product_identification_helper.x_generic_uris[*].namespace
   $.product_tree.branches[*].product.product_identification_helper.x_generic_uris[*].uri
-  $.product_tree.branches[*]..product.product_identification_helper.sbom_urls[*]
-  $.product_tree.branches[*]..product.product_identification_helper.x_generic_uris[*].namespace
-  $.product_tree.branches[*]..product.product_identification_helper.x_generic_uris[*].uri
+  $.product_tree..branches[*].product.product_identification_helper.sbom_urls[*]
+  $.product_tree..branches[*].product.product_identification_helper.x_generic_uris[*].namespace
+  $.product_tree..branches[*].product.product_identification_helper.x_generic_uris[*].uri
   $.product_tree.full_product_names[*].product_identification_helper.sbom_urls[*]
   $.product_tree.full_product_names[*].product_identification_helper.x_generic_uris[*].namespace
   $.product_tree.full_product_names[*].product_identification_helper.x_generic_uris[*].uri

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-08-spell-check.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-08-spell-check.md
@@ -24,10 +24,8 @@ The relevant paths for this test are:
   $.document.tracking.aliases[*]
   $.document.tracking.generator.engine.name
   $.document.tracking.revision_history[*].summary
-  $.product_tree.branches[*]..name
-  $.product_tree.branches[*]..product.name
-  $.product_tree.branches[*].name
-  $.product_tree.branches[*].product.name
+  $.product_tree..branches[*].name
+  $.product_tree..branches[*].product.name
   $.product_tree.full_product_names[*].name
   $.product_tree.product_groups[*].summary
   $.product_tree.product_paths[*].full_product_name.name

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-10-usage-of-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-10-usage-of-product-version-range.md
@@ -8,7 +8,7 @@ For each element of type `$['$defs'].branches_t` it MUST be tested that the `cat
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..category
+  $.product_tree..branches[*].category
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-11-usage-of-v-as-version-indicator.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-11-usage-of-v-as-version-indicator.md
@@ -12,7 +12,7 @@ the value of `name` does not start with `v` or `V` before the version.
 The relevant paths for this test are:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
@@ -207,7 +207,7 @@ For each `EPVR` (as `CTPVR`), it MUST be tested that all product version ranges 
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*
@@ -246,7 +246,7 @@ For each `EPVR` (as `CTPVR`), it MUST be tested that all product versions of ele
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..name
+  $.product_tree..branches[*].name
 ```
 
 *Example 1 (which fails the test):*

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
@@ -16,7 +16,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*].category
-  $.product_tree.branches[*]..product.x_extensions[*].category
+  $.product_tree..branches[*].product.x_extensions[*].category
   $.product_tree.full_product_names[*].x_extensions[*].category
   $.product_tree.product_paths[*].full_product_name.x_extensions[*].category
   $.vulnerabilities[*].metrics[*].content.x_extensions[*].category
@@ -48,7 +48,7 @@ The relevant paths for this test are:
 
 ```list-of-jsonpaths
   $.document.x_extensions[*]
-  $.product_tree.branches[*]..product.x_extensions[*]
+  $.product_tree..branches[*].product.x_extensions[*]
   $.product_tree.full_product_names[*].x_extensions[*]
   $.product_tree.product_paths[*].full_product_name.x_extensions[*]
   $.vulnerabilities[*].metrics[*].content.x_extensions[*]
@@ -115,7 +115,7 @@ It MUST be tested that the element `x_extensions` does not exist in any path tha
 The relevant path for this test is:
 
 ```list-of-jsonpaths
-  $.product_tree.branches[*]..product.x_extensions
+  $.product_tree..branches[*].product.x_extensions
 ```
 
 *Example 1 (which fails the test):*


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1311
- add comment for implementers regarding descendant syntax used for recursion in JSONPath
- change all occurrence of recursion JSONPath from `.branches[*]..` to `..branches[*].` as stated in typographical conventions
- remove direct JSONPath that are covered through a recursive JSONPath