### PR TITLE
Vulnerability IDs for Security Advisory

### DIFF
--- a/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
@@ -62,10 +62,13 @@ Secondly, the program fulfills the following for all items of:
   If more than one `cvrf:Organization` instance is given, the CVRF CSAF Converter converts the first one into the `organization`.
   In addition, the converter issues a warning that information might be lost during conversion of document or vulnerability acknowledgment.
 - `$.document.category`:
-  - If the `cvrf:DocumentType` is Security Advisory (case-insensitive), the CVRF CSAF Converter SHALL try to convert the data
-    into a valid CSAF Document in this profile according to CSAF 2.1.
+  - If the `cvrf:DocumentType` is Security Advisory (white space and case-insensitive),
+    the CVRF CSAF Converter SHALL try to convert the data into a valid CSAF Document in this profile according to CSAF 2.1.
 
     > A tool MAY offer rules to create the missing fixed products from version ranges, if applicable.
+    > A tool MAY offer rules to assign missing CVEs or vulnerability IDs.
+    > Nevertheless, issuing parties are responsible to keep track of assigned IDs to prevent
+    > the assignment of the same ID twice for different issues.
 
     If the CVRF CSAF Converter is unable to create a valid CSAF 2.1 Document according to the profile, it SHALL set the `category` value to
     `csaf_deprecated_security_advisory`.

--- a/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
@@ -68,7 +68,7 @@ Secondly, the program fulfills the following for all items of:
     > A tool MAY offer rules to create the missing fixed products from version ranges, if applicable.
     > A tool MAY offer rules to assign missing CVEs or vulnerability IDs.
     > Nevertheless, issuing parties are responsible to keep track of assigned IDs to prevent
-    > the assignment of the same ID more than once for different issues.
+    > the assignment of the same ID for different issues.
 
     If the CVRF CSAF Converter is unable to create a valid CSAF 2.1 Document according to the profile, it SHALL set the `category` value to
     `csaf_deprecated_security_advisory`.

--- a/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-05-cvrf-converter.md
@@ -68,7 +68,7 @@ Secondly, the program fulfills the following for all items of:
     > A tool MAY offer rules to create the missing fixed products from version ranges, if applicable.
     > A tool MAY offer rules to assign missing CVEs or vulnerability IDs.
     > Nevertheless, issuing parties are responsible to keep track of assigned IDs to prevent
-    > the assignment of the same ID twice for different issues.
+    > the assignment of the same ID more than once for different issues.
 
     If the CVRF CSAF Converter is unable to create a valid CSAF 2.1 Document according to the profile, it SHALL set the `category` value to
     `csaf_deprecated_security_advisory`.

--- a/csaf_2.1/prose/edit/src/conformance-01-cls-06-content-management-system.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-06-content-management-system.md
@@ -23,6 +23,9 @@ A CSAF Content Management System satisfies the "CSAF Content Management System" 
   - show an audit log for each CSAF Document
   - identify the latest version of CSAF Documents with the same `$.document.tracking.id`
   - suggest a `$.document.tracking.id` based on the given configuration.
