### PR TITLE
Editorial

### DIFF
--- a/csaf_2.1/prose/edit/src/tests-04-presets.md
+++ b/csaf_2.1/prose/edit/src/tests-04-presets.md
@@ -61,6 +61,7 @@ Additional presets are defined as follows:
     - [sec](#public-openpgp-key-url)
     - [sec](#use-of-non-self-referencing-urls-failing-to-resolve)
     - [sec](#use-of-self-referencing-urls-failing-to-resolve)
+    - [sec](#public-openpgp-key-url-user-id)
 - `external-request-free`:
   - Description: Any test that can be executed without a request into the Internet or a different network.
 


### PR DESCRIPTION
- fixes oasis-tcs/csaf#1579
- add missing test 6.3.24 to preset