### PR TITLE
Editorial: MUST vs SHALL

### DIFF
--- a/csaf_2.1/prose/edit/src/additional-conventions.md
+++ b/csaf_2.1/prose/edit/src/additional-conventions.md
@@ -4,10 +4,10 @@ This section provides additional rules for handling CSAF documents.
 
 ## Filename
 
-The following rules MUST be applied to determine the filename for the CSAF document:
+The following rules SHALL be applied to determine the filename for the CSAF document:
 
-1. The value `$.document.tracking.id` is converted into lowercase.
-2. Any character sequence which is not part of one of the following groups MUST be replaced by a single underscore (`_`):
+1. The value `$.document.tracking.id` SHALL be converted into lowercase.
+2. Any character sequence which is not part of one of the following groups SHALL be replaced by a single underscore (`_`):
    * lower-case ASCII letters (0x61 - 0x7A)
    * digits (0x30 - 0x39)
    * special characters: `+` (0x2B), `-` (0x2D)
@@ -19,7 +19,7 @@ The following rules MUST be applied to determine the filename for the CSAF docum
    > where the conversion rule might lead to multiple consecutive underscores.
    > As a result, a `$.document.tracking.id` with the value `2022_#01-A` is converted into `2022_01-a` instead of `2022__01-a`.
 
-3. The file extension `.json` MUST be appended.
+3. The file extension `.json` SHALL be appended.
 
 *Examples 1:*
 
@@ -43,7 +43,7 @@ The following rules MUST be applied to determine the filename for the CSAF docum
 ## Separation in Data Stream
 
 If multiple CSAF documents are transported via a data stream in a sequence without requests inbetween,