+  - option to suggest an ID for a vulnerability based on the given configuration.
+  - initialize a vulnerability element from a given CVE by loading the corresponding CVE JSON from a location provided in the configuration.
+    Local instances implementing the respective CVE API SHALL be supported.
   - track of the version of CSAF Documents automatically and increment according to the versioning scheme
     (see also subsections of [sec](#version-type)) selected in the configuration.
   - check that the document version is set correctly based on the changes in comparison to the previous version
@@ -33,7 +36,7 @@ A CSAF Content Management System satisfies the "CSAF Content Management System" 
     `interim` and no new release has be done during the given threshold in the configuration (default: `6` weeks)
 
     > Note that the terms "publish", "publication" and their derived forms are used in this conformance profile independent of
-      whether the specified target group is the public or a closed group.
+    > whether the specified target group is the public or a closed group.
 
   - support the following workflows:
 

--- a/csaf_2.1/prose/edit/src/conformance-01-cls-18-csaf-2-0-converter.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-18-csaf-2-0-converter.md
@@ -227,16 +227,19 @@ Secondly, the program fulfills the following for all items of:
     to CSAF 2.1 Converter SHOULD add a new product with the version of the last constraint and add that in the appropriate places as `fixed`.
     The CSAF 2.0 to CSAF 2.1 Converter SHALL issue a warning that a product was added to the `product_tree` and the corresponding `$.vulnerabilities[*]`.
     Such warning SHALL contain the full product name and its path as well as the paths of the `$.vulnerabilities[*]` it was added to.
-    If the CSAF 2.0 to CSAF 2.1 Converter is unable to create a valid CSAF 2.1 Document according to the profile, it SHALL set the `category` value to
-    `csaf_deprecated_security_advisory`.
+    The CSAF 2.0 to CSAF 2.1 Converter MAY have a non-default option to assign organization-wide IDs to any vulnerability not
+    containing a CVE nor any other vulnerability ID and therefore failing test [sec](#vulnerability-id).
+    Issuing parties are responsible to keep track of assigned IDs to prevent the assignment of the same ID twice for different issues.
+    If the CSAF 2.0 to CSAF 2.1 Converter is unable to create a valid CSAF 2.1 Document according to the profile,
+    it SHALL set the `category` value to `csaf_deprecated_security_advisory`.
   - If the `$.document.lang` is English or unspecified, the following rules apply:
     - If the `$.document.title` starts with the string `Superseded` or the `$.document.category` has the value `Superseded` (case-insensitive),
       the CSAF 2.0 to CSAF 2.1 Converter SHALL try to convert all data into a valid CSAF Document in the profile "Superseded" according to CSAF 2.1.
     - If the `$.document.title` starts with the string `Withdrawn` or the `$.document.category` has the value `Withdrawn` (case-insensitive),
       the CSAF 2.0 to CSAF 2.1 Converter SHALL try to convert all data into a valid CSAF Document in the profile "Withdrawn" according to CSAF 2.1.
  
-    > A tool MAY provide a non-default option to remove or transform certain or all elements the hinder the creation of a valid CSAF Document according
-    > to the profile.
+    > A tool MAY provide a non-default option to remove or transform certain or all elements the hinder the creation of a valid CSAF Document
+    > according to the profile.
 
     > A tool MAY support this detection for other languages.
 

--- a/csaf_2.1/prose/edit/src/conformance-01-cls-18-csaf-2-0-converter.md
+++ b/csaf_2.1/prose/edit/src/conformance-01-cls-18-csaf-2-0-converter.md
@@ -229,7 +229,7 @@ Secondly, the program fulfills the following for all items of:
     Such warning SHALL contain the full product name and its path as well as the paths of the `$.vulnerabilities[*]` it was added to.
     The CSAF 2.0 to CSAF 2.1 Converter MAY have a non-default option to assign organization-wide IDs to any vulnerability not
     containing a CVE nor any other vulnerability ID and therefore failing test [sec](#vulnerability-id).
-    Issuing parties are responsible to keep track of assigned IDs to prevent the assignment of the same ID twice for different issues.
+    Issuing parties are responsible to keep track of assigned IDs to prevent the assignment of the same ID  for different issues.
     If the CSAF 2.0 to CSAF 2.1 Converter is unable to create a valid CSAF 2.1 Document according to the profile,
     it SHALL set the `category` value to `csaf_deprecated_security_advisory`.
   - If the `$.document.lang` is English or unspecified, the following rules apply:

--- a/csaf_2.1/prose/edit/src/profiles.md
+++ b/csaf_2.1/prose/edit/src/profiles.md
@@ -121,6 +121,9 @@ A CSAF document SHALL fulfill the following requirements to satisfy the profile 
   - all elements required by the profile "CSAF Base".
   - `$.product_tree` which lists all products referenced later on in the CSAF document regardless of their state.
   - `$.vulnerabilities` which lists all vulnerabilities.
+  - at least one of
+    - `$.vulnerabilities[*].cve`
+    - `$.vulnerabilities[*].ids`
   - `$.vulnerabilities[*].notes`
 
     > Provides details about the vulnerability.

--- a/csaf_2.1/prose/edit/src/tests-01-mndtr-27-08-vulnerability-id.md
+++ b/csaf_2.1/prose/edit/src/tests-01-mndtr-27-08-vulnerability-id.md
@@ -12,6 +12,7 @@ This is independent from whether the product is referenced directly or indirectl
 The relevant values for `$.document.category` are:
 
 ```
+  csaf_security_advisory
   csaf_vex
   csaf_vulnerability_report
 ```

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Mandatory Test: Affected Products (failing example 1)",
+    "title": "Mandatory Test: Vulnerability ID (failing example 4)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-12-01",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-08-04",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {
@@ -42,6 +42,14 @@
                   "name": "Example Company Product A 4.1",
                   "product_id": "CSAFPID-9080700"
                 }
+              },
+              {
+                "category": "product_version",
+                "name": "4.2",
+                "product": {
+                  "name": "Example Company Product A 4.2",
+                  "product_id": "CSAFPID-9080701"
+                }
               }
             ],
             "category": "product_name",
@@ -55,7 +63,6 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-1900-0001",
       "notes": [
         {
           "category": "summary",
@@ -64,6 +71,9 @@
         }
       ],
       "product_status": {
+        "known_affected": [
+          "CSAFPID-9080701"
+        ],
         "under_investigation": [
           "CSAFPID-9080700"
         ]

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.result.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": false,
+  "primary_result": {
+    "errors": [
+      {
+        "instance_path": "/vulnerabilities/0",
+        "message": "needs at least one of the following properties: `cve`, `ids`"
+      }
+    ],
+    "id": "6.1.27.8",
+    "passed": false
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.json
@@ -13,10 +13,10 @@
       "name": "OASIS CSAF TC",
       "namespace": "https://csaf.io"
     },
-    "title": "Mandatory Test: Affected Products (failing example 1)",
+    "title": "Mandatory Test: Vulnerability ID (valid example 4)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-12-01",
+      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-27-08-14",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {
@@ -42,6 +42,14 @@
                   "name": "Example Company Product A 4.1",
                   "product_id": "CSAFPID-9080700"
                 }
+              },
+              {
+                "category": "product_version",
+                "name": "4.2",
+                "product": {
+                  "name": "Example Company Product A 4.2",
+                  "product_id": "CSAFPID-9080701"
+                }
               }
             ],
             "category": "product_name",
