### PR TITLE
JSON Schema

### DIFF
--- a/csaf_2.1/json_schema/extension-metaschema.json
+++ b/csaf_2.1/json_schema/extension-metaschema.json
@@ -18,7 +18,10 @@
       "description": "Contains the actual value of the $schema property.",
       "type": "string",
       "format": "uri",
-      "pattern": "^(?!https:\\/\\/docs\\.oasis-open\\.org\\/csaf\\/csaf\\/v2\\.1\\/([^\\/\\s]+\/)*schema\\/extension-content\\.json)(https:\\/\\/[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?(\\.[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?)+\\/([^\\/\\s]+\/)*[^\\/\\s]+_(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\\.json)$"
+      "pattern": "^(https:\\/\\/[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?(\\.[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?)+\\/([^\\/\\s]+\/)*[^\\/\\s]+_(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\\.json)$",
+      "not": {
+        "pattern": "^https:\\/\\/docs\\.oasis-open\\.org\\/csaf\\/csaf\\/v2\\.1\\/([^\\/\\s]+\/)*schema\\/extension-content\\.json$"
+      }
     },
     "schema": {
       "$dynamicAnchor": "meta",
@@ -261,7 +264,6 @@
           "description": "Contains the definition of the object of the CSAF Extension content.",
           "type": "object",
           "$ref": "#/$defs/schema",
-          "minProperties": 6,
           "required": [
             "title",
             "description",
@@ -295,8 +297,13 @@
               "title": "Minimum count of properties of the CSAF Extension Content object",
               "description": "Contains the number of properties within the `object`.",
               "type": "integer",
-              "minimum": 1,
-              "multipleOf": 1
+              "minimum": 1
+            },
+            "properties": {
+              "title": "Properties of the CSAF Extension Content object",
+              "description": "Contains the properties as object of the CSAF Extension Schema.",
+              "$ref": "#/$defs/schema",
+              "minProperties": 1
             },
             "unevaluatedProperties": {
               "title": "Unevaluated properties of the CSAF Extension Content object",


### PR DESCRIPTION
- addresses parts of oasis-tcs/csaf#1518
- replace negative lookahead with `not` construct
- fix some mistakes in extension-metaschema