### PR TITLE
11 years time warp

### DIFF
--- a/.github/workflows/csaf_2.0_main.yml
+++ b/.github/workflows/csaf_2.0_main.yml
@@ -21,11 +21,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test examples against CSAF schema

--- a/.github/workflows/csaf_2.0_validator.yml
+++ b/.github/workflows/csaf_2.0_validator.yml
@@ -20,11 +20,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test validator/data/mandatory against schema

--- a/.github/workflows/csaf_2.1_extensions.yml
+++ b/.github/workflows/csaf_2.1_extensions.yml
@@ -21,11 +21,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test extensions in extension/data/valid/*/*.json
@@ -45,11 +44,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test extension metadata in extension/data/valid/*/*.json

--- a/.github/workflows/csaf_2.1_main.yml
+++ b/.github/workflows/csaf_2.1_main.yml
@@ -21,11 +21,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test examples against CSAF schema

--- a/.github/workflows/csaf_2.1_translations.yml
+++ b/.github/workflows/csaf_2.1_translations.yml
@@ -20,11 +20,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: language_specific_translation/translations.json against testcase schema

--- a/.github/workflows/csaf_2.1_validator.yml
+++ b/.github/workflows/csaf_2.1_validator.yml
@@ -20,11 +20,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test validator/data/mandatory against schema

--- a/.github/workflows/registry_id_mapping.yml
+++ b/.github/workflows/registry_id_mapping.yml
@@ -20,11 +20,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test registry/id/mapping.json against RVISC Mapping schema and for consistency

--- a/.github/workflows/registry_id_registry.yml
+++ b/.github/workflows/registry_id_registry.yml
@@ -20,11 +20,10 @@ jobs:
         sudo apt-get update -q && sudo apt-get install -y --no-install-recommends -qq \
           python3 \
           python3-simplejson \
-          python3-jsonpath-rw \
           python3-pip \
           python3-setuptools \
           python3-wheel
-        pip3 install jsonschema[format]
+        pip3 install jsonschema[format] python-jsonpath
     - name: Check jsonschema version
       run: python3 -c "from importlib.metadata import version; print(version('jsonschema'))"
     - name: Test registry/id/registry.json against RVISC schema and for consistency

--- a/csaf_2.0/test/generate_strict_schema.py
+++ b/csaf_2.0/test/generate_strict_schema.py
@@ -1,7 +1,7 @@
 import jsonschema
 import simplejson as json
 import sys
-import jsonpath_rw
+import jsonpath
 from pprint import pprint
 
 if len(sys.argv)!=2:
@@ -14,8 +14,8 @@ with open(json_schema, 'r') as f:
     schema_data = f.read()
     schema = json.loads(schema_data)
 
-for i in jsonpath_rw.parse("$..* where properties").find(schema):
-    i.value['additionalProperties'] = False
+for node in jsonpath.findall("$..[?@.properties]", schema):
+    node['additionalProperties'] = False
 
 # Don't forget to add it at the root level
 schema['additionalProperties'] = False

--- a/csaf_2.1/json_schema/extension-metaschema.json
+++ b/csaf_2.1/json_schema/extension-metaschema.json
@@ -18,7 +18,10 @@
       "description": "Contains the actual value of the $schema property.",
       "type": "string",
       "format": "uri",
-      "pattern": "^(?!https:\\/\\/docs\\.oasis-open\\.org\\/csaf\\/csaf\\/v2\\.1\\/([^\\/\\s]+\/)*schema\\/extension-content\\.json)(https:\\/\\/[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?(\\.[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?)+\\/([^\\/\\s]+\/)*[^\\/\\s]+_(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\\.json)$"
+      "pattern": "^(https:\\/\\/[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?(\\.[a-z0-9](([a-z0-9-]){0,61}[a-z0-9])?)+\\/([^\\/\\s]+\/)*[^\\/\\s]+_(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\\.json)$",
+      "not": {
+        "pattern": "^https:\\/\\/docs\\.oasis-open\\.org\\/csaf\\/csaf\\/v2\\.1\\/([^\\/\\s]+\/)*schema\\/extension-content\\.json$"
+      }
     },
     "schema": {
       "$dynamicAnchor": "meta",
@@ -261,7 +264,6 @@
           "description": "Contains the definition of the object of the CSAF Extension content.",
           "type": "object",
           "$ref": "#/$defs/schema",
-          "minProperties": 6,
           "required": [
             "title",
             "description",
@@ -295,8 +297,13 @@
               "title": "Minimum count of properties of the CSAF Extension Content object",
               "description": "Contains the number of properties within the `object`.",
               "type": "integer",
-              "minimum": 1,
-              "multipleOf": 1
+              "minimum": 1
+            },
+            "properties": {
+              "title": "Properties of the CSAF Extension Content object",
+              "description": "Contains the properties as object of the CSAF Extension Schema.",
+              "$ref": "#/$defs/schema",
+              "minProperties": 1
             },
             "unevaluatedProperties": {
               "title": "Unevaluated properties of the CSAF Extension Content object",

--- a/csaf_2.1/test/generate_strict_schema.py
+++ b/csaf_2.1/test/generate_strict_schema.py
@@ -1,7 +1,7 @@
 import jsonschema
 import simplejson as json
 import sys
-import jsonpath_rw
+import jsonpath
 from pprint import pprint
 
 if len(sys.argv)!=2:
@@ -14,8 +14,8 @@ with open(json_schema, 'r') as f:
     schema_data = f.read()
     schema = json.loads(schema_data)
 
-for i in jsonpath_rw.parse("$..* where properties").find(schema):
-    i.value['additionalProperties'] = False
+for node in jsonpath.findall("$..[?@.properties]", schema):
+    node['additionalProperties'] = False
 
 # Don't forget to add it at the root level
 schema['additionalProperties'] = False


### PR DESCRIPTION
Feel free to retarget to master branch - whatever is more convenient for you, @tschmidtb51 

# Description

The jsonpath-rw package is from April 2015 an installs in the bin folder of the python environment a script called jsonpath.py.

This unfortunately shadows the import of jsonpath from the python-jsonpath module.

Symptom: make render fails.

Workaround: remove the bin/jsonpath.py file from that active python environment after install of jsonpath-rw.
With pyenv one can find that path by executing pyenv which jsonpath.py

Solution (IMO): Just use python-jsonpath which is already installed by nide.

This minimally changed version of the "strictifier" script works with python-jsonpath ...