### PR TITLE
Extensions: Clarify Extension Package

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance-01-cls-35-extension-package.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-35-extension-package.md
@@ -5,3 +5,5 @@ A compilation of artifacts satisfies the "CSAF Extension Package" conformance pr
 - it contains exactly one specification satisfying the "CSAF Extension Specification" conformance profile.
 - it contains exactly one compilation of artifacts satisfying the "CSAF Extension Bundle" conformance profile.
 - has a name that it can be referred to.
+
+A CSAF Extension Package MAY contain additional documentation and artifacts to guide implementers.


### PR DESCRIPTION
- resolves oasis-tcs/csaf#1424
- clarify CSAF Extension Package to allow additional documentation and artifacts