@@ -55,7 +63,12 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-1900-0001",
+      "ids": [
+        {
+          "system_name": "https://github.com/oasis-tcs/csaf",
+          "text": "#1559"
+        }
+      ],
       "notes": [
         {
           "category": "summary",
@@ -64,6 +77,9 @@
         }
       ],
       "product_status": {
+        "known_affected": [
+          "CSAFPID-9080701"
+        ],
         "under_investigation": [
           "CSAFPID-9080700"
         ]

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.result.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.result.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/csaf/master/csaf_2.1/test/validator/testresult_json_schema.json",
+  "overall_valid": true,
+  "primary_result": {
+    "id": "6.1.27.8",
+    "passed": true
+  },
+  "resultschema_version": "2.1"
+}

--- a/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-12-11.json
+++ b/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-12-11.json
@@ -63,6 +63,7 @@
   },
   "vulnerabilities": [
     {
+      "cve": "CVE-1900-0001",
       "notes": [
         {
           "category": "summary",

--- a/csaf_2.1/test/validator/data/testcases.json
+++ b/csaf_2.1/test/validator/data/testcases.json
@@ -1129,6 +1129,11 @@
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-03.json",
           "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-03.result.json",
           "valid": false
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-04.result.json",
+          "valid": false
         }
       ],
       "valid": [
@@ -1145,6 +1150,11 @@
         {
           "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-13.json",
           "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-13.result.json",
+          "valid": true
+        },
+        {
+          "name": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.json",
+          "result": "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-14.result.json",
           "valid": true
         }
       ]


### PR DESCRIPTION
- addresses parts of https://github.com/oasis-tcs/csaf/issues/1559
- add requirement to profile
- add profile to 6.1.27.8
- add invalid example
- add valid example
- add result files
- update test metadata
- adapt rules in converters
- fix formatting
- make white space also a matching criteria
- adapt conformance target 6 to initialize vulnerabilities based on CVE data
- adapt conformance target 6 to suggest IDs for vulnerabilities 