-they MUST be separated by the Record Separator in accordance with [cite](#RFC7464).
+they SHALL be separated by the Record Separator in accordance with [cite](#RFC7464).
 
 ## Sorting{#additional-conventions--sorting}
 
@@ -71,7 +71,7 @@ The use of GitHub-flavoured Markdown is permitted in the following fields:
   $.vulnerabilities[*].threats[*].details
 ```
 
-Other fields MUST NOT contain Markdown.
+Other fields SHALL NOT contain Markdown.
 
 ## Branch Recursion
 
@@ -83,9 +83,9 @@ The `$.product_tree` uses a nested structure for `branches`. Along a single path
 
 ## Hardware and Software within the Product Tree
 
-If a product consists of hardware and software, the hardware part MUST be presented as one product in the product tree
+If a product consists of hardware and software, the hardware part SHALL be presented as one product in the product tree
 and the software part as another one.
-To form the overall product, both parts MUST be combined through a product path.
+To form the overall product, both parts SHALL be combined through a product path.
 
 *Example 1:*
 

--- a/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-01-construction-principles.md
@@ -70,7 +70,7 @@ The JSON schemas defined in this standard do not allow the use of additional pro
 
 Sole exception are the dedicated extension points (`x_extensions`) which allow the usage of extension defined outside this specification.
 To still ensure interoperability and guide tools how to deal with this data a CSAF Extension Content Schema
-and CSAF Extension Metaschema has been defined and MUST be adhered to (cf. section [sec](#extensions)).
+and CSAF Extension Metaschema has been defined and SHALL be adhered to (cf. section [sec](#extensions)).
 Document issuers are advised to always balance pros and cons regarding the use of extension.
 
 Section [sec](#profiles) defined profiles that are used to ensure a common understanding of which fields are required in a given use case.

--- a/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-03-date-time.md
@@ -4,13 +4,13 @@ This standard uses the `date-time` format as defined in JSON Schema Draft 2020-1
 In accordance with [cite](#RFC3339) and [cite](#ISO8601-1), the following rules apply:
 
 - The letter `T` separating the date and time SHALL be upper case.
-- The separator between date and time MUST be the letter `T`.
+- The separator between date and time SHALL be the letter `T`.
 - The letter `Z` indicating the timezone UTC SHALL be upper case.
 - Fractions of seconds are allowed as specified in the standards mention above with the full stop (`.`) as separator.
-- Empty timezones MUST NOT be used.
+- Empty timezones SHALL NOT be used.
 - The ABNF of RFC 3339, section 5.6 applies.
 
-In contrast to the aforementioned standards, leap seconds MUST NOT be used.
+In contrast to the aforementioned standards, leap seconds SHALL NOT be used.
 
   > While a full support of [cite](#RFC3339) would be preferred, significant challenges have been mentioned by implementers
   > as most libraries are lacking the support for leap seconds.

--- a/csaf_2.1/prose/edit/src/design-considerations-04-extensions.md
+++ b/csaf_2.1/prose/edit/src/design-considerations-04-extensions.md
@@ -4,10 +4,10 @@ This standard allows for extensions to the standardized schema.
 
 The following rules apply:
 
-- An extension MUST NOT occur in any other place than specified.
-- An extension MUST satisfy the Conformance Target "CSAF Extension".
-- The schema specifying the content and properties of the CSAF Extension MUST satisfy the Conformance Target "CSAF Extension Schema".
-- For official and registered extensions a CSAF Extension Package MUST be provided.
+- An extension SHALL NOT occur in any other place than specified.
+- An extension SHALL satisfy the Conformance Target "CSAF Extension".
+- The schema specifying the content and properties of the CSAF Extension SHALL satisfy the Conformance Target "CSAF Extension Schema".
+- For official and registered extensions a CSAF Extension Package SHALL be provided.
 - CSAF Extensions SHOULD NOT provide CSAF Extension Overlay Tests for tests in the preset `extensions`.
 
 ### Classes
@@ -40,18 +40,18 @@ The OASIS CSAF TC maintains:
 - a list of deny-listed extensions.
 
 Deprecated extensions can still be used but support for them is removed in near future. If avoidable, they SHOULD NOT be used.
-Deny-listed extensions MUST NOT be used.
+Deny-listed extensions SHALL NOT be used.
 The lists of deprecated extensions and deny-listed extensions MAY contain extensions that do not fulfill the conformance target CSAF Extension.
 
 The list MAY contain additional examples.
 
 ### Metaschema
 
-The CSAF Extension Metaschema MUST be used to validate a CSAF Extension Schema.
+The CSAF Extension Metaschema SHALL be used to validate a CSAF Extension Schema.
 
 ### Content Schema
 
-An extension MUST contain exactly the following elements:
+An extension SHALL contain exactly the following elements:
 CSAF Extension Schema (`$schema`), Extension Category (`category`), Critical (`critical`) and Content (`content`).
 
 ```yaml <!--json-path($.properties)-->
@@ -70,8 +70,8 @@ CSAF Extension Schema (`$schema`) of value type CSAF Extension Content `$schema`
 This SHOULD also be the location where the JSON schema can be retrieved.
 The value SHOULD match the `$id` of the JSON schema that defines the extension.
 The URL SHOULD contain a human-readable name for the extension before the version string.
-The versioning MUST use [cite](#SemVer).
-URLs using a domain mentioned in [cite](#RFC2606) MUST be used according to their defined purpose.
+The versioning SHALL use [cite](#SemVer).
+URLs using a domain mentioned in [cite](#RFC2606) SHALL be used according to their defined purpose.
 
 *Examples 1:*
 
@@ -93,7 +93,7 @@ Valid `enum` values are:
 
 The value `essential` indicates, that the content provided through this extension is crucial to understand of the CSAF document
 this extension is included in.
-CSAF consumers and CSAF validators MUST warn if they process a CSAF Document including such extension instance and
+CSAF consumers and CSAF validators SHALL warn if they process a CSAF Document including such extension instance and
 do not have the extension in question already implemented.
 
 The value `significant` indicates, that the content provided through this extension is highly relevant and significantly aids
@@ -116,7 +116,7 @@ The property names (JSON keys) can be chosen freely; they SHOULD characterize th
 Critical (`critical`) of value type `boolean` determines whether using the extension would fail a mandatory test.
 The `default` value for this is `false`.
 
-For any failing test, a CSAF Extension Test MUST be provided.
+For any failing test, a CSAF Extension Test SHALL be provided.
 
 ### Metadata
 

--- a/csaf_2.1/prose/edit/src/distributing-01-requirements.md
+++ b/csaf_2.1/prose/edit/src/distributing-01-requirements.md
@@ -16,27 +16,27 @@ The CSAF document has a filename according to the rules in section [sec](#filena
 ### Requirement 3: TLS
 
 The CSAF document is per default retrievable from a website which uses TLS for encryption and server authenticity.
-The CSAF document MUST NOT be downloadable from a location which does not encrypt the transport when crossing organizational
+The CSAF document SHALL NOT be downloadable from a location which does not encrypt the transport when crossing organizational
 boundaries to maintain the chain of custody.
 
 ### Requirement 4: TLP:CLEAR
 
-If the CSAF document is labeled TLP:CLEAR, it MUST be freely accessible.
+If the CSAF document is labeled TLP:CLEAR, it SHALL be freely accessible.
 
 This does not exclude that such a document is also available in an access protected customer portal.
-However, there MUST be one copy of the document available for people without access to the portal.
+However, there SHALL be one copy of the document available for people without access to the portal.
 
 > Reasoning: If an advisory is already in the media, an end user should not be forced to collect the pieces of information from a
 > press release but be able to retrieve the CSAF document.
 
 ### Requirement 5: TLP:AMBER, TLP:AMBER+STRICT and TLP:RED{#requirement-5-tlp-amber-tlp-amber-strict-and-tlp-red}
 
-CSAF documents labeled TLP:AMBER, TLP:AMBER+STRICT or TLP:RED MUST be access protected.
+CSAF documents labeled TLP:AMBER, TLP:AMBER+STRICT or TLP:RED SHALL be access protected.
 If they are provided via a web server this SHALL be done under a different path than for TLP:CLEAR,
 TLP:GREEN and unlabeled CSAF documents. TLS client authentication, access tokens or any other automatable authentication method SHALL be used.
 
 An issuing party MAY agree with the recipients to use any kind of secured drop at the recipients' side to avoid putting them on their own website.
-However, it MUST be ensured that the documents are still access protected.
+However, it SHALL be ensured that the documents are still access protected.
 
 ### Requirement 6: No Redirects
 
@@ -45,13 +45,13 @@ If they are inevitable only HTTP Header redirects SHALL be used.
 
 > Reasoning: Clients should not parse the payload for navigation and some, as e.g. `curl`, do not follow any other kind of redirects.
 
-If any redirects are used, there SHOULD NOT be more than `10`, and MUST NOT be more than `20` consecutive redirects.
+If any redirects are used, there SHOULD NOT be more than `10`, and SHALL NOT be more than `20` consecutive redirects.
 
 > This aligns with section 4.4 of the [cite](#FETCH) specification.
 
 ### Requirement 7: provider-metadata.json
 
-The party MUST provide a valid `provider-metadata.json` according to the schema
+The party SHALL provide a valid `provider-metadata.json` according to the schema
 [CSAF provider metadata](https://docs.oasis-open.org/csaf/csaf/v2.1/schema/provider.json) for its own metadata.
 The `publisher` object SHOULD match the one used in the CSAF documents of the issuing party but can be set to whatever value a
 CSAF aggregator SHOULD display over any individual `publisher` values in the CSAF documents themselves.
@@ -119,7 +119,7 @@ Furthermore, such programs SHOULD evaluate the `maintained_from` property and ou
 
 If a CSAF publisher (cf. section [sec](#role-csaf-publisher)) does not provide the `provider-metadata.json`,
 an aggregator SHOULD contact the CSAF publisher in question to determine the values for `list_on_CSAF_aggregators` and `mirror_on_CSAF_aggregators`.
-If that is impossible or if the CSAF publisher is unresponsive the following values MUST be used:
+If that is impossible or if the CSAF publisher is unresponsive the following values SHALL be used:
 
 ```
     "list_on_CSAF_aggregators": true,
@@ -134,8 +134,8 @@ If that is impossible or if the CSAF publisher is unresponsive the following val
 
 ### Requirement 8: security.txt
 
-In the security.txt there MUST be at least one field `CSAF` which points to the `provider-metadata.json` (requirement 7).
-If this field indicates a web URI, then it MUST begin with "https://" (as per section 2.7.2 of [cite](#RFC7230)).
+In the security.txt there SHALL be at least one field `CSAF` which points to the `provider-metadata.json` (requirement 7).
+If this field indicates a web URI, then it SHALL begin with "https://" (as per section 2.7.2 of [cite](#RFC7230)).
 See [cite](#SECURITY-TXT) for more details.
 
 > The security.txt was published as [cite](#RFC9116) in April 2022.
@@ -155,7 +155,7 @@ e.g. in case of changes to the organizational structure through mergers and acqu
 However, this SHOULD NOT be done and removed as soon as possible.
 A valid use case for temporarily including multiple entries would be a transition phase between different CSAF versions, in which documents 
 and provider metadata of both versions are served simultaneously (cf. section [sec](#transition-between-csaf-2-0-and-csaf-2-1)).
-If one of the URLs fulfills requirement 9, it MUST be set as the first CSAF entry in the security.txt.
+If one of the URLs fulfills requirement 9, it SHALL be set as the first CSAF entry in the security.txt.
 
 ### Requirement 9: Well-Known URL for provider-metadata.json{#requirement-9-well-known-url-for-provider-metadata-json}
 
@@ -171,7 +171,7 @@ The use of the scheme "HTTPS" is required. See [cite](#RFC8615) for more details
 
 As specified in [sec](#transition-between-csaf-2-0-and-csaf-2-1), the value of `canonical_url` MAY differ from the URL that was
 requested as a part of this requirement.
-Such state is intended and MUST NOT be reported as error.
+Such state is intended and SHALL NOT be reported as error.
 
 ### Requirement 10: DNS Path
 
@@ -186,7 +186,7 @@ The use of the scheme "HTTPS" is required.
 
 ### Requirement 11: One Folder per Year
 
-The CSAF documents MUST be located within folders named `<YYYY>` where `<YYYY>` is the year given in the
+The CSAF documents SHALL be located within folders named `<YYYY>` where `<YYYY>` is the year given in the
 value of `$.document.tracking.initial_release_date`.
 
 *Examples 1:*
@@ -198,7 +198,7 @@ value of `$.document.tracking.initial_release_date`.
 
 ### Requirement 12: index.txt{#requirement-12-index-txt}
 
-The file `index.txt` MUST contain the list of all filenames of CSAF documents which are located in the sub-directories with their filenames.
+The file `index.txt` SHALL contain the list of all filenames of CSAF documents which are located in the sub-directories with their filenames.
 Each entry SHALL be terminated by a newline sequence.
 The last entry MAY skip the newline sequence.
 
@@ -309,8 +309,8 @@ The file `index.txt` SHALL be located in the folder given as directory URL under
 ### Requirement 13: changes.csv{#requirement-13-changes-csv}
 
 The file `changes.csv` contains a list of CSAF documents in the current TLP level that were changed recently.
-Therefore, it MUST contain the filename as well as the value of `$.document.tracking.current_release_date` for each
-CSAF document in the sub-directories without a heading; lines MUST be sorted by the `current_release_date` timestamp with the latest one first.
+Therefore, it SHALL contain the filename as well as the value of `$.document.tracking.current_release_date` for each
+CSAF document in the sub-directories without a heading; lines SHALL be sorted by the `current_release_date` timestamp with the latest one first.
 The `changes.csv` SHALL be a valid comma separated values format as defined by [cite](#RFC4180) without double quotes.
 
 > Note: As a consequence of section [sec](#requirement-2-filename) Requirement 2 for filenames and section [sec](#requirement-11-one-folder-per-year)
@@ -346,7 +346,7 @@ Server-side generated directory listing SHALL be enabled to support manual navig
 
 Resource-Oriented Lightweight Information Exchange (ROLIE) is a standard to ease discovery of security content.
 ROLIE is built on top of the Atom Publishing Format and Protocol, with specific requirements that support publishing security content.
-All CSAF documents with the same TLP level MUST be listed in a single ROLIE feed (summary feed).
+All CSAF documents with the same TLP level SHALL be listed in a single ROLIE feed (summary feed).
 Additional ROLIE feeds might exist that contain only a subset of the CSAF documents.
 The selection criteria SHOULD be described through the summary.
 At least one of the feeds
@@ -354,11 +354,11 @@ At least one of the feeds
 - TLP:CLEAR
 - TLP:GREEN
 
-MUST exist.
-Each ROLIE feed document MUST be a JSON file that conforms with [cite](#RFC8322).
+SHALL exist.
+Each ROLIE feed document SHALL be a JSON file that conforms with [cite](#RFC8322).
 
-The ROLIE feed document MUST contain a feed category with the registered ROLIE information type `csaf`.
-The `scheme` for this category MUST be `urn:ietf:params:rolie:category:information-type`.
+The ROLIE feed document SHALL contain a feed category with the registered ROLIE information type `csaf`.
+The `scheme` for this category SHALL be `urn:ietf:params:rolie:category:information-type`.
 
 *Example 1:*
 
@@ -417,15 +417,15 @@ The `scheme` for this category MUST be `urn:ietf:params:rolie:category:informati
   }
 ```
 
-Any existing hash file (requirement 18) MUST be listed in the corresponding entry of the ROLIE feed as an item of
+Any existing hash file (requirement 18) SHALL be listed in the corresponding entry of the ROLIE feed as an item of
 the array `link` having the `rel` value of `hash`.
-Any existing signature file (requirement 19) MUST be listed in the corresponding entry of the ROLIE feed as an item of the array `link`
+Any existing signature file (requirement 19) SHALL be listed in the corresponding entry of the ROLIE feed as an item of the array `link`
 having the `rel` value of `signature`.
 
 ### Requirement 16: ROLIE Service Document
 
 The use and therefore the existence of ROLIE service document is optional.
-If it is used, each ROLIE service document MUST be a JSON file that conforms with [cite](#RFC8322) and lists the ROLIE feed documents.
+If it is used, each ROLIE service document SHALL be a JSON file that conforms with [cite](#RFC8322) and lists the ROLIE feed documents.
 Additionally, it can also list the corresponding ROLIE category documents.
 The ROLIE service document SHOULD use the filename `service.json` and reside next to the `provider-metadata.json`.
 
@@ -460,7 +460,7 @@ The ROLIE service document SHOULD use the filename `service.json` and reside nex
 ### Requirement 17: ROLIE Category Document
 
 The use and therefore the existence of ROLIE category document is optional.
-If it is used, each ROLIE category document MUST be a JSON file that conforms with [cite](#RFC8322).
+If it is used, each ROLIE category document SHALL be a JSON file that conforms with [cite](#RFC8322).
 A ROLIE category document SHOULD reside next to the corresponding ROLIE feed.
 ROLIE categories SHOULD be used for to further dissect CSAF documents by one or more of the following criteria:
 
@@ -545,7 +545,7 @@ Any subsequent data (like a filename) which is optional SHALL be separated by at
 ea6a209dba30a958a78d82309d6cdcc6929fcb81673b3dc4d6b16fac18b6ff38  esa-2022-02723.json
 ```
 
-If a ROLIE feed exists, each hash file MUST be listed in it as described in requirement 15.
+If a ROLIE feed exists, each hash file SHALL be listed in it as described in requirement 15.
 
 ### Requirement 19: Signatures
 
@@ -561,9 +561,9 @@ File name of CSAF document: esa-2022-02723.json
 File name of signature file: esa-2022-02723.json.asc
 ```
 
-If a ROLIE feed exists, each signature file MUST be listed in it as described in requirement 15.
+If a ROLIE feed exists, each signature file SHALL be listed in it as described in requirement 15.
 
-At all times, signatures MUST remain valid for a minimum of 30 days and ideally for at least 90 days. When executing
+At all times, signatures SHALL remain valid for a minimum of 30 days and ideally for at least 90 days. When executing
 CSAF document signatures, the signing party SHOULD adhere to or surpass the prevailing best practices and recommendations
 regarding key length.
 Tools SHOULD treat the violation of the rules given in the first sentence as:
@@ -575,7 +575,7 @@ Tools SHOULD treat the violation of the rules given in the first sentence as:
 
 ### Requirement 20: Public OpenPGP Key
 
-The public part of the OpenPGP key used to sign the CSAF documents MUST be available.
+The public part of the OpenPGP key used to sign the CSAF documents SHALL be available.
 This key file SHALL be presented as an ASCII armored file.
 It SHOULD also be available at a public key server.
 
@@ -587,9 +587,9 @@ The OpenPGP key SHOULD have a strength that is considered secure.
 
 ### Requirement 21: List of CSAF Providers
 
-The file `aggregator.json` MUST be present and valid according to the
+The file `aggregator.json` SHALL be present and valid according to the
 JSON schema [CSAF aggregator](https://docs.oasis-open.org/csaf/csaf/v2.1/schema/aggregator.json).
-It MUST NOT be stored adjacent to a `provider-metadata.json`.
+It SHALL NOT be stored adjacent to a `provider-metadata.json`.
 
 The file `aggregator.json` SHOULD be accessible at the registered path in the `.well-known` directory:
 `/.well-known/csaf-aggregator/aggregator.json`.
@@ -654,10 +654,10 @@ or one CSAF publisher and one CSAF provider (including CSAF trusted provider).
 
 ### Requirement 23: Mirror
 
-The CSAF documents for each issuing party that is mirrored MUST be in a different folder.
+The CSAF documents for each issuing party that is mirrored SHALL be in a different folder.
 The folder name SHOULD be retrieved from the name of the issuing authority.
-This folders MUST be adjacent to the `aggregator.json` (requirement 21).
-Each such folder MUST at least:
+This folders SHALL be adjacent to the `aggregator.json` (requirement 21).
+Each such folder SHALL at least:
 
 - provide a `provider-metadata.json` for the current issuing party.
 - provide the ROLIE feed document according to requirement 15 which links to the local copy of the CSAF document.
@@ -714,7 +714,7 @@ Each such folder MUST at least:
 
 ### Requirement 24: HTTP User-Agent
 
-Access to the CSAF related files and directories provided, for both metadata and documents, MUST be allowed independent of the
+Access to the CSAF related files and directories provided, for both metadata and documents, SHALL be allowed independent of the
 value of HTTP User-Agent.
 
 > Limit the value of HTTP User-Agents to a certain set would hinder adoption of tools retrieving the files.

--- a/csaf_2.1/prose/edit/src/distributing-02-roles.md
+++ b/csaf_2.1/prose/edit/src/distributing-02-roles.md
@@ -8,13 +8,13 @@ The roles "CSAF Publisher", "CSAF Provider", and "CSAF Trusted Provider" are int
 The second group consists of the roles "CSAF Lister" and "CSAF Aggregator".
 They collect data from the aforementioned issuing parties of the first group and provide them in a single place to aid in automation.
 Parties of the second group can also issue their own advisories.
-However, they MUST follow the rules for the first group for that.
+However, they SHALL follow the rules for the first group for that.
 
 Both, a CSAF lister and a CSAF aggregator, decide based on their own rules which issuing parties to list respectively to mirror.
 However, an issuing party MAY apply to be listed or mirrored.
 
-Issuing parties MUST indicate through the value `false` in `list_on_CSAF_aggregators` if they do not want to be listed.
-Issuing parties MUST indicate through the value `false` in `mirror_on_CSAF_aggregators` if they do not want to be mirrored.
+Issuing parties SHALL indicate through the value `false` in `list_on_CSAF_aggregators` if they do not want to be listed.
+Issuing parties SHALL indicate through the value `false` in `mirror_on_CSAF_aggregators` if they do not want to be mirrored.
 
 The values are independent.
 The combination of the value `false` in `list_on_CSAF_aggregators` and `true` in `mirror_on_CSAF_aggregators` implies that
@@ -45,8 +45,8 @@ Thirdly, the party:
 
 - satisfies the requirements 11 to 14 in section [sec](#requirements) or requirements 15 to 17 in section [sec](#requirements).
 
-> If the party uses the ROLIE-based distribution, it MUST also satisfy requirements 15 to 17.
-> If it uses the directory-based distribution, it MUST also satisfy requirements 11 to 14.
+> If the party uses the ROLIE-based distribution, it must also satisfy requirements 15 to 17.
+> If it uses the directory-based distribution, it must also satisfy requirements 11 to 14.
 
 ### Role: CSAF Trusted Provider
 
@@ -97,6 +97,6 @@ Additionally, a CSAF aggregator MAY list one or more issuing parties that it doe
 > To minimize the implementation efforts and process overhead, a CSAF aggregator MAY upload the CSAF documents of a CSAF publisher into
 > an internal instance of a CSAF provider software.
 > Such construct is called "CSAF Proxy Provider" as it can be mirrored by the CSAF aggregator software.
-> However, such a CSAF proxy provider MUST NOT be accessible from anyone else than the CSAF aggregator itself.
+> However, such a CSAF proxy provider SHALL NOT be accessible from anyone else than the CSAF aggregator itself.
 > Otherwise, that would violate the second rule of section [sec](#role-csaf-publisher).
 > Therefore, it is recommended to expose the CSAF proxy provider only on localhost and allow the access only from the CSAF aggregator software.

--- a/csaf_2.1/prose/edit/src/distributing-03-retrieving-rules.md
+++ b/csaf_2.1/prose/edit/src/distributing-03-retrieving-rules.md
@@ -39,7 +39,7 @@ Given a `provider-metadata.json`, the following process SHOULD be used to retrie
    If both are present, the ROLIE information SHOULD be preferred.
 2. For any CSAF trusted provider, the hash and signature files (requirements 18 to 19 in section [sec](#requirements)) SHOULD be retrieved together
    with the CSAF document.
-   They MUST be checked before further processing the CSAF document.
+   They SHALL be checked before further processing the CSAF document.
 3. Test the CSAF document against the schema.
 4. Execute mandatory tests on the CSAF document.
 

--- a/csaf_2.1/prose/edit/src/distributing-04-transition-20-21.md
+++ b/csaf_2.1/prose/edit/src/distributing-04-transition-20-21.md
@@ -39,14 +39,14 @@ The announcement MAY contain also the following information:
 The following process SHOULD be followed:
 
 - A `provider-metadata.json` in conformance to CSAF 2.0 SHOULD be placed at `/.well-known/csaf/v2.0/provider-metadata.json`.
-  - Its `canonical_url` MUST be set to an URL corresponding to the `/.well-known/csaf/v2.0/provider-metadata.json` path.
+  - Its `canonical_url` SHALL be set to an URL corresponding to the `/.well-known/csaf/v2.0/provider-metadata.json` path.
 
     > The property `maintained_until` was not defined in CSAF 2.0 and therefore cannot be used -
     > otherwise it would be set to the end of the transition period.
 
   - The URL SHALL also be added as an entry in the security.txt, if used.
 - A `provider-metadata.json` in conformance to CSAF 2.1 SHOULD be placed at `/.well-known/csaf/v2.1/provider-metadata.json`.
-  - Its `canonical_url` MUST be set to an URL corresponding to the `/.well-known/csaf/v2.1/provider-metadata.json` path.
+  - Its `canonical_url` SHALL be set to an URL corresponding to the `/.well-known/csaf/v2.1/provider-metadata.json` path.
   - Optionally, the property `maintained_from` can be set to an appropriate date in the future, if the service is not considered stable yet.
 
     > The transition officially starts at the date and time noted in the property `maintained_from` as this is the point in time
@@ -80,9 +80,9 @@ If a DNS path (cf. section [sec](#requirement-10-dns-path)) is used instead of t
 The following rules apply for the archival of CSAF document from a previous version:
 
 - This archive SHOULD be located in `/.well-known/csaf/archive/` and use the file name `v2.0.tar.zst`, `v2.0.tar.bz2` or `v2.0.tar.xz`.
-- The CSAF documents within the archive MUST be sorted into folders according to requirement 11 in section
+- The CSAF documents within the archive SHALL be sorted into folders according to requirement 11 in section
   [sec](#requirement-11-one-folder-per-year) and be accompanied by a hash according to requirement 18 [sec](#requirement-18-integrity).
-- The archive MUST be accompanied by a hash of the same algorithm.
+- The archive SHALL be accompanied by a hash of the same algorithm.
 - Existing signatures MAY also be included into the archive.
   It is NOT RECOMMENDED to renew the signatures in the archive unless the archive is updated with new content.
 
@@ -95,4 +95,4 @@ It is RECOMMENDED to use the following URLs during the process:
 - `/.well-known/csaf-aggregator/v2.0/aggregator.json` for a valid CSAF 2.0 `aggregator.json`
 - `/.well-known/csaf-aggregator/v2.1/aggregator.json` for a valid CSAF 2.1 `aggregator.json`
 
-A CSAF 2.1 aggregator MUST only sync and list CSAF 2.1 publishers and providers.
+A CSAF 2.1 aggregator SHALL only sync and list CSAF 2.1 publishers and providers.

--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -5,7 +5,7 @@ To ensure a common understanding of which fields are required in a given use cas
 Each subsection describes such a profile by describing necessary content for that specific use case and providing insights into its purpose.
 The value of `$.document.category` is used to identify a CSAF document's profile. The following rules apply:
 
-1. Each CSAF document MUST conform the **CSAF Base** profile.
+1. Each CSAF document SHALL conform the **CSAF Base** profile.
 2. Each profile extends the base profile "CSAF Base" - directly or indirect through another profile from the standard - by making additional
    fields from the standard mandatory.
    A profile can always add, but never subtract nor overwrite requirements defined in the profile it extends.
@@ -19,7 +19,7 @@ The value of `$.document.category` is used to identify a CSAF document's profile
 6. Values of `$.document.category` that do not match any of the values defined in section [sec](#profiles) of this standard SHALL be validated against
    the "CSAF Base" profile.
 7. Local or private profiles MAY exist and tools MAY choose to support them.
-8. If an official profile and a private profile exists, tools MUST validate against the official one from the standard.
+8. If an official profile and a private profile exists, tools SHALL validate against the official one from the standard.
 
 ## Profile 1: CSAF Base
 
@@ -29,7 +29,7 @@ Furthermore, it is the foundation all other profiles are build on.
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "CSAF Base":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - `$['$schema']`
   - `$.document.category`
   - `$.document.csaf_version`
@@ -55,7 +55,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 
 An issuing party might choose to prepend its `$.document.publisher.name` to a value in `$.document.category` that would otherwise be 
 intended to only be used by another profile, to state that the CSAF document does not use the profile associated with this value.
-In this case, the (case insensitive) string "CSAF" MUST be removed from the value.
+In this case, the (case insensitive) string "CSAF" SHALL be removed from the value.
 This SHOULD be done if the issuing party is unable or unwilling to use the value `csaf_base`, e.g. due to legal or cooperate identity reasons.
 
 > Both values `Example Company Security Advisory` and `Example Company security_advisory` in `$.document.category` are therefore valid 
@@ -73,7 +73,7 @@ the implications on its own products and infrastructure.
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Security Incident Response":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.document.notes` with at least one item which has a `category` of `description`, `details`, `general` or `summary`
 
@@ -92,7 +92,7 @@ This profile SHOULD be used to provide information which are **not related to a 
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Informational Advisory":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.document.notes` with at least one item which has a `category` of `description`, `details`, `general` or `summary`
 
@@ -109,7 +109,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   If there is any information that would reside in the element `$.vulnerabilities` the CSAF document SHOULD use another profile,
   e.g. "Security Advisory".
 
-If the element `$.product_tree` exists, a user MUST assume that all products mentioned are affected.
+If the element `$.product_tree` exists, a user SHALL assume that all products mentioned are affected.
 
 ## Profile 4: Security Advisory
 
@@ -117,7 +117,7 @@ This profile SHOULD be used to provide information which is related to vulnerabi
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Security Advisory":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   - `$.vulnerabilities` which lists all vulnerabilities.
@@ -155,7 +155,7 @@ See [cite](#VEX) for details.
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "VEX":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   - `$.vulnerabilities` which lists all vulnerabilities.
@@ -174,7 +174,7 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 - For each item in
   - `$.vulnerabilities[*].product_status.known_not_affected` an impact statement SHALL exist as machine readable flag
     in `$.vulnerabilities[*].flags` or as human readable justification in `$.vulnerabilities[*].threats`.
-    For the latter one, the `category` value for such a statement MUST be `impact` and the `details` field SHALL contain
+    For the latter one, the `category` value for such a statement SHALL be `impact` and the `details` field SHALL contain
     a description why the vulnerability cannot be exploited.
   - `$.vulnerabilities[*].product_status.known_affected` additional product specific information SHALL be provided
     in `$.vulnerabilities[*].remediations` as an action statement.
@@ -183,9 +183,9 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
     > The use of the categories `no_fix_planned` and `none_available` for an action statement is permitted.
 
   > Even though Product status lists Product IDs, Product Group IDs can be used in the `remediations` and `threats` object.
-  > However, it MUST be ensured that for each Product ID the required information according to its product status as stated
-  > in the two points above is available. This implies that all products with the status `known_not_affected` MUST have an
-  > impact statement and all products with the status `known_affected` MUST have additional product specific information
+  > However, it SHALL be ensured that for each Product ID the required information according to its product status as stated
+  > in the two points above is available. This implies that all products with the status `known_not_affected` SHALL have an
+  > impact statement and all products with the status `known_affected` SHALL have additional product specific information
   > regardless of whether that is referenced through the Product ID or a Product Group ID.
 
 - The value of `$.document.category` SHALL be `csaf_vex`.
@@ -201,7 +201,7 @@ The profile "Security Advisory" from section [sec](#profile-4-security-advisory)
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Deprecated Security Advisory":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   - `$.vulnerabilities` which lists all vulnerabilities.
@@ -217,21 +217,21 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
 
 ## Profile 7: Withdrawn
 
-This profile MUST be used for any CSAF document that is withdrawn. It MUST NOT be used for any superseded document.
+This profile SHALL be used for any CSAF document that is withdrawn. It SHALL NOT be used for any superseded document.
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Withdrawn":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.document.notes` with exactly one item using the `category` `description`
     describing the original content and the reasons for the withdrawal
 
     > Other items, such as a legal disclaimer, may exist alongside the required one.
 
-    The `title` MUST be `Reasoning for Withdrawal` for English or an unspecified document language.
+    The `title` SHALL be `Reasoning for Withdrawal` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.
   - `$.document.tracking.revision_history` with at least `2` entries.
-    Any previous items MUST NOT be removed.
+    Any previous items SHALL NOT be removed.
 
     > A CSAF document cannot be withdrawn during the initial release to its specified target group.
     > In such case, the CSAF document should not be released at all.
@@ -244,27 +244,27 @@ The CSAF document MAY link to additional information through `$.document.referen
 
 ## Profile 8: Superseded
 
-This profile MUST be used for any CSAF document that is superseded. It MUST NOT be used for any withdrawn document.
+This profile SHALL be used for any CSAF document that is superseded. It SHALL NOT be used for any withdrawn document.
 
 A CSAF document SHALL fulfill the following requirements to satisfy the profile "Superseded":
 
-- The following elements MUST exist and be valid:
+- The following elements SHALL exist and be valid:
   - all elements required by the profile "CSAF Base".
   - `$.document.notes` with exactly one item using the `category` `description`
 
       > Other items, such as a legal disclaimer, may exist alongside the required one.
 
-    The `title` MUST be `Reasoning for Supersession` for English or an unspecified document language.
+    The `title` SHALL be `Reasoning for Supersession` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.
   - `$.document.tracking.revision_history` with at least `2` entries.
-    Any previous items MUST NOT be removed.
+    Any previous items SHALL NOT be removed.
 
     > A CSAF document cannot be superseded during the initial release to its specified target group.
     > In such case, the CSAF document should not be released at all.
     > If it was shared previously in draft status, then the `$.document.tracking.status` is kept in `draft`.
 
   - `$.document.references` containing at least one item with `category` `external`
-    The `summary` MUST start with `Superseding Document` for English or an unspecified document language.
+    The `summary` SHALL start with `Superseding Document` for English or an unspecified document language.
     For any other language, it SHOULD be the language specific translation of that term.
 - The value of `$.document.category` SHALL be `csaf_superseded`.
 - The elements `$.product_tree` and `$.vulnerabilities` SHALL NOT exist.

--- a/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
+++ b/csaf_2.1/prose/edit/src/safety-security-and-data-protection.md
@@ -1,6 +1,6 @@
 # Safety, Security, and Data Protection Considerations
 
-All safety, security, and data protection requirements relevant to the context in which CSAF documents are used MUST be translated into,
+All safety, security, and data protection requirements relevant to the context in which CSAF documents are used SHALL be translated into,
 and consistently enforced through, CSAF implementations and processes.
 
 CSAF documents are based on JSON, thus the security considerations of [cite](#RFC8259) apply and are repeated here as service for the reader:

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-02-branches.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-02-branches.md
@@ -70,7 +70,7 @@ The value `product_name` indicates the name of the product.
 
 The value `product_version` indicates exactly a single version of the product.
 The value of the adjacent `name` property can be numeric or some other descriptor.
-However, it MUST NOT contain version ranges of any kind.
+However, it SHALL NOT contain version ranges of any kind.
 
 > It is recommended to enumerate versions wherever possible.
 > Nevertheless, the TC understands that this is sometimes impossible.
@@ -115,7 +115,7 @@ part of the product version as given by the vendor.
 
 ##### Branches Type - Name under Product Version
 
-If adjacent property `category` has the value `product_version`, the value of `name` MUST NOT contain version ranges of any kind.
+If adjacent property `category` has the value `product_version`, the value of `name` SHALL NOT contain version ranges of any kind.
 
 *Examples 1 (for `name` when using `product_version`):*
 
@@ -145,8 +145,8 @@ If adjacent property `category` has the value `product_version`, the value of `n
 
 ##### Branches Type - Name under Product Version Range{#branches-type---name-under-product-version-range}
 
-If adjacent property `category` has the value `product_version_range`, the value of `name` MUST contain version ranges.
-The value of MUST obey to exactly one of the following options:
+If adjacent property `category` has the value `product_version_range`, the value of `name` SHALL contain version ranges.
+The value of SHALL obey to exactly one of the following options:
 
 1. VErsion Range Specifier (VERS)
 
@@ -171,7 +171,7 @@ The value of MUST obey to exactly one of the following options:
 2. VERS-like Specifier (vls)
 
     This option uses only the `constraint` part from the VERS specification.
-    It MUST NOT have the `scheme` nor the `type` part.
+    It SHALL NOT have the `scheme` nor the `type` part.
     It is a fallback option and SHOULD NOT be used unless really necessary.
 
     > The reason for that is, that it is nearly impossible for tools to reliable determine whether a given version is in the range or not.

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-extensions.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-03-extensions.md
@@ -10,6 +10,6 @@ $defs:
   # ...
 ```
 
-Each item MUST comply with the rules for CSAF Extensions and validate against the
+Each item SHALL comply with the rules for CSAF Extensions and validate against the
 [CSAF Extension Content schema](https://docs.oasis-open.org/csaf/csaf/v2.1/schema/extension-content.json) as well as the schema given
 through its `$schema` property.

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-04-full-product-name.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-04-full-product-name.md
@@ -242,14 +242,14 @@ possibly with placeholders.
 > Often it is abbreviated as "MN", M/N" or "model no.".
 
 If a part of a model number of the component to identify is given,
-it MUST begin at the first and end at the last character position of the string representing the targeted component.
+it SHALL begin at the first and end at the last character position of the string representing the targeted component.
 The wildcard characters `?` (for a single character) and `*` (for zero or more characters) signal exclusion of characters at
 these positions from matching.
 This applies also to the first character.
-An unescaped `*` MUST be the only `*` wildcard in the string.
-As part of the model number, the special characters `?`, `*` and `\` MUST be escaped with `\`.
+An unescaped `*` SHALL be the only `*` wildcard in the string.
+As part of the model number, the special characters `?`, `*` and `\` SHALL be escaped with `\`.
 
-> Note: A backslash MUST be escaped itself in a JSON string.
+> Note: A backslash SHALL be escaped itself in a JSON string.
 
 *Examples 1:*
 
@@ -347,14 +347,14 @@ Any given serial number of value type `string` with at least `1` character repre
 possibly with placeholders.
 
 If a part of a serial number of the component to identify is given,
-it MUST begin at the first and end at the last character position of the string representing the targeted component.
+it SHALL begin at the first and end at the last character position of the string representing the targeted component.
 The wildcard characters `?` (for a single character) and `*` (for zero or more characters) signal exclusion of characters at
 these positions from matching.
 This applies also to the first character.
-An unescaped `*` MUST be the only `*` wildcard in the string.
-As part of the serial number, the special characters `?`, `*` and `\` MUST be escaped with `\`.
+An unescaped `*` SHALL be the only `*` wildcard in the string.
+As part of the serial number, the special characters `?`, `*` and `\` SHALL be escaped with `\`.
 
-> Note: A backslash MUST be escaped itself in a JSON string.
+> Note: A backslash SHALL be escaped itself in a JSON string.
 
 *Examples 1:*
 
@@ -396,14 +396,14 @@ of the component to identify - possibly with placeholders.
 > Sometimes this is also called "item number", "article number" or "product number".
 
 If a part of a stock keeping unit of the component to identify is given,
-it MUST begin at the first and end at the last character position of the string representing the targeted component.
+it SHALL begin at the first and end at the last character position of the string representing the targeted component.
 The wildcard characters `?` (for a single character) and `*` (for zero or more characters) signal exclusion of characters at
 these positions from matching.
 This applies also to the first character.
-An unescaped `*` MUST be the only `*` wildcard in the string.
-As part of the stock keeping unit, the special characters `?`, `*` and `\` MUST be escaped with `\`.
+An unescaped `*` SHALL be the only `*` wildcard in the string.
+As part of the stock keeping unit, the special characters `?`, `*` and `\` SHALL be escaped with `\`.
 
-> Note: A backslash MUST be escaped itself in a JSON string.
+> Note: A backslash SHALL be escaped itself in a JSON string.
 
 *Examples 1:*
 

--- a/csaf_2.1/prose/edit/src/schema-elements-01-defs-13-version.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-01-defs-13-version.md
@@ -12,7 +12,7 @@ There are two options how it can be used:
 - semantic versioning (preferred; according to the rules below)
 - integer versioning
 
-A CSAF document MUST use only one versioning system.
+A CSAF document SHALL use only one versioning system.
 
 *Examples 1:*
 
@@ -35,17 +35,17 @@ The regular expression for this type is:
 
 The following rules apply:
 
-1. Once a versioned document has been released, the contents of that version MUST NOT be modified.
-   Any modifications MUST be released as a new version.
+1. Once a versioned document has been released, the contents of that version SHALL NOT be modified.
+   Any modifications SHALL be released as a new version.
 2. Version zero (`0`) is for initial development before the `initial_release_date`.
-   The document status MUST be `draft`. Anything MAY change at any time. The document SHOULD NOT be considered stable.
+   The document status SHALL be `draft`. Anything MAY change at any time. The document SHOULD NOT be considered stable.
 3. Version `1` defines the initial release to the specified target group.
    Each new version where `$.document.tracking.status` is `final` has a version number incremented by one.
-4. Pre-release versions (document status `draft`) MUST carry the new version number.
+4. Pre-release versions (document status `draft`) SHALL carry the new version number.
    Sole exception is before the initial release (see rule 2).
    The combination of document status `draft` and version `1` MAY be used to indicate that the content is unlikely to change.
 5. Build metadata is never included in the version.
-6. Precedence MUST be determined by integer comparison.
+6. Precedence SHALL be determined by integer comparison.
 
 #### Version Type - Semantic Versioning{#version-type---semantic-versioning}
 
@@ -59,14 +59,14 @@ The goal of this structure is to provide additional information to the end user 
 The "public API" in regard to CSAF is the CSAF document with its structure and content.
 This results in the following rules:
 
-1. A normal version number MUST take the form `X.Y.Z` where `X`, `Y`, and `Z` are non-negative integers, and MUST NOT contain leading zeroes.
+1. A normal version number SHALL take the form `X.Y.Z` where `X`, `Y`, and `Z` are non-negative integers, and SHALL NOT contain leading zeroes.
    `X` is the major version, `Y` is the minor version, and `Z` is the patch version.
-   Each element MUST increase numerically.
+   Each element SHALL increase numerically.
    For instance: `1.9.0` -> `1.10.0` -> `1.11.0`.
-2. Once a versioned document has been released, the contents of that version MUST NOT be modified.
-   Any modifications MUST be released as a new version.
+2. Once a versioned document has been released, the contents of that version SHALL NOT be modified.
+   Any modifications SHALL be released as a new version.
 3. Major version zero (`0.y.z`) is for initial development before the `initial_release_date`.
-   The document status MUST be `draft`. Anything MAY change at any time.
+   The document status SHALL be `draft`. Anything MAY change at any time.
    The document SHOULD NOT be considered stable. Changes which would increment the major version according to rule 7 are
    tracked in this stage with (`0.y.z`) by incrementing the minor version `y` instead.
    Changes that would increment the minor or patch version according to rule 6 or 5 are both tracked in this stage with
@@ -74,16 +74,16 @@ This results in the following rules:
 4. Version `1.0.0` defines the initial release to the specified target group.
    The way in which the version number is incremented after this release is dependent on the content and structure of
    the document and how it changes.
-5. Patch version `Z` (`x.y.Z` | `x > 0`) MUST be incremented if only backwards compatible bug fixes are introduced.
+5. Patch version `Z` (`x.y.Z` | `x > 0`) SHALL be incremented if only backwards compatible bug fixes are introduced.
    A bug fix is defined as an internal change that fixes incorrect behavior.
 
    > In the context of the document this is the case e.g. for spelling mistakes.
 
-6. Minor version `Y` (`x.Y.z` | `x > 0`) MUST be incremented if the content of an existing element changes except for
+6. Minor version `Y` (`x.Y.z` | `x > 0`) SHALL be incremented if the content of an existing element changes except for
    those which are covered through rule 7.
-   It MUST be incremented if substantial new information are introduced or new elements are provided.
-   It MAY include patch level changes. Patch version MUST be reset to `0` when minor version is incremented.
-7. Major version `X` (`X.y.z` | `X > 0`) MUST be incremented if a new comparison with the end user's asset database is required.
+   It SHALL be incremented if substantial new information are introduced or new elements are provided.
+   It MAY include patch level changes. Patch version SHALL be reset to `0` when minor version is incremented.
+7. Major version `X` (`X.y.z` | `X > 0`) SHALL be incremented if a new comparison with the end user's asset database is required.
    This includes:
 
    * changes (adding, removing elements or modifying content) in `$.product_tree` or elements which contain `$.product_tree` in their path
@@ -98,10 +98,10 @@ This results in the following rules:
      * `$.vulnerabilities[*].product_status.known_not_affected`
 
    It MAY also include minor and patch level changes.
-   Patch and minor version MUST be reset to `0` when major version is incremented.
+   Patch and minor version SHALL be reset to `0` when major version is incremented.
 8. A pre-release version (document status `draft`) MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately
-   following the patch version. Identifiers MUST comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]`.
-   Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes.
+   following the patch version. Identifiers SHALL comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]`.
+   Identifiers SHALL NOT be empty. Numeric identifiers SHALL NOT include leading zeroes.
    Pre-release versions have a lower precedence than the associated normal version.
    A pre-release version indicates that the version is unstable and might not satisfy the intended compatibility requirements as
    denoted by its associated normal version.
@@ -116,10 +116,10 @@ This results in the following rules:
    1.0.0-x.7.z.92
    ```
 
-9. Pre-release MUST NOT be included if `$.document.tracking.status` is `final`.
+9. Pre-release SHALL NOT be included if `$.document.tracking.status` is `final`.
 10. Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following
-    the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]`.
-    Identifiers MUST NOT be empty. Build metadata MUST be ignored when determining version precedence.
+    the patch or pre-release version. Identifiers SHALL comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]`.
+    Identifiers SHALL NOT be empty. Build metadata SHALL be ignored when determining version precedence.
     Thus two versions that differ only in the build metadata, have the same precedence.
 
     *Examples 2:*
@@ -133,7 +133,7 @@ This results in the following rules:
 
 11. Precedence refers to how versions are compared to each other when ordered.
 
-    1. Precedence MUST be calculated by separating the version into major, minor,
+    1. Precedence SHALL be calculated by separating the version into major, minor,
        patch and pre-release identifiers in that order (Build metadata does not figure into precedence).
     2. Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows:
        Major, minor, and patch versions are always compared numerically.
@@ -153,7 +153,7 @@ This results in the following rules:
        ```
 
     4. Precedence for two pre-release versions with the same major, minor,
-       and patch version MUST be determined by comparing each dot separated identifier from left to right until a difference is found as follows:
+       and patch version SHALL be determined by comparing each dot separated identifier from left to right until a difference is found as follows:
 
        1. Identifiers consisting of only digits are compared numerically.
        2. Identifiers with letters or hyphens are compared lexically in ASCII sort order.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-02-document.md
@@ -141,7 +141,7 @@ Therefore, the Sharing Group MAY also be used to convey special TLP restrictions
     Releasable to NATO countries
 ```
 
-> Note that for such restrictions the Sharing Group Name MUST exist and all participants MUST know the associated
+> Note that for such restrictions the Sharing Group Name SHALL exist and all participants SHALL know the associated
 > Sharing Group IDs to allow for automation.
 
 ##### Document Property - Distribution - Sharing Group{#document-property---distribution-sharing-group}
@@ -175,7 +175,7 @@ e.g. during a Multi-Party Coordinated Vulnerability Disclosure case.
 > Otherwise, the consequences of adding or removing parties from a case and the implications to other cases have to be considered.
 
 The ID SHOULD NOT change throughout different CSAF documents, if the same sharing group is addressed.
-It MUST differ if a different sharing group is addressed.
+It SHALL differ if a different sharing group is addressed.
 
 > It is assumed that the ID is globally unique, if constructed according to the specification for UUID Version 4.
 
@@ -190,7 +190,7 @@ Therefore, they are reserved for implementation-specific situations:
   > For example, the system uses the UUID as an indication whether a user allowed to see the document.
   > The security considerations from [cite](#RFC9562) should be reflected on.
 
-- A system MAY use the Nil UUID for CSAF documents that MUST NOT be shared.
+- A system MAY use the Nil UUID for CSAF documents that SHALL NOT be shared.
 
   > For example, the CSAF document is just being drafted and the accidental leakage should be prevented.
 
@@ -285,10 +285,10 @@ corresponding to IETF BCP 47 / RFC 5646.
 
 License expression (`license_expression`) of value type `string` with `1` or more characters contains the
 SPDX license expression for the CSAF document.
-It MUST NOT contain a license text.
+It SHALL NOT contain a license text.
 See Annex B of [cite](#SPDX301) for details.
-The `DocumentRef` part given in that ABNF MUST NOT be used in CSAF.
-Any SPDX license identifier not from the official SPDX license identifier list MUST contain a prefix of the form
+The `DocumentRef` part given in that ABNF SHALL NOT be used in CSAF.
+Any SPDX license identifier not from the official SPDX license identifier list SHALL contain a prefix of the form
 `LicenseRef-<license-inventoring-entity>-` where `<license-inventoring-entity>` is replaced with a unique name for the
 entity that provided the database this license identifier was found in.
 Unless otherwise previously established, the unique name SHOULD be a domain name.
@@ -297,17 +297,17 @@ The same applies for `AdditionRef-` identifiers.
 In addition, the following rules apply:
 
 - License identification:
-  1. The SPDX License List Version 3.26.0 or later MUST be consulted to identify the appropriate SPDX license identifier or
+  1. The SPDX License List Version 3.26.0 or later SHALL be consulted to identify the appropriate SPDX license identifier or
      construct an expression based on a SPDX license identifier.
      Deprecated license identifiers SHOULD NOT be used.
-     SPDX license identifiers that were deprecated before the version listed above MUST NOT be used.
+     SPDX license identifiers that were deprecated before the version listed above SHALL NOT be used.
 
      > The list is available at <https://spdx.org/licenses/>.
      > It includes also the exceptions.
 
   2. If the appropriate license identifier is not found in the SPDX License List or expression been possible to constructed,
-     the license database AboutCode's "ScanCode LicenseDB" MUST be consulted as a next step.
-     License identifiers from this database MUST use the prefix `LicenseRef-scancode-`.
+     the license database AboutCode's "ScanCode LicenseDB" SHALL be consulted as a next step.
+     License identifiers from this database SHALL use the prefix `LicenseRef-scancode-`.
 
      > The database is currently available at <https://scancode-licensedb.aboutcode.org/>.
 
@@ -315,8 +315,8 @@ In addition, the following rules apply:
   3. If the first two steps did not result in an appropriate license identifier or expression and no extant identifier was found,
      the issuing party SHALL create their own license identifier following the rules above.
      The license identifier SHOULD contain the version number of the license.
-     The license text MUST be made available through exactly one document note using the `category` `legal_disclaimer`.
-     The `title` MUST be `License` for English or an unspecified document language.
+     The license text SHALL be made available through exactly one document note using the `category` `legal_disclaimer`.
+     The `title` SHALL be `License` for English or an unspecified document language.
      For any other language, it SHOULD be the language specific translation of that term.
 
 - License similarity:
@@ -357,7 +357,7 @@ Document notes (`notes`) of value type Notes Type (`notes_t`) holds notes associ
     # ...
 ```
 
-The following combinations of `category` and `title` have a special meaning and MUST be used as stated below:
+The following combinations of `category` and `title` have a special meaning and SHALL be used as stated below:
 
 \columns=15%,35%,
 
@@ -370,7 +370,7 @@ The following combinations of `category` and `title` have a special meaning and 
 
 Table: Requirements for combinations of `category` and `title` that have a special meaning.{#tab:special-combinations-of-category-and-title}
 
-If a note is specific to a product or product group it MUST be bound via the `group_ids` respectively `product_ids`.
+If a note is specific to a product or product group it SHALL be bound via the `group_ids` respectively `product_ids`.
 
 #### Document Property - Publisher
 
@@ -573,7 +573,7 @@ Document references (`references`) of value type References Type (`references_t`
 Source language (`source_lang`) of value type Language Type (`lang_t`) identifies if this copy of the document is
 a translation then the value of this property describes from which language this document was translated.
 
-The property MUST be present for any CSAF document with the value `translator` in `$.document.publisher.category`.
+The property SHALL be present for any CSAF document with the value `translator` in `$.document.publisher.category`.
 The property SHALL NOT be present if the document was not translated.
 
 If an issuing party publishes a CSAF document with the same content in more than one language,
@@ -716,7 +716,7 @@ It SHALL NOT start or end with a white space and SHALL NOT contain a newline seq
 
 The ID is a simple label that provides for a wide range of numbering values, types, and schemes.
 Its value SHOULD be assigned and maintained by the original document issuing authority.
-It MUST be unique for that organization.
+It SHALL be unique for that organization.
 
 *Examples 1:*
 
@@ -741,8 +741,8 @@ when this document was first released to the specified target group.
 > For `TLP:GREEN` and higher, this is the timestamp when it was first made available to the specific group.
 > Note that the initial release date does not change after the initial release even if the document is later on released to a broader audience.
 
-If the timestamp of the initial release date was set incorrectly, it MUST be corrected.
-This change MUST be tracked with a new entry in the revision history.
+If the timestamp of the initial release date was set incorrectly, it SHALL be corrected.
+This change SHALL be tracked with a new entry in the revision history.
 
 ##### Document Property - Tracking - Revision History
 
@@ -793,12 +793,12 @@ The Number (`number`) has value type Version (`version_t`).
 The Summary of the revision (`summary`) of value type `string` with `1` or more characters holds a single non-empty string representing
 a short description of the changes.
 
-Each Revision item which has a `number` of `0` or `0.y.z` MUST be removed from the document if the document status is `final`.
+Each Revision item which has a `number` of `0` or `0.y.z` SHALL be removed from the document if the document status is `final`.
 Versions of the document which are pre-release SHALL NOT have its own revision item.
-All changes MUST be tracked in the item for the next release version.
+All changes SHALL be tracked in the item for the next release version.
 Build metadata SHOULD NOT be included in the `number` of any revision item.
 
-Any issuing party using a CSAF document as basis and modifying it MUST create a new revision history tracking the modified document.
+Any issuing party using a CSAF document as basis and modifying it SHALL create a new revision history tracking the modified document.
 This applies especially to CSAF multiplier.
 
 > The new revision history (and consequently the corresponding ensures `current_release_date`) that the CSAF document can be found
@@ -808,7 +808,7 @@ This applies especially to CSAF multiplier.
 ##### Document Property - Tracking - Status
 
 Document status (`status`) of value type `string` and `enum` defines the draft status of the document.
-The value MUST be one of the following:
+The value SHALL be one of the following:
 
 ```
     draft
@@ -825,7 +825,7 @@ This SHOULD be used if the issuing party expects no, slow or few changes.
 
 The value `interim` indicates, that the issuing party expects rapid updates.
 This SHOULD be used if the expected rate of release for this document is significant higher than for other documents.
-Once the rate slows down it MUST be changed to `final`. This MAY be done in a patch version.
+Once the rate slows down it SHALL be changed to `final`. This MAY be done in a patch version.
 
 > This is extremely useful for downstream vendors to constantly inform the end users about ongoing investigation.
 > It can be used as an indication to pull the CSAF document more frequently.

--- a/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
+++ b/csaf_2.1/prose/edit/src/schema-elements-02-props-04-vulnerabilities.md
@@ -192,7 +192,7 @@ contains a list of dates of first known exploitations.
 Every First known exploitation date item of value type `object` with the two mandatory properties Date of the information (`date`) and
 Date of the exploitation (`exploitation_date`) holds at least `3` properties and contains information on when this vulnerability was
 first known to be exploited in the wild in the products specified.
-At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) MUST be present to state for which products or
+At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) SHALL be present to state for which products or
 product groups this date is applicable.
 
 > This information can be helpful to determine the risk of compromise.
@@ -243,7 +243,7 @@ List of flags (`flags`) of value type `array` with `1` or more unique items (a s
 Every Flag item of value type `object` with the mandatory property Label (`label`) contains product specific information in regard to
 this vulnerability as a single machine readable flag.
 For example, this could be a machine readable justification code why a product is not affected.
-At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) MUST be present to state for which products or
+At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) SHALL be present to state for which products or
 product groups this flag is applicable.
 
 > These flags enable the receiving party to automate the selection of actions to take.
@@ -281,7 +281,7 @@ Label of the flag (`label`) of value type `string` and `enum` specifies the mach
 
 The given values reflect the VEX not affected justifications.
 See [cite](#VEX-Justification) for more details.
-The values MUST be used as follows:
+The values SHALL be used as follows:
 
 - `component_not_present`: The software is not affected because the vulnerable component is not in the product.
 - `vulnerable_code_not_present`: The product is not affected because the code underlying the vulnerability is not present in the product.
@@ -707,7 +707,7 @@ Vulnerability notes (`notes`) of value type Notes Type (`notes_t`) holds notes a
   # ...
 ```
 
-The following combinations of `category` and `title` have a special meaning and MUST be used as stated below:
+The following combinations of `category` and `title` have a special meaning and SHALL be used as stated below:
 
 \columns=12%,24%,
 
@@ -719,7 +719,7 @@ The following combinations of `category` and `title` have a special meaning and 
 
 Table: Combinations of `category` and `title` with special meaning.{#vulnerabilities-property-notes-tab-1}
 
-If a note is specific to a product or product group it MUST be bound via the `group_ids` respectively `product_ids`.
+If a note is specific to a product or product group it SHALL be bound via the `group_ids` respectively `product_ids`.
 
 #### Vulnerabilities Property - Product Status{#vulnerabilities-property-product-status}
 
@@ -822,7 +822,7 @@ The individual properties form the following product status groups:
   ```
 
 As the aforementioned product status groups contradict each other,
-the sets formed by the contradicting groups within one vulnerability item MUST be pairwise disjoint.
+the sets formed by the contradicting groups within one vulnerability item SHALL be pairwise disjoint.
 
 > Note: An issuer might recommend (`$.vulnerabilities[*].product_status.recommended`) a product version from any group - also from the affected group,
 > i.e. if it was discovered that fixed versions introduce a more severe vulnerability.
@@ -863,7 +863,7 @@ List of remediations (`remediations`) of value type `array` with `1` or more Rem
 
 Every Remediation item of value type `object` with the two mandatory properties Category (`category`) and
 Details (`details`) specifies details on how to handle (and presumably, fix) a vulnerability.
-At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) MUST be present to state for which
+At least one of the optional elements Group IDs (`group_ids`) and Product IDs (`product_ids`) SHALL be present to state for which
 products or product groups this remediation is applicable.
 
 In addition, any Remediation MAY expose the six optional properties Date (`date`), Entitlements (`entitlements`), Group IDs (`group_ids`),
@@ -938,7 +938,7 @@ This is often the case when a product has been orphaned, declared end-of-life, o
 The text in field `details` SHOULD contain details about why there will be no fix issued.
 
 Some category values contradict each other and thus are mutually exclusive per product.
-Therefore, such a combination MUST NOT be used in the list of remediations for the same product.
+Therefore, such a combination SHALL NOT be used in the list of remediations for the same product.
 This is independent from whether the product is referenced directly or indirectly through a product group.
 The following tables shows the allowed and prohibited combinations:
 
@@ -958,7 +958,7 @@ The following tables shows the allowed and prohibited combinations:
 Table: Remediation Combinations{#vulnerabilities-property-remediations-category-tab-1}
 
 Some category values contradict certain product status groups.
-Therefore, such a combination MUST NOT exist in a vulnerability item for the same product.
+Therefore, such a combination SHALL NOT exist in a vulnerability item for the same product.
 This is independent from whether the product is referenced directly or indirectly through a product group.
 The following tables shows the allowed, discouraged and prohibited combinations:
 
@@ -1093,7 +1093,7 @@ Valid values are:
     zone
 ```
 
-The values MUST be used as follows:
+The values SHALL be used as follows:
 
 - `none`: No restart required.
 - `vulnerable_component`: Only the vulnerable component (as given by the elements of `product_ids` or `group_ids` in the current remediation item)

--- a/csaf_2.1/prose/edit/src/tests-01-mandatory.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mandatory.md
@@ -1,4 +1,4 @@
 ## Mandatory Tests
 
-Mandatory tests MUST NOT fail at a valid CSAF document.
-A program MUST handle a test failure as an error.
+Mandatory tests SHALL NOT fail at a valid CSAF document.
+A program SHALL handle a test failure as an error.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-01-missing-definition-of-product-id.md
@@ -1,7 +1,7 @@
 ### Missing Definition of Product ID
 
 For each element of type `$['$defs'].product_id_t` which is not inside a Full Product Name (type: `full_product_name_t`) and
-therefore reference an element within the `product_tree` it MUST be tested that the Full Product Name element with the matching `product_id` exists.
+therefore reference an element within the `product_tree` it SHALL be tested that the Full Product Name element with the matching `product_id` exists.
 The same applies for all items of elements of type `$['$defs'].products_t`.
 
 The relevant paths for this test are:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-02-multiple-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-02-multiple-definition-of-product-id.md
@@ -1,7 +1,7 @@
 ### Multiple Definition of Product ID
 
 For each Product ID (type `$['$defs'].product_id_t`) in Full Product Name elements (type: `$['$defs'].full_product_name_t`) it
-MUST be tested that the `product_id` was not already defined within the same document.
+SHALL be tested that the `product_id` was not already defined within the same document.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-03-circular-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-03-circular-definition-of-product-id.md
@@ -1,7 +1,7 @@
 ### Circular Definition of Product ID
 
 For each new defined Product ID (type `$['$defs'].product_id_t`) in items of product paths (`$.product_tree.product_paths`) it
-MUST be tested that the `product_id` does not end up in a circle.
+SHALL be tested that the `product_id` does not end up in a circle.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-04-missing-definition-of-product-group-id.md
@@ -1,7 +1,7 @@
 ### Missing Definition of Product Group ID
 
 For each element of type `$['$defs'].product_group_id_t` which is not inside a Product Group (`$.product_tree.product_groups[*]`) and
-therefore reference an element within the `product_tree` it MUST be tested that the Product Group element with the matching `group_id` exists.
+therefore reference an element within the `product_tree` it SHALL be tested that the Product Group element with the matching `group_id` exists.
 The same applies for all items of elements of type `$['$defs'].product_groups_t`.
 
 The relevant paths for this test are:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-05-multiple-definition-of-product-group-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-05-multiple-definition-of-product-group-id.md
@@ -1,7 +1,7 @@
 ### Multiple Definition of Product Group ID
 
 For each Product Group ID (type `$['$defs'].product_group_id_t`) Product Group elements (`$.product_tree.product_groups[*]`) it
-MUST be tested that the `group_id` was not already defined within the same document.
+SHALL be tested that the `group_id` was not already defined within the same document.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-06-contradicting-product-status.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-06-contradicting-product-status.md
@@ -1,8 +1,8 @@
 ### Contradicting Product Status
 
-For each item in `$.vulnerabilities` it MUST be tested that the same Product ID is not a member of contradicting
+For each item in `$.vulnerabilities` it SHALL be tested that the same Product ID is not a member of contradicting
 product status groups (see section [sec](#vulnerabilities-property-product-status)).
-The sets formed by the contradicting groups within one vulnerability item MUST be pairwise disjoint.
+The sets formed by the contradicting groups within one vulnerability item SHALL be pairwise disjoint.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-07-multiple-scores-with-same-version-per-product.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-07-multiple-scores-with-same-version-per-product.md
@@ -1,6 +1,6 @@
 ### Multiple Scores with Same Version per Product
 
-For each item in `$.vulnerabilities` it MUST be tested that the same Product ID is not a member of more than one CVSS vector with the same version and same source.
+For each item in `$.vulnerabilities` it SHALL be tested that the same Product ID is not a member of more than one CVSS vector with the same version and same source.
 
 > Different sources might assign different scores for the same product.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-08-invalid-cvss.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-08-invalid-cvss.md
@@ -1,6 +1,6 @@
 ### Invalid CVSS
 
-It MUST be tested that the given CVSS object is valid according to the referenced schema.
+It SHALL be tested that the given CVSS object is valid according to the referenced schema.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-09-invalid-cvss-computation.md
@@ -1,6 +1,6 @@
 ### Invalid CVSS Computation
 
-It MUST be tested that the given CVSS object has the values computed correctly according to the definition.
+It SHALL be tested that the given CVSS object has the values computed correctly according to the definition.
 
 > The `vectorString` SHOULD take precedence.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-10-inconsistent-cvss.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-10-inconsistent-cvss.md
@@ -1,6 +1,6 @@
 ### Inconsistent CVSS
 
-It MUST be tested that the given CVSS properties do not contradict the CVSS vector.
+It SHALL be tested that the given CVSS properties do not contradict the CVSS vector.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-11-cwe.md
@@ -1,7 +1,7 @@
 ### CWE{#mandatory-tests--cwe}
 
-For each CWE it MUST be tested that the given CWE exists and is valid in the `version` provided.
-Any `id` that refers to a CWE Category or View MUST fail the test.
+For each CWE it SHALL be tested that the given CWE exists and is valid in the `version` provided.
+Any `id` that refers to a CWE Category or View SHALL fail the test.
 
 > A list of all CWE release archives is available at [cite](#CWE-A).
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-12-language.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-12-language.md
@@ -1,6 +1,6 @@
 ### Language
 
-For each element of type `$['$defs'].lang_t` it MUST be tested that the language code is valid and exists.
+For each element of type `$['$defs'].lang_t` it SHALL be tested that the language code is valid and exists.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-13-purl.md
@@ -1,6 +1,6 @@
 ### PURL
 
-It MUST be tested that all given PURLs are valid.
+It SHALL be tested that all given PURLs are valid.
 
 > It is not sufficient to just test against the `pattern` provided in section [sec](#full-product-name-type-product-identification-helper-purls).
 > The PURL must be validated against the requirements in the [cite](#ECMA-427) specification and the additional constraints given in

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-14-sorted-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-14-sorted-revision-history.md
@@ -1,8 +1,8 @@
 ### Sorted Revision History
 
-It MUST be tested that the value of `number` of items of the revision history are sorted ascending when the items are sorted
+It SHALL be tested that the value of `number` of items of the revision history are sorted ascending when the items are sorted
 ascending by `date` and as a second level criteria `number`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 In order to create consistent results in the case of mixed integer and semantic versioning (failing test
 [sec](#mixed-integer-and-semantic-versioning)), implementations SHALL map items with integer versioning to

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-15-translator.md
@@ -1,6 +1,6 @@
 ### Translator
 
-It MUST be tested that `$.document.source_lang` is present and set if the value `translator` is used for `$.document.publisher.category`.
+It SHALL be tested that `$.document.source_lang` is present and set if the value `translator` is used for `$.document.publisher.category`.
 A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
 not being present at all.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-16-latest-document-version.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-16-latest-document-version.md
@@ -1,8 +1,8 @@
 ### Latest Document Version
 
-It MUST be tested that document version has the same value as the `number` in the last item of the revision history when
+It SHALL be tested that document version has the same value as the `number` in the last item of the revision history when
 it is sorted ascending by `date` and as a second level criteria `number`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 Build metadata is ignored in the comparison.
 Any pre-release part is also ignored if the document status is `draft`.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-17-document-status-draft.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-17-document-status-draft.md
@@ -1,6 +1,6 @@
 ### Document Status Draft
 
-It MUST be tested that document status is `draft` if the document version is `0` or `0.y.z` or contains the pre-release part.
+It SHALL be tested that document status is `draft` if the document version is `0` or `0.y.z` or contains the pre-release part.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-18-released-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-18-released-revision-history.md
@@ -1,6 +1,6 @@
 ### Released Revision History
 
-It MUST be tested that no item of the revision history has a `number` of `0` or `0.y.z` when the document status is `final` or `interim`.
+It SHALL be tested that no item of the revision history has a `number` of `0` or `0.y.z` when the document status is `final` or `interim`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-19-revision-history-entries-for-pre-release-versions.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-19-revision-history-entries-for-pre-release-versions.md
@@ -1,6 +1,6 @@
 ### Revision History Entries for Pre-release Versions
 
-It MUST be tested that no item of the revision history has a `number` which includes pre-release information.
+It SHALL be tested that no item of the revision history has a `number` which includes pre-release information.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-20-non-draft-document-version.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-20-non-draft-document-version.md
@@ -1,6 +1,6 @@
 ### Non-Draft Document Version
 
-It MUST be tested that document version does not contain a pre-release part if the document status is `final` or `interim`.
+It SHALL be tested that document version does not contain a pre-release part if the document status is `final` or `interim`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-21-missing-item-in-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-21-missing-item-in-revision-history.md
@@ -1,6 +1,6 @@
 ### Missing Item in Revision History
 
-It MUST be tested that items of the revision history do not omit a version number when the items are sorted ascending by `date` and as a second level criteria `number`.
+It SHALL be tested that items of the revision history do not omit a version number when the items are sorted ascending by `date` and as a second level criteria `number`.
 
 > Dates are used as primary sorting criteria as they correspond to publications.
 > The assigned numbers might be incorrect.
@@ -10,10 +10,10 @@ It MUST be tested that items of the revision history do not omit a version numbe
 > Nevertheless, the newly added item created to release the corrected version of the document to the intended target group will have a newer
 > timestamp and therefore show up correctly at CSAF consumers.
 
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
-The error message MUST differentiate between a version number not present at all and one that is missing in the sorted list.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
+The error message SHALL differentiate between a version number not present at all and one that is missing in the sorted list.
 In the case of semantic versioning, this applies only to the Major version.
-It MUST also be tested that the first item in such a sorted list has either the version number 0 or 1 in the case of integer versioning or
+It SHALL also be tested that the first item in such a sorted list has either the version number 0 or 1 in the case of integer versioning or
 a Major version of 0 or 1 in the case of semantic versioning.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-22-multiple-definition-in-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-22-multiple-definition-in-revision-history.md
@@ -1,6 +1,6 @@
 ### Multiple Definition in Revision History
 
-It MUST be tested that items of the revision history do not contain the same version number.
+It SHALL be tested that items of the revision history do not contain the same version number.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-23-multiple-use-of-same-cve.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-23-multiple-use-of-same-cve.md
@@ -1,6 +1,6 @@
 ### Multiple Use of Same CVE
 
-It MUST be tested that a CVE is not used in multiple vulnerability items.
+It SHALL be tested that a CVE is not used in multiple vulnerability items.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-24-multiple-definition-in-involvements.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-24-multiple-definition-in-involvements.md
@@ -1,6 +1,6 @@
 ### Multiple Definition in Involvements
 
-It MUST be tested that items of the list of involvements do not contain the same `party` regardless of its `status` more than once at any `date`.
+It SHALL be tested that items of the list of involvements do not contain the same `party` regardless of its `status` more than once at any `date`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-25-multiple-use-of-same-hash-algorithm.md
@@ -1,6 +1,6 @@
 ### Multiple Use of Same Hash Algorithm
 
-It MUST be tested that the same hash algorithm is not used multiple times in one item of file hashes.
+It SHALL be tested that the same hash algorithm is not used multiple times in one item of file hashes.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-26-prohibited-document-category-name.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-26-prohibited-document-category-name.md
@@ -1,6 +1,6 @@
 ### Prohibited Document Category Name
 
-It MUST be tested that the document category is not equal to the (case insensitive) name (without the prefix `csaf_`) or
+It SHALL be tested that the document category is not equal to the (case insensitive) name (without the prefix `csaf_`) or
 value of any other profile than "CSAF Base".
 Any occurrences of dash, hyphen, minus, underscore, and white space characters are removed from the values on both sides before the
 case insensitive match.
@@ -21,10 +21,10 @@ case insensitive match.
 > * Fullwidth low line
 
 This applies for both, the comparison against the name and value.
-Also the value MUST NOT start with the reserved prefix `csaf_` except if the value is exactly `csaf_base`.
+Also the value SHALL NOT start with the reserved prefix `csaf_` except if the value is exactly `csaf_base`.
 
 This test does only apply for CSAF documents with the profile "CSAF Base".
-Therefore, it MUST be skipped if the document category matches one of the values defined for the profile other than "CSAF Base".
+Therefore, it SHALL be skipped if the document category matches one of the values defined for the profile other than "CSAF Base".
 
 > For CSAF 2.1, the test must be skipped for the following values in `$.document.category`:
 >

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-01-document-notes-for-informational-advisory-and-security-incident-response.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-01-document-notes-for-informational-advisory-and-security-incident-response.md
@@ -1,6 +1,6 @@
 #### Document Notes{#document-notes-for-informational-advisory-and-security-incident-response}
 
-It MUST be tested that at least one item in `$.document.notes` exists which has a `category` of `description`, `details`, `general` or `summary`.
+It SHALL be tested that at least one item in `$.document.notes` exists which has a `category` of `description`, `details`, `general` or `summary`.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-02-document-references-for-informational-advisory-and-security-incident-response.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-02-document-references-for-informational-advisory-and-security-incident-response.md
@@ -1,6 +1,6 @@
 #### Document References{#document-references-for-informational-advisory-and-security-incident-response}
 
-It MUST be tested that at least one item in `$.document.references` exists that has links to an `external` source.
+It SHALL be tested that at least one item in `$.document.references` exists that has links to an `external` source.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-03-vulnerabilities-for-informational-advisory.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-03-vulnerabilities-for-informational-advisory.md
@@ -1,6 +1,6 @@
 #### Vulnerabilities{#vulnerabilities-for-informational-advisory}
 
-It MUST be tested that the element `$.vulnerabilities` does not exist.
+It SHALL be tested that the element `$.vulnerabilities` does not exist.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-04-product-tree-for-security-advisory-vex-deprecated-security-advisory.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-04-product-tree-for-security-advisory-vex-deprecated-security-advisory.md
@@ -1,6 +1,6 @@
 #### Product Tree{#product-tree-for-security-advisory-vex-deprecated-security-advisory}
 
-It MUST be tested that the element `$.product_tree` exists.
+It SHALL be tested that the element `$.product_tree` exists.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-05-vulnerability-notes.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-05-vulnerability-notes.md
@@ -1,6 +1,6 @@
 #### Vulnerability Notes
 
-For each item in `$.vulnerabilities` it MUST be tested that the element `notes` exists.
+For each item in `$.vulnerabilities` it SHALL be tested that the element `notes` exists.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-06-product-status.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-06-product-status.md
@@ -1,6 +1,6 @@
 #### Product Status
 
-For each item in `$.vulnerabilities` it MUST be tested that the element `product_status` exists.
+For each item in `$.vulnerabilities` it SHALL be tested that the element `product_status` exists.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-07-vex-product-status.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-07-vex-product-status.md
@@ -1,6 +1,6 @@
 #### VEX Product Status
 
-For each item in `$.vulnerabilities` it MUST be tested that at least one of the elements `fixed`, `known_affected`, `known_not_affected`,
+For each item in `$.vulnerabilities` it SHALL be tested that at least one of the elements `fixed`, `known_affected`, `known_not_affected`,
 or `under_investigation` is present in `product_status`.
 
 The relevant value for `$.document.category` is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-08-vulnerability-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-08-vulnerability-id.md
@@ -1,8 +1,8 @@
 #### Vulnerability ID
 
-For each item in `$.vulnerabilities` it MUST be tested that at least one of the elements `cve` or `ids` is present.
+For each item in `$.vulnerabilities` it SHALL be tested that at least one of the elements `cve` or `ids` is present.
 If no `cve` is present and all items in `ids` contain `group_ids` or `product_ids`,
-it MUST be tested that each product mentioned in `product_status[*][*]` is assigned at least one item in `ids`.
+it SHALL be tested that each product mentioned in `product_status[*][*]` is assigned at least one item in `ids`.
 This is independent from whether the product is referenced directly or indirectly through a product group.
 
 > Without this rule, a product could be mentioned in a VEX that has no clear reference to a vulnerability identifier.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-09-impact-statement.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-09-impact-statement.md
@@ -1,8 +1,8 @@
 #### Impact Statement
 
-For each item in `$.vulnerabilities[*].product_status.known_not_affected` it MUST be tested that
+For each item in `$.vulnerabilities[*].product_status.known_not_affected` it SHALL be tested that
 a corresponding impact statement exist in `$.vulnerabilities[*].flags` or `$.vulnerabilities[*].threats`.
-For the latter one, the `category` value for such a statement MUST be `impact`.
+For the latter one, the `category` value for such a statement SHALL be `impact`.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-10-action-statement.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-10-action-statement.md
@@ -1,6 +1,6 @@
 #### Action Statement
 
-For each item in `$.vulnerabilities[*].product_status.known_affected` it MUST be tested that
+For each item in `$.vulnerabilities[*].product_status.known_affected` it SHALL be tested that
 a corresponding action statement exist in `$.vulnerabilities[*].remediations`.
 
 The relevant value for `$.document.category` is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-11-vulnerabilities-for-security-advisory-or-vex.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-11-vulnerabilities-for-security-advisory-or-vex.md
@@ -1,6 +1,6 @@
 #### Vulnerabilities{#vulnerabilities-for-security-advisory-or-vex}
 
-It MUST be tested that the element `$.vulnerabilities` exists.
+It SHALL be tested that the element `$.vulnerabilities` exists.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-12-affected-products.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-12-affected-products.md
@@ -1,6 +1,6 @@
 #### Affected Products
 
-For each item in `$.vulnerabilities` it MUST be tested that the element `product_status/known_affected` exists.
+For each item in `$.vulnerabilities` it SHALL be tested that the element `product_status/known_affected` exists.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-13-corresponding-affected-products.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-13-corresponding-affected-products.md
@@ -1,7 +1,7 @@
 #### Corresponding Affected Products
 
 For each product listed in the product status group fixed in any vulnerability,
-it MUST be tested that a corresponding version of the product is listed as affected in the same vulnerability.
+it SHALL be tested that a corresponding version of the product is listed as affected in the same vulnerability.
 
 > For a product path including the `installed_with` relationship the product path leading to but not including the relationship
 > is a corresponding product.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-14-document-notes-for-withdrawn-and-superseded.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-14-document-notes-for-withdrawn-and-superseded.md
@@ -1,6 +1,6 @@
 #### Document Notes{#document-notes-for-withdrawn-and-superseded}
 
-It MUST be tested that at least one item in `$.document.notes` exists which has a `category` of `description`.
+It SHALL be tested that at least one item in `$.document.notes` exists which has a `category` of `description`.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-15-product-tree-for-withdrawn-and-superseded.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-15-product-tree-for-withdrawn-and-superseded.md
@@ -1,6 +1,6 @@
 #### Product Tree{#product-tree-for-withdrawn-and-superseded}
 
-It MUST be tested that the element `$.product_tree` does not exist.
+It SHALL be tested that the element `$.product_tree` does not exist.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-16-revision-history-for-withdrawn-and-superseded.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-16-revision-history-for-withdrawn-and-superseded.md
@@ -1,6 +1,6 @@
 #### Revision History{#revision-history-for-withdrawn-and-superseded}
 
-It MUST be tested that the revision history contains at least two entries.
+It SHALL be tested that the revision history contains at least two entries.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-17-reasoning-for-withdrawal.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-17-reasoning-for-withdrawal.md
@@ -1,8 +1,8 @@
 #### Reasoning for Withdrawal
 
-If the document language is English or unspecified, it MUST be tested that exactly one item in document notes exists
+If the document language is English or unspecified, it SHALL be tested that exactly one item in document notes exists
 that has the title `Reasoning for Withdrawal`.
-The `category` of this item MUST be `description`.
+The `category` of this item SHALL be `description`.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-18-reasoning-for-supersession.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-18-reasoning-for-supersession.md
@@ -1,8 +1,8 @@
 #### Reasoning for Supersession
 
-If the document language is English or unspecified, it MUST be tested that exactly one item in document notes exists
+If the document language is English or unspecified, it SHALL be tested that exactly one item in document notes exists
 that has the title `Reasoning for Supersession`.
-The `category` of this item MUST be `description`.
+The `category` of this item SHALL be `description`.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-19-reference-to-superseding-document.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-19-reference-to-superseding-document.md
@@ -1,8 +1,8 @@
 #### Reference to Superseding Document
 
-If the document language is English or unspecified, it MUST be tested that at least one item in document references exists
+If the document language is English or unspecified, it SHALL be tested that at least one item in document references exists
 that has a summary starting with `Superseding Document`.
-The `category` of this item MUST be `external`.
+The `category` of this item SHALL be `external`.
 
 The relevant value for `$.document.category` is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-28-translation.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-28-translation.md
@@ -1,6 +1,6 @@
 ### Translation
 
-It MUST be tested that the given source language and document language are not the same.
+It SHALL be tested that the given source language and document language are not the same.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-29-remediation-without-product-reference.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-29-remediation-without-product-reference.md
@@ -1,6 +1,6 @@
 ### Remediation without Product Reference
 
-For each item in `$.vulnerabilities[*].remediations` it MUST be tested that it includes at least one of the elements `group_ids` or `product_ids`.
+For each item in `$.vulnerabilities[*].remediations` it SHALL be tested that it includes at least one of the elements `group_ids` or `product_ids`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-30-mixed-integer-and-semantic-versioning.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-30-mixed-integer-and-semantic-versioning.md
@@ -1,6 +1,6 @@
 ### Mixed Integer and Semantic Versioning
 
-It MUST be tested that all elements of type `$['$defs'].version_t` follow either integer versioning or
+It SHALL be tested that all elements of type `$['$defs'].version_t` follow either integer versioning or
 semantic versioning homogeneously within the same document.
 
 The relevant paths for this test are:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-31-version-range-in-product-version.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-31-version-range-in-product-version.md
@@ -1,6 +1,6 @@
 ### Version Range in Product Version
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version` it MUST be tested that
+For each element of type `$['$defs'].branches_t` with `category` of `product_version` it SHALL be tested that
 the value of `name` does not contain a version range.
 
 > To implement this test it is deemed sufficient that, when converted to lowercase, the value of `name` satisfies the two requirements below:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-32-flag-without-product-reference.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-32-flag-without-product-reference.md
@@ -1,6 +1,6 @@
 ### Flag without Product Reference
 
-For each item in `$.vulnerabilities[*].flags` it MUST be tested that it includes at least one of the elements `group_ids` or `product_ids`.
+For each item in `$.vulnerabilities[*].flags` it SHALL be tested that it includes at least one of the elements `group_ids` or `product_ids`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-33-multiple-flags-with-vex-justification-codes-per-product.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-33-multiple-flags-with-vex-justification-codes-per-product.md
@@ -1,6 +1,6 @@
 ### Multiple Flags with VEX Justification Codes per Product
 
-For each item in `$.vulnerabilities[*]` it MUST be tested that a Product is not member of more than one Flag item with
+For each item in `$.vulnerabilities[*]` it SHALL be tested that a Product is not member of more than one Flag item with
 a VEX justification code (see section [sec](#vulnerabilities-property-flags)).
 This takes indirect relations through Product Groups into account.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-34-branches-recursion-depth.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-34-branches-recursion-depth.md
@@ -1,6 +1,6 @@
 ### Branches Recursion Depth{#mandatory-tests--branches-recursion-depth}
 
-For each product defined under `$.product_tree.branches[*]` it MUST be tested that the complete JSON path
+For each product defined under `$.product_tree.branches[*]` it SHALL be tested that the complete JSON path
 does not contain more than 30 instances of `branches`.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-35-contradicting-remediations.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-35-contradicting-remediations.md
@@ -1,6 +1,6 @@
 ### Contradicting Remediations
 
-For each item in `$.vulnerabilities[*].remediations` it MUST be tested that a product is not member of
+For each item in `$.vulnerabilities[*].remediations` it SHALL be tested that a product is not member of
 contradicting remediation categories (see table [tab](#vulnerabilities-property-remediations-category-tab-1)).
 This takes indirect relations through product groups into account.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-36-contradicting-product-status-remediation-combination.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-36-contradicting-product-status-remediation-combination.md
@@ -1,6 +1,6 @@
 ### Contradicting Product Status Remediation Combination
 
-For each item in `$.vulnerabilities[*].remediations` it MUST be tested that a product is not member of a
+For each item in `$.vulnerabilities[*].remediations` it SHALL be tested that a product is not member of a
 contradicting product status group (see table [tab](#vulnerabilities-property-remediations-category-tab-2)).
 This takes indirect relations through product groups into account.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-37-date-and-time.md
@@ -1,6 +1,6 @@
 ### Date and Time{#mandatory-tests--date-and-time}
 
-For each item of type `string` and format `date-time` it MUST be tested that it conforms to the rules given in section [sec](#date-and-time).
+For each item of type `string` and format `date-time` it SHALL be tested that it conforms to the rules given in section [sec](#date-and-time).
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-38-non-public-sharing-group-with-max-uuid.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-38-non-public-sharing-group-with-max-uuid.md
@@ -1,6 +1,6 @@
 ### Non-Public Sharing Group with Max UUID
 
-It MUST be tested that a CSAF document using Max UUID as sharing group ID has the TLP label `CLEAR`.
+It SHALL be tested that a CSAF document using Max UUID as sharing group ID has the TLP label `CLEAR`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-39-public-sharing-group-with-no-max-uuid.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-39-public-sharing-group-with-no-max-uuid.md
@@ -1,6 +1,6 @@
 ### Public Sharing Group with No Max UUID
 
-It MUST be tested that a CSAF document with the TLP label `CLEAR` use the Max UUID as sharing group ID if any.
+It SHALL be tested that a CSAF document with the TLP label `CLEAR` use the Max UUID as sharing group ID if any.
 The test SHALL pass if no sharing group is present or the Nil UUID is used and the document status is `draft`.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-40-invalid-sharing-group-name.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-40-invalid-sharing-group-name.md
@@ -1,6 +1,6 @@
 ### Invalid Sharing Group Name
 
-It MUST be tested that the value of sharing group name does not equal the reserved values from section [sec](#document-property---distribution-sharing-group) if the precondition is not fulfilled.
+It SHALL be tested that the value of sharing group name does not equal the reserved values from section [sec](#document-property---distribution-sharing-group) if the precondition is not fulfilled.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-41-missing-sharing-group-name.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-41-missing-sharing-group-name.md
@@ -1,6 +1,6 @@
 ### Missing Sharing Group Name
 
-It MUST be tested that the sharing group name exists and equals the predefined reserved value from section [sec](#document-property---distribution-sharing-group) if the precondition is fulfilled.
+It SHALL be tested that the sharing group name exists and equals the predefined reserved value from section [sec](#document-property---distribution-sharing-group) if the precondition is fulfilled.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-42-purl-qualifiers.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-42-purl-qualifiers.md
@@ -1,6 +1,6 @@
 ### PURL Qualifiers
 
-For each `product_identification_helper` object containing multiple PURLs it MUST be tested that the PURLs only differ in their qualifiers.
+For each `product_identification_helper` object containing multiple PURLs it SHALL be tested that the PURLs only differ in their qualifiers.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-43-use-of-multiple-stars-in-model-number.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in Model Number
 
-For each model number it MUST be tested that it does not contain multiple unescaped stars.
+For each model number it SHALL be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a model number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-44-use-of-multiple-stars-in-serial-number.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in Serial Number
 
-For each serial number it MUST be tested that it does not contain multiple unescaped stars.
+For each serial number it SHALL be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a serial number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-45-inconsistent-disclosure-date.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-45-inconsistent-disclosure-date.md
@@ -1,8 +1,8 @@
 ### Inconsistent Disclosure Date
 
-For each vulnerability, it MUST be tested that the `disclosure_date` is earlier than or equal to the `date` of the newest item of the `revision_history`
+For each vulnerability, it SHALL be tested that the `disclosure_date` is earlier than or equal to the `date` of the newest item of the `revision_history`
 if the document is labeled `TLP:CLEAR` and the document status is `final` or `interim`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-46-invalid-ssvc.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-46-invalid-ssvc.md
@@ -1,6 +1,6 @@
 ### Invalid SSVC
 
-It MUST be tested that the given SSVC object is valid according to the referenced schema.
+It SHALL be tested that the given SSVC object is valid according to the referenced schema.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-47-inconsistent-ssvc-target-ids.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-47-inconsistent-ssvc-target-ids.md
@@ -1,8 +1,8 @@
 ### Inconsistent SSVC Target IDs
 
-For each `ssvc_v2` object it MUST be tested that each item in `target_ids` is either the CVE of the vulnerability given in `cve`
+For each `ssvc_v2` object it SHALL be tested that each item in `target_ids` is either the CVE of the vulnerability given in `cve`
 or the `text` of an item in the `ids` array of the vulnerability.
-The test MUST fail, if the target ID equals the `$.document.tracking.id` and the CSAF document contains more than one vulnerability.
+The test SHALL fail, if the target ID equals the `$.document.tracking.id` and the CSAF document contains more than one vulnerability.
 
 The relevant path for this test is:
 
@@ -38,4 +38,4 @@ The relevant path for this test is:
 
 > A tool MAY remove any inconsistent SSVC Target ID as a quick fix.
 
-If the tool removes the last item of the array, it MUST remove the element `target_ids` as well.
+If the tool removes the last item of the array, it SHALL remove the element `target_ids` as well.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-48-ssvc-decision-points.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-48-ssvc-decision-points.md
@@ -1,9 +1,9 @@
 ### SSVC Decision Points
 
-For each SSVC decision point given under `selections` within a registered base `namespace`, it MUST be tested that given decision point exists,
+For each SSVC decision point given under `selections` within a registered base `namespace`, it SHALL be tested that given decision point exists,
 is valid and the items in `values` are ordered correctly.
 The test SHALL pass, if a unregistered `namespace` is used.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 > A list of all currently registered namespaces is a available in the SSVC documentation at [cite](#SSVC-RNS).
 >

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-49-inconsistent-ssvc-timestamp.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-49-inconsistent-ssvc-timestamp.md
@@ -1,8 +1,8 @@
 ### Inconsistent SSVC Timestamp
 
-For each vulnerability, it MUST be tested that each SSVC `timestamp` is earlier than or equal to the `date` of the newest item of the
+For each vulnerability, it SHALL be tested that each SSVC `timestamp` is earlier than or equal to the `date` of the newest item of the
 `revision_history` if the document status is `final` or `interim`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-50-product-version-range-rules.md
@@ -1,9 +1,9 @@
 ### Product Version Range Rules
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it MUST be tested
+For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it SHALL be tested
 that the value of `name` complies with the rules given in section [sec](#branches-type---name-under-product-version-range).
-VERS types not supported by the implementation SHALL result in a warning which MUST include the VERS type name used.
-Nevertheless, all other rules MUST be checked to the extent possible.
+VERS types not supported by the implementation SHALL result in a warning which SHALL include the VERS type name used.
+Nevertheless, all other rules SHALL be checked to the extent possible.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-51-inconsistent-epss-timestamp.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-51-inconsistent-epss-timestamp.md
@@ -1,8 +1,8 @@
 ### Inconsistent EPSS Timestamp
 
-For each vulnerability, it MUST be tested that each EPSS `timestamp` is earlier than or equal to the `date` of the newest item of the
+For each vulnerability, it SHALL be tested that each EPSS `timestamp` is earlier than or equal to the `date` of the newest item of the
 `revision_history` if the document status is `final` or `interim`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-52-inconsistent-first-known-exploitation-dates.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-52-inconsistent-first-known-exploitation-dates.md
@@ -1,8 +1,8 @@
 ### Inconsistent First Known Exploitation Dates
 
-For each First Known Exploitation Dates item, it MUST be tested that the values of its `date` and `exploitation_date` properties are both earlier than
+For each First Known Exploitation Dates item, it SHALL be tested that the values of its `date` and `exploitation_date` properties are both earlier than
 or equal to the `date` of the newest item of the `revision_history` if the document status is `final` or `interim`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-53-inconsistent-exploitation-date.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-53-inconsistent-exploitation-date.md
@@ -1,8 +1,8 @@
 ### Inconsistent Exploitation Date
 
-For each First Known Exploitation Dates item, it MUST be tested that the value of `exploitation_date` is earlier than or equal to value of the
+For each First Known Exploitation Dates item, it SHALL be tested that the value of `exploitation_date` is earlier than or equal to value of the
 sibling element `date`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-54-license-expression.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-54-license-expression.md
@@ -1,6 +1,6 @@
 ### License Expression
 
-It MUST be tested that the license expression is valid.
+It SHALL be tested that the license expression is valid.
 
 > To implement this test, it is deemed sufficient to check for the ABNF defined in annex B of [cite](#SPDX301) and
 > the restriction on the `DocumentRef` part given in [sec](#document-property---license-expression).

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-55-license-text.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-55-license-text.md
@@ -2,8 +2,8 @@
 
 If the document language is English or unspecified,
 and the `license_expression` contains license identifiers or exceptions that are not listed in the SPDX license list or AboutCode's "ScanCode LicenseDB",
-it MUST be tested that exactly one item in document notes exists that has the title `License`.
-The category of this item MUST be `legal_disclaimer`.
+it SHALL be tested that exactly one item in document notes exists that has the title `License`.
+The category of this item SHALL be `legal_disclaimer`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-56-use-of-cvss-and-qualitative-severity-rating.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-56-use-of-cvss-and-qualitative-severity-rating.md
@@ -1,6 +1,6 @@
 ### Use of CVSS and Qualitative Severity Rating
 
-For each item in `$.vulnerabilities` it MUST be tested that no Qualitative Severity Rating and CVSS values are listed for the tuple of Product ID
+For each item in `$.vulnerabilities` it SHALL be tested that no Qualitative Severity Rating and CVSS values are listed for the tuple of Product ID
 and source.
 
 > Different source might assign different metrics for the same product.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-57-stacked-branch-categories.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-57-stacked-branch-categories.md
@@ -1,9 +1,9 @@
 ### Stacked Branch Categories
 
-For each `full_product_name_t` element under `$.product_tree.branches`, it MUST be tested that branch categories used along the path
+For each `full_product_name_t` element under `$.product_tree.branches`, it SHALL be tested that branch categories used along the path
 leading to the `full_product_name_t` element appear only once in the path.
 The sole exception is `product_family` which can occur multiple times.
-Therefore, `product_family` MUST be ignored in the test.
+Therefore, `product_family` SHALL be ignored in the test.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-58-use-of-product-version-in-one-path-with-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-58-use-of-product-version-in-one-path-with-product-version-range.md
@@ -1,6 +1,6 @@
 ### Use of `product_version` in one Path with `product_version_range`{#use-of-product-version-in-one-path-with-product-version-range}
 
-For each `full_product_name_t` element under `$.product_tree.branches`, it MUST be tested that only one of the branch categories
+For each `full_product_name_t` element under `$.product_tree.branches`, it SHALL be tested that only one of the branch categories
 `product_version` and `product_version_range` is used along the path leading to the `full_product_name_t` element.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-59-single-version-as-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-59-single-version-as-product-version-range.md
@@ -1,6 +1,6 @@
 ### Single Version as Product Version Range
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it MUST be tested that the value of `name` does not
+For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it SHALL be tested that the value of `name` does not
 identify only a single version.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-60-extension-tests.md
@@ -7,7 +7,7 @@ Each of the following tests SHOULD be treated as they were listed similar to the
 
 #### Content Schema{#mandatory-tests--extension-tests-content-schema}
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the item is valid against the Extension Content Schema.
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the item is valid against the Extension Content Schema.
 
 The relevant paths for this test are:
 
@@ -39,8 +39,8 @@ The relevant paths for this test are:
 
 #### Extension Schema{#mandatory-tests--extension-tests-extension-schema}
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the item is valid against the declared CSAF Extension Schema.
-CSAF Extensions not supported by the implementation SHALL result in a warning which MUST include the value of `$schema` of the extension.
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the item is valid against the declared CSAF Extension Schema.
+CSAF Extensions not supported by the implementation SHALL result in a warning which SHALL include the value of `$schema` of the extension.
 Such warning SHALL differentiate between the different classes of extensions.
 
 The relevant paths for this test are:
@@ -77,9 +77,9 @@ The relevant paths for this test are:
 
 #### Extension Metadata{#mandatory-tests--extension-tests-metadata}
 
-For each element of type `$['$defs'].extensions_t` it MUST be tested that the requirements provided through its metadata are fulfilled
+For each element of type `$['$defs'].extensions_t` it SHALL be tested that the requirements provided through its metadata are fulfilled
 for each CSAF Extension used.
-CSAF Extensions not supported by the implementation SHALL result in a warning which MUST include the value of `$schema` of the extension.
+CSAF Extensions not supported by the implementation SHALL result in a warning which SHALL include the value of `$schema` of the extension.
 Such warning SHALL differentiate between the different classes of extensions.
 
 > This includes, but is not limited to:

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-61-use-of-multiple-stars-in-sku.md
@@ -1,6 +1,6 @@
 ### Use of Multiple Stars in SKU
 
-For each stock keeping unit it MUST be tested that it does not contain multiple unescaped stars.
+For each stock keeping unit it SHALL be tested that it does not contain multiple unescaped stars.
 
 > Multiple `*` that match zero or multiple characters within a model number introduce ambiguity and are therefore prohibited.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-01-unused-definition-of-product-id.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-01-unused-definition-of-product-id.md
@@ -1,6 +1,6 @@
 ### Unused Definition of Product ID
 
-For each Product ID (type `$['$defs'].product_id_t`) in Full Product Name elements (type: `$['$defs'].full_product_name_t`) it MUST be tested that
+For each Product ID (type `$['$defs'].product_id_t`) in Full Product Name elements (type: `$['$defs'].full_product_name_t`) it SHALL be tested that
 the `product_id` is referenced somewhere within the same document.
 
 This test SHALL be skipped for CSAF documents conforming the profile "Informational Advisory".

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-02-missing-remediation.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-02-missing-remediation.md
@@ -1,6 +1,6 @@
 ### Missing Remediation
 
-For each Product ID (type `$['$defs'].product_id_t`) in the Product Status groups Affected and Under investigation it MUST be tested that
+For each Product ID (type `$['$defs'].product_id_t`) in the Product Status groups Affected and Under investigation it SHALL be tested that
 a remediation exists.
 
 > The remediation might be of the category `none_available` or `no_fix_planned`.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-03-missing-metric.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-03-missing-metric.md
@@ -1,6 +1,6 @@
 ### Missing Metric
 
-For each Product ID (type `$['$defs'].product_id_t`) in the Product Status groups Affected it MUST be tested that
+For each Product ID (type `$['$defs'].product_id_t`) in the Product Status groups Affected it SHALL be tested that
 a metric object exists which covers this product.
 
 The relevant paths for this test are:

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-04-build-metadata-in-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-04-build-metadata-in-revision-history.md
@@ -1,6 +1,6 @@
 ### Build Metadata in Revision History
 
-For each item in revision history it MUST be tested that `number` does not include build metadata.
+For each item in revision history it SHALL be tested that `number` does not include build metadata.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-05-older-initial-release-date-than-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-05-older-initial-release-date-than-revision-history.md
@@ -1,7 +1,7 @@
 ### Older Initial Release Date than Revision History
 
-It MUST be tested that the Initial Release Date is not older than the `date` of the oldest item in Revision History.
-As the timestamps might use different timezones, the sorting and comparison MUST take timezones into account.
+It SHALL be tested that the Initial Release Date is not older than the `date` of the oldest item in Revision History.
+As the timestamps might use different timezones, the sorting and comparison SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-06-older-current-release-date-than-Revision.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-06-older-current-release-date-than-Revision.md
@@ -1,7 +1,7 @@
 ### Older Current Release Date than Revision History
 
-It MUST be tested that the Current Release Date is not older than the `date` of the newest item in Revision History.
-As the timestamps might use different timezones, the sorting and comparison MUST take timezones into account.
+It SHALL be tested that the Current Release Date is not older than the `date` of the newest item in Revision History.
+As the timestamps might use different timezones, the sorting and comparison SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-07-missing-date-in-involvements.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-07-missing-date-in-involvements.md
@@ -1,6 +1,6 @@
 ### Missing Date in Involvements
 
-For each item in the list of involvements it MUST be tested that it includes the property `date`.
+For each item in the list of involvements it SHALL be tested that it includes the property `date`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-08-use-of-md5-as-the-only-hash-algorith.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-08-use-of-md5-as-the-only-hash-algorith.md
@@ -1,6 +1,6 @@
 ### Use of MD5 As the Only Hash Algorithm
 
-It MUST be tested that the hash algorithm `md5` is not the only one present.
+It SHALL be tested that the hash algorithm `md5` is not the only one present.
 
 > Since collision attacks exist for MD5 such value should be accompanied by a second cryptographically stronger hash.
 > This will allow users to double check the results.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-09-use-of-sha-1-as-the-only-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-09-use-of-sha-1-as-the-only-hash-algorithm.md
@@ -1,6 +1,6 @@
 ### Use of SHA-1 As the Only Hash Algorithm
 
-It MUST be tested that the hash algorithm `sha1` is not the only one present.
+It SHALL be tested that the hash algorithm `sha1` is not the only one present.
 
 > Since collision attacks exist for SHA-1 such value should be accompanied by a second cryptographically stronger hash.
 > This will allow users to double check the results.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-11-missing-canonical-url.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-11-missing-canonical-url.md
@@ -1,6 +1,6 @@
 ### Missing Canonical URL
 
-It MUST be tested that the CSAF document has a canonical URL.
+It SHALL be tested that the CSAF document has a canonical URL.
 
 > To implement this test it is deemed sufficient that one item in `$.document.references` fulfills all of the following:
 >

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-12-missing-document-language.md
@@ -1,6 +1,6 @@
 ### Missing Document Language
 
-It MUST be tested that the document language member is present and set.
+It SHALL be tested that the document language member is present and set.
 A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
 not being present at all.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-13-sorting.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-13-sorting.md
@@ -1,6 +1,6 @@
 ### Sorting{#recommended-tests--sorting}
 
-It MUST be tested that all keys in a CSAF document are sorted alphabetically.
+It SHALL be tested that all keys in a CSAF document are sorted alphabetically.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-14-use-of-private-language.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-14-use-of-private-language.md
@@ -1,6 +1,6 @@
 ### Use of Private Language
 
-For each element of type `$['$defs'].lang_t` it MUST be tested that the language code does not contain subtags reserved for private use.
+For each element of type `$['$defs'].lang_t` it SHALL be tested that the language code does not contain subtags reserved for private use.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-15-use-of-default-language.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-15-use-of-default-language.md
@@ -1,6 +1,6 @@
 ### Use of Default Language
 
-For each element of type `$['$defs'].lang_t` it MUST be tested that the language code is not `i-default`.
+For each element of type `$['$defs'].lang_t` it SHALL be tested that the language code is not `i-default`.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-16-missing-product-identification-helper.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-16-missing-product-identification-helper.md
@@ -1,6 +1,6 @@
 ### Missing Product Identification Helper
 
-For each element of type `$['$defs'].full_product_name_t` it MUST be tested that it includes the property `product_identification_helper`.
+For each element of type `$['$defs'].full_product_name_t` it SHALL be tested that it includes the property `product_identification_helper`.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-17-cve-in-field-ids.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-17-cve-in-field-ids.md
@@ -1,6 +1,6 @@
 ### CVE in Field IDs
 
-For each item in `$.vulnerabilities[*].ids` it MUST be tested that it is not a CVE ID.
+For each item in `$.vulnerabilities[*].ids` it SHALL be tested that it is not a CVE ID.
 
 > It is sufficient to check, whether the property `text` matches the regex `^CVE-[0-9]{4}-[0-9]{4,}$`.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-18-product-version-range-without-vers.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-18-product-version-range-without-vers.md
@@ -1,6 +1,6 @@
 ### Product Version Range without VERS
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version_range` it MUST be tested that
+For each element of type `$['$defs'].branches_t` with `category` of `product_version_range` it SHALL be tested that
 the value of `name` indicates that the product version range is using VERS.
 
 > Compliance with the VERS specification itself is enforced via test [sec](#product-version-range-rules).
@@ -12,7 +12,7 @@ the value of `name` indicates that the product version range is using VERS.
 >   ^vers:[a-z\\.\\-\\+][a-z0-9\\.\\-\\+]*/.+
 > ```
 
-The warning MUST clearly advise to carefully check whether VERS can be used or the versions can be enumerated as
+The warning SHALL clearly advise to carefully check whether VERS can be used or the versions can be enumerated as
 the use of vls is only a fallback option.
 For more details, see sections [sec](#branches-type---category) and [sec](#branches-type---name-under-product-version-range).
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-19-cvss-for-fixed-products.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-19-cvss-for-fixed-products.md
@@ -1,6 +1,6 @@
 ### CVSS for Fixed Products
 
-For each item the fixed products group (`first_fixed` and `fixed`) it MUST be tested that
+For each item the fixed products group (`first_fixed` and `fixed`) it SHALL be tested that
 a CVSS applying to this product has an overall score of `0`.
 The test SHALL pass if none of the Product IDs listed within product status `fixed` or
 `first_fixed` is found in `products` of any item of the `metrics` element.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-20-additional-properties.md
@@ -1,10 +1,10 @@
 ### Additional Properties
 
-It MUST be tested that there is no additional property in the CSAF document that was not defined in the CSAF JSON schema.
+It SHALL be tested that there is no additional property in the CSAF document that was not defined in the CSAF JSON schema.
 This also applies for referenced schemas.
-For CSAF Extensions, the declared schemas MUST be checked additionally to the CSAF Extension Content Schema.
-Additional and unevaluated properties allowed by the CSAF Extension Content Schema MUST not be reported.
-CSAF Extensions not supported by the implementation SHALL result in a warning which MUST include the value of `$schema` of the extension.
+For CSAF Extensions, the declared schemas SHALL be checked additionally to the CSAF Extension Content Schema.
+Additional and unevaluated properties allowed by the CSAF Extension Content Schema SHALL not be reported.
+CSAF Extensions not supported by the implementation SHALL result in a warning which SHALL include the value of `$schema` of the extension.
 Such warning SHALL differentiate between the different classes of extensions.
 
 > Some of the errors could be reported by combining the JSON schema check with several mandatory tests,

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-21-same-timestamps-in-revision-history.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-21-same-timestamps-in-revision-history.md
@@ -1,7 +1,7 @@
 ### Same Timestamps in Revision History
 
-It MUST be tested that the timestamps of all items in the revision history are pairwise disjoint.
-As the timestamps might use different timezones, the comparison MUST take timezones into account.
+It SHALL be tested that the timestamps of all items in the revision history are pairwise disjoint.
+As the timestamps might use different timezones, the comparison SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-22-document-tracking-id-in-title.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-22-document-tracking-id-in-title.md
@@ -1,6 +1,6 @@
 ### Document Tracking ID in Title
 
-It MUST be tested that the `$.document.title` does not contain the `$.document.tracking.id`.
+It SHALL be tested that the `$.document.title` does not contain the `$.document.tracking.id`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-23-usage-of-deprecated-cwe.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-23-usage-of-deprecated-cwe.md
@@ -1,6 +1,6 @@
 ### Usage of Deprecated CWE
 
-For each item in the CWE array it MUST be tested that the CWE is not deprecated in the given version.
+For each item in the CWE array it SHALL be tested that the CWE is not deprecated in the given version.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-24-usage-of-non-latest-cwe-version.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-24-usage-of-non-latest-cwe-version.md
@@ -1,6 +1,6 @@
 ### Usage of Non-Latest CWE Version
 
-For each item in the CWE array it MUST be tested that the latest CWE version available at the time of the last revision was used.
+For each item in the CWE array it SHALL be tested that the latest CWE version available at the time of the last revision was used.
 The test SHALL fail if a later CWE version was used.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-25-usage-of-cwe-not-allowed-for-vulnerability-mapping.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-25-usage-of-cwe-not-allowed-for-vulnerability-mapping.md
@@ -1,6 +1,6 @@
 ### Usage of CWE Not Allowed for Vulnerability Mapping
 
-For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed.
+For each item in the CWE array it SHALL be tested that the vulnerability mapping is allowed.
 
 > Currently, this includes the two usage state `Allowed` and `Allowed-with-Review`.
 >

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-26-usage-of-cwe-allowed-with-review-for-vulnerability-mapping.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-26-usage-of-cwe-allowed-with-review-for-vulnerability-mapping.md
@@ -1,6 +1,6 @@
 ### Usage of CWE Allowed with Review for Vulnerability Mapping
 
-For each item in the CWE array it MUST be tested that the vulnerability mapping is allowed without review.
+For each item in the CWE array it SHALL be tested that the vulnerability mapping is allowed without review.
 
 > Reasoning: CWEs marked with a vulnerability mapping state of `Allowed-with-Review` should only be used if a thorough review was done.
 > This test helps to flag such mappings which can be used to trigger processes that ensure the extra review, e.g. by a senior analyst.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-27-discouraged-product-status-remediation-combination.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-27-discouraged-product-status-remediation-combination.md
@@ -1,6 +1,6 @@
 ### Discouraged Product Status Remediation Combination
 
-For each item in `$.vulnerabilities[*].remediations`, it MUST be tested that a Product is not member of a discouraged product status group
+For each item in `$.vulnerabilities[*].remediations`, it SHALL be tested that a Product is not member of a discouraged product status group
 remediation category combination (see table [tab](#vulnerabilities-property-remediations-category-tab-2)).
 This takes indirect relations through Product Groups into account.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-28-sage-of-max-uuid.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-28-sage-of-max-uuid.md
@@ -1,6 +1,6 @@
 ### Usage of Max UUID
 
-It MUST be tested that the Max UUID is not used as sharing group id.
+It SHALL be tested that the Max UUID is not used as sharing group id.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-29-usage-of-nil-uuid.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-29-usage-of-nil-uuid.md
@@ -1,6 +1,6 @@
 ### Usage of Nil UUID
 
-It MUST be tested that the Nil UUID is not used as sharing group id.
+It SHALL be tested that the Nil UUID is not used as sharing group id.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-30-usage-of-sharing-group-on-tlp-clear.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-30-usage-of-sharing-group-on-tlp-clear.md
@@ -1,6 +1,6 @@
 ### Usage of Sharing Group on TLP:CLEAR{#usage-of-sharing-group-on-tlp-clear}
 
-It MUST be tested that no sharing group is used if the document is `TLP:CLEAR`.
+It SHALL be tested that no sharing group is used if the document is `TLP:CLEAR`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-31-hardware-and-software.md
@@ -1,6 +1,6 @@
 ### Hardware and Software
 
-For each product containing at least one of the Product Identification Helpers `serial_numbers` or `model_numbers` it MUST be tested
+For each product containing at least one of the Product Identification Helpers `serial_numbers` or `model_numbers` it SHALL be tested
 that a product path exists referencing this product.
 
 > This tests detects a potential situation where hardware and software have been mixed in the `product_tree`.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-32-use-of-same-product-identification-helper-for-different-products.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-32-use-of-same-product-identification-helper-for-different-products.md
@@ -1,6 +1,6 @@
 ### Use of Same Product Identification Helper for Different Products
 
-For each Product Identification Helper category it MUST be tested that the same value is not used for multiple products in this category.
+For each Product Identification Helper category it SHALL be tested that the same value is not used for multiple products in this category.
 
 > This test detects a potentially incorrect constructed product tree.
 > Note: This test will fail if the CSAF document contains in its `product_tree` the old and new name of a product that was renamed.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-33-disclosure-date-newer-than-revision.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-33-disclosure-date-newer-than-revision.md
@@ -1,8 +1,8 @@
 ### Disclosure Date Newer than Revision History
 
-For each vulnerability, it MUST be tested that the `disclosure_date` is earlier or equal to the `date` of the newest item of the `revision_history`
+For each vulnerability, it SHALL be tested that the `disclosure_date` is earlier or equal to the `date` of the newest item of the `revision_history`
 if the `disclosure_date` is in the past at the time of the test execution.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 > The result of the test is dependent upon the time of the execution of the test - it might change for a given CSAF document over time.
 > However, the latest version of a CSAF document should always pass the test.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-34-usage-of-unknown-ssvc-decision.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-34-usage-of-unknown-ssvc-decision.md
@@ -1,7 +1,7 @@
 ### Usage of Unknown SSVC Decision Point Base Namespace
 
-For each SSVC decision point given under `selections`, it MUST be tested that the base `namespace` is a registered one.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+For each SSVC decision point given under `selections`, it SHALL be tested that the base `namespace` is a registered one.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 > This test fails on unregistered namespaces as well as registered ones not yet supported by the implementation.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-35-usage-of-unregistered-ssvc-decision-point.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-35-usage-of-unregistered-ssvc-decision-point.md
@@ -1,8 +1,8 @@
 ### Usage of Unregistered SSVC Decision Point Base Namespace in TLP:CLEAR Document{#usage-of-unregistered-ssvc-decision-point-base-namespace-in-tlp-clear-document}
 
-For each SSVC decision point given under `selections`, it MUST be tested that the base `namespace` is not an unregistered one
+For each SSVC decision point given under `selections`, it SHALL be tested that the base `namespace` is not an unregistered one
 if the document is labeled `TLP:CLEAR`.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-36-usage-of-ssvc-decision-point-namespa.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-36-usage-of-ssvc-decision-point-namespa.md
@@ -1,8 +1,8 @@
 ### Usage of SSVC Decision Point Namespace with Extension in TLP:CLEAR Document{#usage-of-ssvc-decision-point-namespace-with-extension-in-tlp-clear-document}
 
-For each SSVC decision point given under `selections`, it MUST be tested that the `namespace` does not use an extension
+For each SSVC decision point given under `selections`, it SHALL be tested that the `namespace` does not use an extension
 if the document is labeled `TLP:CLEAR`.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-37-usage-of-unknown-ssvc-decision-point-without-resource.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-37-usage-of-unknown-ssvc-decision-point-without-resource.md
@@ -1,14 +1,14 @@
 ### Usage of Unknown SSVC Decision Point Namespace without Resource
 
 For each SSVC object containing a decision point with a full `namespace` that is not registered,
-it MUST be tested that a Decision Point Resource exists for each one that provides additional context about the
+it SHALL be tested that a Decision Point Resource exists for each one that provides additional context about the
 decision points from this namespace.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 > A full namespace includes any extension.
 > To implement this test it is deemed sufficient to check whether the `summary` contains the full `namespace`.
 
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-38-usage-of-deprecated-profile.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-38-usage-of-deprecated-profile.md
@@ -1,6 +1,6 @@
 ### Usage of Deprecated Profile
 
-It MUST be tested that the `$.document.category` does not start with `csaf_deprecated_`.
+It SHALL be tested that the `$.document.category` does not start with `csaf_deprecated_`.
 
 > To implement this test it is deemed sufficient to do a "starts with" check.
 > In contrast to test [sec](#prohibited-document-category-name), this test detects the use of a profile defined by CSAF that is deprecated.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-01-missing-fixed-product.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-01-missing-fixed-product.md
@@ -1,10 +1,10 @@
 #### Missing Fixed Product
 
 For each product listed in the product status group affected in any vulnerability,
-it MUST be tested that a corresponding version of the product is listed as fixed in the same vulnerability.
-The test MUST be skipped if there is a clear indication, that such a version of the product does not exist.
+it SHALL be tested that a corresponding version of the product is listed as fixed in the same vulnerability.
+The test SHALL be skipped if there is a clear indication, that such a version of the product does not exist.
 Indicators include a remediation item with one of the categories `fix_planned`, `no_fix_planned` or `none_available` referring to the affected product.
-The test MUST NOT be skipped, if there is an indication, that such a version of the product might exist.
+The test SHALL NOT be skipped, if there is an indication, that such a version of the product might exist.
 Indicators include an affected product version range with the comparator `<` in the last version constraint and
 a remediation item with the categories `vendor_fix` referring to the affected product.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-02-language-specific-reasoning-for-withdrawal.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-02-language-specific-reasoning-for-withdrawal.md
@@ -1,9 +1,9 @@
 #### Language Specific Reasoning for Withdrawal
 
-If the document language is specified but not English, it MUST be tested that exactly one item in document notes exists
+If the document language is specified but not English, it SHALL be tested that exactly one item in document notes exists
 that has the language specific translation of the term `Reasoning for Withdrawal` as `title`.
-The `category` of this item MUST be `description`.
-If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no such translation is known.
+The `category` of this item SHALL be `description`.
+If no language specific translation has been recorded, the test SHALL be skipped and output an information to the user that no such translation is known.
 
 > A list of the language specific translations is kept at the OASIS CSAF TC.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-03-language-specific-reasoning-for-supersession.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-03-language-specific-reasoning-for-supersession.md
@@ -1,9 +1,9 @@
 #### Language Specific Reasoning for Supersession
 
-If the document language is specified but not English, it MUST be tested that exactly one item in document notes exists
+If the document language is specified but not English, it SHALL be tested that exactly one item in document notes exists
 that has the language specific translation of the term `Reasoning for Supersession` as `title`.
-The `category` of this item MUST be `description`.
-If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no such translation is known.
+The `category` of this item SHALL be `description`.
+If no language specific translation has been recorded, the test SHALL be skipped and output an information to the user that no such translation is known.
 
 > A list of the language specific translations is kept at the OASIS CSAF TC.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-04-language-specific-superseding-document.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-04-language-specific-superseding-document.md
@@ -1,9 +1,9 @@
 #### Language Specific Superseding Document
 
-If the document language is specified but not English, it MUST be tested that at least one item in document references exists
+If the document language is specified but not English, it SHALL be tested that at least one item in document references exists
 that starts with the language specific translation of the term `Superseding Document` as `summary`.
-The `category` of this item MUST be `external`.
-If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no such translation is known.
+The `category` of this item SHALL be `external`.
+If no language specific translation has been recorded, the test SHALL be skipped and output an information to the user that no such translation is known.
 
 > A list of the language specific translations is kept at the OASIS CSAF TC.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-05-extension-in-superseded-or-withdrawn-document.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-39-05-extension-in-superseded-or-withdrawn-document.md
@@ -1,6 +1,6 @@
 #### Extension in Superseded or Withdrawn Document
 
-It MUST be tested that the document does not contain an extension.
+It SHALL be tested that the document does not contain an extension.
 
 The relevant values for `$.document.category` are:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-40-product-description-without-product.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-40-product-description-without-product.md
@@ -1,12 +1,12 @@
 ### Product Description without Product Reference
 
-For each product description it MUST be tested that it includes at least one of the elements `group_ids` or `product_ids`.
+For each product description it SHALL be tested that it includes at least one of the elements `group_ids` or `product_ids`.
 
 > If the document language is English or unspecified, the product description can be identified by checking for a note containing the corresponding
 > `category` and `title` combination from [sec](#document-property---notes).
 > For other languages, the language specific translation is used.
 
-If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no translation for
+If no language specific translation has been recorded, the test SHALL be skipped and output an information to the user that no translation for
 product description is known.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-41-old-epss-timestamp.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-41-old-epss-timestamp.md
@@ -1,8 +1,8 @@
 ### Old EPSS Timestamp
 
-For each vulnerability, it MUST be tested that the youngest EPSS `timestamp` is not more than 15 days older than to the `date` of the newest item of the
+For each vulnerability, it SHALL be tested that the youngest EPSS `timestamp` is not more than 15 days older than to the `date` of the newest item of the
 `revision_history` if the document status is `final` or `interim`.
-As the timestamps might use different timezones, the sorting MUST take timezones into account.
+As the timestamps might use different timezones, the sorting SHALL take timezones into account.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-42-inconsistent-product-identification-helper.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-42-inconsistent-product-identification-helper.md
@@ -1,8 +1,8 @@
 ### Inconsistent Product Identification Helper
 
-For each product identification helper which resides in `branches`, it MUST be tested that the product identification helper contain at least
+For each product identification helper which resides in `branches`, it SHALL be tested that the product identification helper contain at least
 the same information as the categorized strings.
-Information that cannot be represented in the specific product identification helper MUST be omitted from the comparison.
+Information that cannot be represented in the specific product identification helper SHALL be omitted from the comparison.
 
 > To implement this test it is deemed sufficient to follow the process below.
 > It is based on a static mapping of branch categories to the corresponding part of the product identification helpers.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-43-missing-license-expression.md
@@ -1,6 +1,6 @@
 ### Missing License Expression
 
-It MUST be tested that the license expression is present and set.
+It SHALL be tested that the license expression is present and set.
 A CSAF Validator SHALL differentiate in the error message between the key being present but having no or an empty value and
 not being present at all.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-44-deprecated-license-identifier.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-44-deprecated-license-identifier.md
@@ -1,6 +1,6 @@
 ### Deprecated License Identifier
 
-It MUST be tested that all license identifier and exceptions used are not deprecated.
+It SHALL be tested that all license identifier and exceptions used are not deprecated.
 This SHALL be tested for the SPDX license list and AboutCode's "ScanCode LicenseDB".
 The test MAY be skipped for other license inventoring entities.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-45-non-existing-license-identifier.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-45-non-existing-license-identifier.md
@@ -1,6 +1,6 @@
 ### Non-Existing License Identifier
 
-It MUST be tested that all license identifier and exceptions used exist.
+It SHALL be tested that all license identifier and exceptions used exist.
 This SHALL be tested for the SPDX license list and AboutCode's "ScanCode LicenseDB".
 The test MAY be skipped for other license inventoring entities.
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-46-language-specific-license-text.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-46-language-specific-license-text.md
@@ -2,9 +2,9 @@
 
 If the document language is specified but not English,
 and the `license_expression` contains license identifiers or exceptions that are not listed in the SPDX license list or AboutCode's "ScanCode LicenseDB",
-it MUST be tested that exactly one item in document notes exists that has the language specific translation of the term `License` as title.
-The category of this item MUST be `legal_disclaimer`.
-If no language specific translation has been recorded, the test MUST be skipped and output an information to the user that no such translation is known.
+it SHALL be tested that exactly one item in document notes exists that has the language specific translation of the term `License` as title.
+The category of this item SHALL be `legal_disclaimer`.
+If no language specific translation has been recorded, the test SHALL be skipped and output an information to the user that no such translation is known.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-47-use-of-qualitative-severity-rating-by-issuing-party.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-47-use-of-qualitative-severity-rating-by-issuing-party.md
@@ -1,6 +1,6 @@
 ### Use of Qualitative Severity Rating by Issuing Party
 
-For each item in `metrics` provided by the issuing party it MUST be tested that it does not use the qualitative severity rating.
+For each item in `metrics` provided by the issuing party it SHALL be tested that it does not use the qualitative severity rating.
 
 > This covers all items in `metrics` that do not have a `source` property and those where the `source` is equal to
 > the canonical URL.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-48-misuse-at-vendor-name.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-48-misuse-at-vendor-name.md
@@ -1,6 +1,6 @@
 ### Misuse at Vendor Name
 
-For each item in `branches` with category `vendor` it MUST be tested that the `name` is not `Open Source`.
+For each item in `branches` with category `vendor` it SHALL be tested that the `name` is not `Open Source`.
 The comparison is case and white space insensitive.
 
 > Some issuing parties use `Open Source` as a vendor name for all open source products.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-49-upper-open-ended-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-49-upper-open-ended-product-version-range.md
@@ -1,6 +1,6 @@
 ### Upper Open Ended Product Version Range
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it MUST be tested that the value of `name` is not an
+For each element of type `$['$defs'].branches_t` with `category` of `product_version_range`, it SHALL be tested that the value of `name` is not an
 upper open ended product version range.
 
 > Usually, the last including version constraint of an upper open ended product version range contains as comparator either `>` or `>=`.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-50-overlapping-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-50-overlapping-version-range.md
@@ -49,8 +49,8 @@ The following definitions apply to all tests:
 
 #### Overlapping Product Version Range with VERS in Contradicting Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVRSS+l-vers` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVRSS+l-vers` that overlap with `CTPVR` are not
 member of a contradicting product status groups (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:
@@ -116,8 +116,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with vls in Contradicting Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVRSS+l-vls` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVRSS+l-vls` that overlap with `CTPVR` are not
 member of a contradicting product status groups (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:
@@ -183,8 +183,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with Product Version in Contradicting Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVSS+l` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVSS+l` that overlap with `CTPVR` are not
 member of a contradicting product status groups (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-51-unknown-vers-type.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-51-unknown-vers-type.md
@@ -1,8 +1,8 @@
 ### Unknown VERS Type
 
 For each element of type `$['$defs'].branches_t` with `category` of `product_version_range` which indicates that it is using vers,
-it MUST be tested that the VERS type is officially registered and supported by the implementation.
-The warning MUST differentiate between officially registered VERS types and those that are not in this state.
+it SHALL be tested that the VERS type is officially registered and supported by the implementation.
+The warning SHALL differentiate between officially registered VERS types and those that are not in this state.
 
 > Different implementations might support different VERS types.
 > Usually, unknown VERS types hinder the automated evaluation of VERS.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-52-unknown-hash-algorithm.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-52-unknown-hash-algorithm.md
@@ -1,8 +1,8 @@
 ### Unknown Hash Algorithm
 
 For each element of type `$['$defs'].full_product_name_t..product_identification_helper..hashes[*]..file_hashes[*]..algorithm`,
-it MUST be tested that the hash algorithm is supported by the implementation.
-The warning MUST differentiate between the values mentioned in section [sec](#full-product-name-type---product-identification-helper---hashes)
+it SHALL be tested that the hash algorithm is supported by the implementation.
+The warning SHALL differentiate between the values mentioned in section [sec](#full-product-name-type---product-identification-helper---hashes)
 and those not mentioned there.
 
 > Different implementations might support different hash algorithms.

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-53-matching-text-for-registered-id-system.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-53-matching-text-for-registered-id-system.md
@@ -1,7 +1,7 @@
 ### Matching Text for Registered ID System
 
 For each item in `$.vulnerabilities[*].ids` that has the value of a registered vulnerability ID system as `system_name`,
-it MUST be tested that the `text` in the CSAF document matches the `text_pattern` given by the
+it SHALL be tested that the `text` in the CSAF document matches the `text_pattern` given by the
 "Registry for Vulnerability ID Systems for CSAF" (RVISC).
 
 > The RVISC is available at [cite](#RVISC).

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-54-extension-tests.md
@@ -7,8 +7,8 @@ Each of the following tests SHOULD be treated as they were listed similar to the
 
 #### Registered Extension
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the item is a registered CSAF Extension.
-The test MUST be skipped for official CSAF Extensions.
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the item is a registered CSAF Extension.
+The test SHALL be skipped for official CSAF Extensions.
 
 The relevant paths for this test are:
 
@@ -37,7 +37,7 @@ The relevant paths for this test are:
 
 #### Official Extension
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the item is an official CSAF Extension.
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the item is an official CSAF Extension.
 
 The relevant paths for this test are:
 
@@ -66,7 +66,7 @@ The relevant paths for this test are:
 
 #### Critical Extension
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the item is not a critical extension.
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the item is not a critical extension.
 
 > It is sufficient to check whether the value of `critical` is `false`.
 
@@ -97,7 +97,7 @@ The relevant paths for this test are:
 
 #### Usage of Experimental Extension in TLP:CLEAR Document{#usage-of-experimental-extension-in-tlp-clear-document}
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that no experimental extension is used
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that no experimental extension is used
 if the document is labeled `TLP:CLEAR`.
 
 The relevant paths for this test are:

--- a/csaf_2.1/prose/edit/src/tests-02-rcmmndd-55-public-openpgp-key-url.md
+++ b/csaf_2.1/prose/edit/src/tests-02-rcmmndd-55-public-openpgp-key-url.md
@@ -1,8 +1,8 @@
 ### Public OpenPGP Key URL
 
-It MUST be tested that the URL given as value of `public_openpgp_key_url` in the CSAF document
+It SHALL be tested that the URL given as value of `public_openpgp_key_url` in the CSAF document
 delivers a valid public OpenPGP key allowing encryption as ASCII armored file with the matching content type.
-The test MUST be skipped if the URL results in a client or server error.
+The test SHALL be skipped if the URL results in a client or server error.
 
 > As these might be temporary errors, they are reported through test [sec](#use-of-non-self-referencing-urls-failing-to-resolve).
 

--- a/csaf_2.1/prose/edit/src/tests-02-recommended.md
+++ b/csaf_2.1/prose/edit/src/tests-02-recommended.md
@@ -2,4 +2,4 @@
 
 Recommended tests SHOULD NOT fail at a valid CSAF document without a good reason. Failing such a test does not make the CSAF document invalid.
 These tests may include information about features which are still supported but expected to be deprecated in a future version of CSAF.
-A program MUST handle a test failure as a warning.
+A program SHALL handle a test failure as a warning.

--- a/csaf_2.1/prose/edit/src/tests-03-informative.md
+++ b/csaf_2.1/prose/edit/src/tests-03-informative.md
@@ -4,4 +4,4 @@ Informative tests provide insights in common mistakes and bad practices.
 They MAY fail at a valid CSAF document.
 It is up to the issuing party to decide whether this was an intended behavior and can be ignore or should be treated.
 These tests MAY include information about recommended usage.
-A program MUST handle a test failure as a information.
+A program SHALL handle a test failure as a information.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-01-use-of-cvss-v2-as-the-only-scoring-system.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-01-use-of-cvss-v2-as-the-only-scoring-system.md
@@ -1,6 +1,6 @@
 ### Use of CVSS v2 As the Only Scoring System
 
-For each item in the list of metrics which contains the `cvss_v2` object under `content` it MUST be tested that is not the only scoring item present.
+For each item in the list of metrics which contains the `cvss_v2` object under `content` it SHALL be tested that is not the only scoring item present.
 The test SHALL pass if a second scoring object is available regarding the specific product.
 
 > One source might just provide CVSS v2.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-02-use-of-cvss-v3-0.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-02-use-of-cvss-v3-0.md
@@ -1,6 +1,6 @@
 ### Use of CVSS v3.0
 
-For each item in the list of metrics which contains the `cvss_v3` object under `content` it MUST be tested that CVSS v3.0 is not used.
+For each item in the list of metrics which contains the `cvss_v3` object under `content` it SHALL be tested that CVSS v3.0 is not used.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-03-missing-cve.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-03-missing-cve.md
@@ -1,6 +1,6 @@
 ### Missing CVE
 
-It MUST be tested that the CVE number is given.
+It SHALL be tested that the CVE number is given.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-04-missing-cwe.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-04-missing-cwe.md
@@ -1,6 +1,6 @@
 ### Missing CWE
 
-It MUST be tested that at least one CWE is given.
+It SHALL be tested that at least one CWE is given.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-05-use-of-short-hash.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-05-use-of-short-hash.md
@@ -1,6 +1,6 @@
 ### Use of Short Hash
 
-It MUST be tested that the length of the hash value is not shorter than 64 characters.
+It SHALL be tested that the length of the hash value is not shorter than 64 characters.
 
 The relevant paths for this test are:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-06-use-of-non-self-referencing-urls-failing-to-resolve.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-06-use-of-non-self-referencing-urls-failing-to-resolve.md
@@ -1,6 +1,6 @@
 ### Use of Non-Self Referencing URLs Failing to Resolve
 
-For each URL which is not in the category `self` it MUST be tested that it resolves with a HTTP status code from
+For each URL which is not in the category `self` it SHALL be tested that it resolves with a HTTP status code from
 the 2xx (Successful) or 3xx (Redirection) class.
 
 > This test does not apply for any item in an array of type `references_t` with the category `self`.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-07-use-of-self-referencing-urls-failing-to-resolve.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-07-use-of-self-referencing-urls-failing-to-resolve.md
@@ -1,6 +1,6 @@
 ### Use of Self Referencing URLs Failing to Resolve
 
-For each item in an array of type `references_t` with the category `self` it MUST be tested that
+For each item in an array of type `references_t` with the category `self` it SHALL be tested that
 the URL referenced resolves with a HTTP status code less than 400.
 
 > This test will most likely fail if the CSAF document is in a status before the initial release.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-08-spell-check.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-08-spell-check.md
@@ -1,6 +1,6 @@
 ### Spell Check
 
-If the document language is given it MUST be tested that a spell check for the given language does not find any mistakes.
+If the document language is given it SHALL be tested that a spell check for the given language does not find any mistakes.
 The test SHALL be skipped if the document language is not set.
 It SHALL fail if the given language is not supported.
 The value of `$.document.category` SHOULD NOT be tested if the CSAF document does not use the profile "CSAF Base".

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-09-branch-categories.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-09-branch-categories.md
@@ -1,6 +1,6 @@
 ### Branch Categories
 
-For each element of type `$['$defs'].full_product_name_t` in `$.product_tree.branches` it MUST be tested that
+For each element of type `$['$defs'].full_product_name_t` in `$.product_tree.branches` it SHALL be tested that
 ancestor nodes along the path exist which use the following branch categories `vendor` -> `product_name` -> `product_version` in that
 order starting with the Product tree node.
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-10-usage-of-product-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-10-usage-of-product-version-range.md
@@ -1,6 +1,6 @@
 ### Usage of Product Version Range
 
-For each element of type `$['$defs'].branches_t` it MUST be tested that the `category` is not `product_version_range`.
+For each element of type `$['$defs'].branches_t` it SHALL be tested that the `category` is not `product_version_range`.
 
 > It is usually hard decide for machines whether a product version matches a product version ranges.
 > Therefore, it is recommended to avoid version ranges and enumerate versions wherever possible.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-11-usage-of-v-as-version-indicator.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-11-usage-of-v-as-version-indicator.md
@@ -1,6 +1,6 @@
 ### Usage of V as Version Indicator
 
-For each element of type `$['$defs'].branches_t` with `category` of `product_version` it MUST be tested that
+For each element of type `$['$defs'].branches_t` with `category` of `product_version` it SHALL be tested that
 the value of `name` does not start with `v` or `V` before the version.
 
 > To implement this test it is deemed sufficient that the value of `name` does not match the following regex:

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-12-missing-cvss-v4-0.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-12-missing-cvss-v4-0.md
@@ -1,7 +1,7 @@
 ### Missing CVSS v4.0
 
-For each item in the list of metrics that contains any CVSS object it MUST be tested that a `cvss_v4` object is present.
-The test MUST fail, if any Product ID (type `$['$defs'].product_id_t`) in the product status group Affected (see section [sec](#vulnerabilities-property-product-status)) is not covered by
+For each item in the list of metrics that contains any CVSS object it SHALL be tested that a `cvss_v4` object is present.
+The test SHALL fail, if any Product ID (type `$['$defs'].product_id_t`) in the product status group Affected (see section [sec](#vulnerabilities-property-product-status)) is not covered by
 any CVSS object.
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-13-usage-of-non-latest-ssvc-decision-point-version.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-13-usage-of-non-latest-ssvc-decision-point-version.md
@@ -1,9 +1,9 @@
 ### Usage of Non-Latest SSVC Decision Point Version
 
-For each SSVC decision point given under `selections` with a registered `namespace`, it MUST be tested the latest decision point
+For each SSVC decision point given under `selections` with a registered `namespace`, it SHALL be tested the latest decision point
 `version` available at the time of the `timestamp` was used.
 The test SHALL fail if a later `version` was used.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 > A list of all valid decision points of registered namespaces including their values is available at the
 > SSVC repository (see [cite](#SSVC-DP)).

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-14-usage-of-unregistered-ssvc-decision-point-base-namespace-in-non-tlp-clear-document.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-14-usage-of-unregistered-ssvc-decision-point-base-namespace-in-non-tlp-clear-document.md
@@ -1,8 +1,8 @@
 ### Usage of Unregistered SSVC Decision Point Base Namespace in Non-TLP:CLEAR Document{#usage-of-unregistered-ssvc-decision-point-base-namespace-in-non-tlp-clear-document}
 
-For each SSVC decision point given under `selections`, it MUST be tested that the base `namespace` is not an unregistered one
+For each SSVC decision point given under `selections`, it SHALL be tested that the base `namespace` is not an unregistered one
 if the document is not labeled `TLP:CLEAR`.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-15-usage-of-ssvc-decision-point-namespace-with-extension-in-non-tlp-clear-document.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-15-usage-of-ssvc-decision-point-namespace-with-extension-in-non-tlp-clear-document.md
@@ -1,8 +1,8 @@
 ### Usage of SSVC Decision Point Namespace with Extension in Non-TLP:CLEAR Document{#usage-of-ssvc-decision-point-namespace-with-extension-in-non-tlp-clear-document}
 
-For each SSVC decision point given under `selections`, it MUST be tested that the `namespace` does not use an extension
+For each SSVC decision point given under `selections`, it SHALL be tested that the `namespace` does not use an extension
 if the document is not labeled `TLP:CLEAR`.
-Namespaces reserved for special purpose MUST be treated as per their definition.
+Namespaces reserved for special purpose SHALL be treated as per their definition.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-16-grammar-check.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-16-grammar-check.md
@@ -1,6 +1,6 @@
 ### Grammar Check
 
-If the document language is given it MUST be tested that a grammar check for the given language does not find any mistakes.
+If the document language is given it SHALL be tested that a grammar check for the given language does not find any mistakes.
 The test SHALL be skipped if the document language is not set.
 It SHALL fail if the given language is not supported.
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-17-use-of-unregistered-license.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-17-use-of-unregistered-license.md
@@ -1,6 +1,6 @@
 ### Use of Unregistered License
 
-It MUST be tested that the all license identifiers and exceptions are listed either in the official SPDX license identifier list
+It SHALL be tested that the all license identifiers and exceptions are listed either in the official SPDX license identifier list
 or AboutCode's "ScanCode LicenseDB".
 
 The relevant path for this test is:

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-18-use-of-qualitative-severity-rating.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-18-use-of-qualitative-severity-rating.md
@@ -1,6 +1,6 @@
 ### Use of Qualitative Severity Rating
 
-For each item in `metrics` it MUST be tested that it does not use the qualitative severity rating.
+For each item in `metrics` it SHALL be tested that it does not use the qualitative severity rating.
 
 > This covers all items in `metrics` regardless of their origin.
 > Even though the Qualitative Severity Rating is a specified property, its usage is discouraged as it provides

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-19-overlapping-version-range.md
@@ -6,8 +6,8 @@ The abbreviations for groups are defined in section [sec](#overlapping-product-v
 
 #### Overlapping Product Version Range with VERS in Same Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVRSS+l-vers` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVRSS+l-vers` that overlap with `CTPVR` are not
 member of the same product status group (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:
@@ -71,8 +71,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with vls in Same Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVRSS+l-vls` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVRSS+l-vls` that overlap with `CTPVR` are not
 member of the same product status group (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:
@@ -136,8 +136,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with Product Version in Same Product Status Group
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that the Product IDs of all elements in `PVSS` that overlap with `CTPVR` are not
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that the Product IDs of all elements in `PVSS` that overlap with `CTPVR` are not
 member of the same product status group (see section [sec](#vulnerabilities-property-product-status)).
 
 The relevant path for this test is:
@@ -201,8 +201,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with Product Version Range in Branch
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that all product version ranges of elements in `PVRSS+b` do not overlap with `CTPVR`.
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that all product version ranges of elements in `PVRSS+b` do not overlap with `CTPVR`.
 
 The relevant path for this test is:
 
@@ -240,8 +240,8 @@ The relevant path for this test is:
 
 #### Overlapping Product Version Range with Product Version in Branch
 
-For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups MUST be identified.
-For each `EPVR` (as `CTPVR`), it MUST be tested that all product versions of elements in `PVSS+b` do not overlap with `CTPVR`.
+For each item in `$.vulnerabilities` all `EPVRPID` in the product status groups SHALL be identified.
+For each `EPVR` (as `CTPVR`), it SHALL be tested that all product versions of elements in `PVSS+b` do not overlap with `CTPVR`.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-20-use-of-unregistered-id-system.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-20-use-of-unregistered-id-system.md
@@ -1,6 +1,6 @@
 ### Use of Unregistered ID System
 
-For each item in `$.vulnerabilities[*].ids` it MUST be tested that the value of `system_name` belongs to a
+For each item in `$.vulnerabilities[*].ids` it SHALL be tested that the value of `system_name` belongs to a
 registered vulnerability ID system in RVISC.
 
 > The RVISC is available at [cite](#RVISC).

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-21-extension-tests.md
@@ -7,7 +7,7 @@ Each of the following tests SHOULD be treated as they were listed similar to the
 
 #### Extension Category Essential
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that the extension `category` of the item
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that the extension `category` of the item
 is not `essential`.
 
 > It is sufficient to check whether the value of `category` is not `essential`.
@@ -41,7 +41,7 @@ The relevant paths for this test are:
 
 #### Usage of Experimental Extension in Non-TLP:CLEAR Document{#usage-of-experimental-extension-in-non-tlp-clear-document}
 
-For each item in an element of type `$['$defs'].extensions_t` it MUST be tested that no experimental extension is used
+For each item in an element of type `$['$defs'].extensions_t` it SHALL be tested that no experimental extension is used
 if the document is not labeled `TLP:CLEAR`.
 
 The relevant paths for this test are:
@@ -84,7 +84,7 @@ The relevant paths for this test are:
 
 #### Usage of Extension at Document Level
 
-It MUST be tested that the element `$.document.x_extensions` does not exist.
+It SHALL be tested that the element `$.document.x_extensions` does not exist.
 
 The relevant path for this test is:
 
@@ -110,7 +110,7 @@ The relevant path for this test is:
 
 #### Usage of Extension in Product Tree Branch Path
 
-It MUST be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.branches`.
+It SHALL be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.branches`.
 
 The relevant path for this test is:
 
@@ -150,7 +150,7 @@ The relevant path for this test is:
 
 #### Usage of Extension in Product Tree Full Product Names Path
 
-It MUST be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.full_product_names`.
+It SHALL be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.full_product_names`.
 
 The relevant path for this test is:
 
@@ -177,7 +177,7 @@ The relevant path for this test is:
 
 #### Usage of Extension in Product Tree Product Paths Path
 
-It MUST be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.product_paths`.
+It SHALL be tested that the element `x_extensions` does not exist in any path that starts with `$.product_tree.product_paths`.
 
 The relevant path for this test is:
 
@@ -209,7 +209,7 @@ The relevant path for this test is:
 
 #### Usage of Extension in Vulnerabilities Metrics Path
 
-It MUST be tested that the element `x_extensions` does not exist in any path that starts with `$.vulnerabilities[*].metrics`.
+It SHALL be tested that the element `x_extensions` does not exist in any path that starts with `$.vulnerabilities[*].metrics`.
 
 The relevant path for this test is:
 
@@ -240,7 +240,7 @@ The relevant path for this test is:
 
 #### Usage of Extension at Vulnerabilities Level
 
-For each item `$.vulnerabilities` it MUST be tested that the element `x_extensions` does not exist.
+For each item `$.vulnerabilities` it SHALL be tested that the element `x_extensions` does not exist.
 
 The relevant path for this test is:
 
@@ -268,7 +268,7 @@ The relevant path for this test is:
 
 #### Usage of Extension at Root Level
 
-It MUST be tested that the element `$.x_extensions` does not exist.
+It SHALL be tested that the element `$.x_extensions` does not exist.
 
 The relevant path for this test is:
 

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-22-nested-product-path.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-22-nested-product-path.md
@@ -1,6 +1,6 @@
 ### Nested Product Path
 
-For each item in `$.product_tree.product_paths[*]` it MUST be tested that all referenced Product IDs are not defined under a
+For each item in `$.product_tree.product_paths[*]` it SHALL be tested that all referenced Product IDs are not defined under a
 `full_product_name_t` element within items of `$.product_tree.product_paths`.
 
 > A product defined by a product path that contains another product path is usually harder to match.

--- a/csaf_2.1/prose/edit/src/tests-03-nfrmtv-24-public-openpgp-key-url-user-id.md
+++ b/csaf_2.1/prose/edit/src/tests-03-nfrmtv-24-public-openpgp-key-url-user-id.md
@@ -1,10 +1,10 @@
 ### Public OpenPGP Key URL User ID
 
-It MUST be tested that the URL given as value of `public_openpgp_key_url` in the CSAF document
+It SHALL be tested that the URL given as value of `public_openpgp_key_url` in the CSAF document
 delivers a public OpenPGP key with an email in the user ID matching the sibling property `email`.
-The test MUST be skipped if the URL results in a client or server error or
+The test SHALL be skipped if the URL results in a client or server error or
 the OpenPGP key retrieved is not in ASCII-armored format.
-The test MUST report if the user ID is not set or empty.
+The test SHALL report if the user ID is not set or empty.
 
 > The cases excluded are handled through tests [sec](#use-of-non-self-referencing-urls-failing-to-resolve)
 > and [sec](#public-openpgp-key-url).

--- a/csaf_2.1/prose/edit/src/tests-04-presets.md
+++ b/csaf_2.1/prose/edit/src/tests-04-presets.md
@@ -4,9 +4,9 @@ A test preset is a predefined set of tests that was given a name.
 It MAY contain any number of tests.
 Two presets MAY overlap.
 The content of a preset MAY vary in different CSAF versions.
-A CSAF validator MUST support every official preset that solely include tests that are implemented by the CSAF validator.
+A CSAF validator SHALL support every official preset that solely include tests that are implemented by the CSAF validator.
 A CSAF validator MAY provide or support additional presets.
-A CSAF validator MUST implement all tests for any supported preset.
+A CSAF validator SHALL implement all tests for any supported preset.
 
 Names of presets not defined in this CSAF standard SHALL have the following prefix before their name:
 
@@ -18,8 +18,8 @@ Names of presets not defined in this CSAF standard SHALL have the following pref
 - `org_` followed by an organization identifier and an underscore (`_`):
   for any preset specified by an organization as a part of a public definition
   that can be implemented by different CSAF validators.
-  The organization identifier MUST only use the characters identified by the pattern `[0-9a-zA-Z-.]`.
-  The organization identifier MUST be registered with the OASIS CSAF TC prior to the publication of the definition.
+  The organization identifier SHALL only use the characters identified by the pattern `[0-9a-zA-Z-.]`.
+  The organization identifier SHALL be registered with the OASIS CSAF TC prior to the publication of the definition.
 
 - `csaf_`: for any preset defined later on by the OASIS CSAF TC.
 
@@ -49,7 +49,7 @@ The following presets are defined through conformance targets:
 
   > Note: The last preset MAY vary between different implementations as it is implementation specific.
 
-As presets are sets, the operator `+` MUST be interpreted as the union operation.
+As presets are sets, the operator `+` SHALL be interpreted as the union operation.
 
 ### Additional Presets
 


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1555
- change MUST to SHALL where applicable
- correct normative language in informative sections